### PR TITLE
Add file content validation to prevent binary files from being interpreted as CalcMark

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -36,14 +36,25 @@ CalcMark is designed to be safe for evaluating user-provided calculation code. T
 - Maximum length: **100 characters**
 - Prevents pathological number parsing
 
+## File Content Validation
+
+All CLI entry points (eval, convert, edit) and the TUI editor validate file content before parsing:
+
+1. **Magic Number Detection**: Rejects files matching known binary format signatures (PNG, JPEG, GIF, PDF, ZIP, GZIP, ELF, PE/MZ, WASM, RIFF, OGG, FLAC, BMP, TIFF, SQLite, 7Z, RAR, Java class, Mach-O)
+2. **Null Byte Detection**: Scans the first 8 KB for null bytes (0x00), which never appear in valid text files
+3. **UTF-8 Validation**: Rejects content that is not valid UTF-8 text
+
+This prevents attacks where a binary file (e.g., `malware.gif`) is renamed to `exploit.cm` and opened by the interpreter.
+
 ## Denial of Service Protections
 
 ### Protection Mechanisms
 
 1. **File Size Validation**: Reject files >1MB before processing
-2. **Path Validation**: Block directory traversal (`..` in paths) for **input** files
-3. **Extension Validation**: Only `.cm` and `.calcmark` files for input
-4. **Timeout Protection** (recommended): Set timeouts in production environments
+2. **File Content Validation**: Reject binary/non-text content before parsing
+3. **Path Validation**: Block directory traversal (`..` in paths) for **input** files
+4. **Extension Validation**: Only `.cm` and `.calcmark` files for input
+5. **Timeout Protection** (recommended): Set timeouts in production environments
 
 Note: Output commands (`:output`, `:save`) allow writing to any path the user specifies, including paths with `..`. This is intentional - users should be able to export results anywhere they have write access.
 
@@ -73,6 +84,7 @@ case <-ctx.Done():
 | Attack | Mitigation |
 |--------|------------|
 | Huge file (e.g., 1GB) | File size limit (1MB for CLI) |
+| Binary file renamed to .cm | Magic number + null byte + UTF-8 validation |
 | Deep nesting `(((...)))` | Depth tracking (planned: 100 levels) |
 | Token bomb `x1+x2+x3+...` | Token count limit (planned: 10K) |
 | Infinite loop in calculation | No loops in language (by design) |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -105,8 +105,10 @@ tasks:
   security:
     desc: Run security-focused tests
     cmds:
-      - go test -v -run "TestValidateFilePath|TestValidateReadFilePath" ./cmd/calcmark/cmd
+      - go test -v -run "TestValidateFilePath|TestValidateReadFilePath|TestValidateFileContent|TestValidateStdinContent|TestReadFilePath" ./cmd/calcmark/cmd
+      - go test -v ./cmd/calcmark/filecheck
       - go test -v -run "TestSecurity" ./spec/parser
+      - go test -v -run "Fuzz" -fuzz=. -fuzztime=5s ./cmd/calcmark/filecheck
       - go test -v -run "Fuzz" -fuzz=. -fuzztime=5s ./spec/lexer
       - go test -v -run "Fuzz" -fuzz=. -fuzztime=5s ./spec/parser
       - go test -v -run "Fuzz" -fuzz=. -fuzztime=5s ./spec/document

--- a/cmd/calcmark/cmd/convert.go
+++ b/cmd/calcmark/cmd/convert.go
@@ -70,6 +70,11 @@ func runConvert(filename string) error {
 		return fmt.Errorf("read file: %w", err)
 	}
 
+	// Security: Reject binary/non-text content before parsing
+	if err := validateFileContent(content); err != nil {
+		return fmt.Errorf("invalid file: %w", err)
+	}
+
 	// Parse document
 	doc, err := document.NewDocument(string(content))
 	if err != nil {

--- a/cmd/calcmark/cmd/eval.go
+++ b/cmd/calcmark/cmd/eval.go
@@ -52,6 +52,9 @@ func runEval(args []string) error {
 		if err != nil {
 			return fmt.Errorf("read file: %w", err)
 		}
+		if err := validateFileContent(bytes); err != nil {
+			return fmt.Errorf("invalid file: %w", err)
+		}
 		input = string(bytes)
 	}
 
@@ -65,6 +68,9 @@ func runEval(args []string) error {
 		}
 		if len(bytes) >= maxStdinSize {
 			return fmt.Errorf("stdin input too large (max 1MB)")
+		}
+		if err := validateStdinContent(bytes); err != nil {
+			return fmt.Errorf("invalid input: %w", err)
 		}
 		input = string(bytes)
 

--- a/cmd/calcmark/cmd/security.go
+++ b/cmd/calcmark/cmd/security.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/CalcMark/go-calcmark/cmd/calcmark/filecheck"
 )
 
 // validateReadFilePath performs security checks on a file path for read-only
@@ -82,4 +84,16 @@ func validateFileConstraints(absPath string) error {
 	}
 
 	return nil
+}
+
+// validateFileContent checks that data is valid text suitable for CalcMark.
+// Delegates to the shared filecheck package for reuse by the TUI editor.
+func validateFileContent(data []byte) error {
+	return filecheck.ValidateContent(data)
+}
+
+// validateStdinContent checks piped stdin data for binary content.
+// Applies the same content checks as file input.
+func validateStdinContent(data []byte) error {
+	return filecheck.ValidateContent(data)
 }

--- a/cmd/calcmark/cmd/security_test.go
+++ b/cmd/calcmark/cmd/security_test.go
@@ -129,3 +129,99 @@ func TestStdinSizeLimit(t *testing.T) {
 	// If this test compiles, the constant is accessible.
 	// The real stdin limit is enforced in runEval via io.LimitReader.
 }
+
+// --- Content validation integration tests ---
+// These verify that validateFileContent and validateStdinContent work
+// correctly when called through the cmd package wrappers.
+
+func TestValidateFileContent_RejectsBinaryFile(t *testing.T) {
+	// Simulates the exact issue scenario: binary GIF renamed to .cm
+	gifData := []byte("GIF89a\x01\x00\x01\x00\x80\x00\x00\xff\xff\xff")
+	err := validateFileContent(gifData)
+	if err == nil {
+		t.Fatal("expected error for GIF binary content, got nil")
+	}
+	if !strings.Contains(err.Error(), "GIF") {
+		t.Fatalf("expected GIF in error, got: %v", err)
+	}
+}
+
+func TestValidateFileContent_AcceptsValidCalcMark(t *testing.T) {
+	data := []byte("# My Budget\nrent = 1200\nutilities = 150\ntotal = rent + utilities\n")
+	if err := validateFileContent(data); err != nil {
+		t.Fatalf("expected no error for valid CalcMark text, got: %v", err)
+	}
+}
+
+func TestValidateFileContent_RejectsNullBytes(t *testing.T) {
+	data := []byte("x = 1\x00\ny = 2\n")
+	err := validateFileContent(data)
+	if err == nil {
+		t.Fatal("expected error for content with null bytes, got nil")
+	}
+	if !strings.Contains(err.Error(), "null bytes") {
+		t.Fatalf("expected null bytes error, got: %v", err)
+	}
+}
+
+func TestValidateFileContent_RejectsInvalidUTF8(t *testing.T) {
+	data := []byte("caf\xe9") // Latin-1 'é', invalid UTF-8
+	err := validateFileContent(data)
+	if err == nil {
+		t.Fatal("expected error for invalid UTF-8, got nil")
+	}
+	if !strings.Contains(err.Error(), "UTF-8") {
+		t.Fatalf("expected UTF-8 error, got: %v", err)
+	}
+}
+
+func TestValidateStdinContent_RejectsBinary(t *testing.T) {
+	pngData := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	err := validateStdinContent(pngData)
+	if err == nil {
+		t.Fatal("expected error for PNG binary via stdin, got nil")
+	}
+	if !strings.Contains(err.Error(), "PNG") {
+		t.Fatalf("expected PNG in error, got: %v", err)
+	}
+}
+
+func TestValidateStdinContent_AcceptsValidText(t *testing.T) {
+	data := []byte("x = 42\n")
+	if err := validateStdinContent(data); err != nil {
+		t.Fatalf("expected no error for valid stdin text, got: %v", err)
+	}
+}
+
+// createTempBinaryCMFile creates a .cm file with binary content for testing.
+func createTempBinaryCMFile(t *testing.T, dir, name string, data []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestReadFilePath_PassesButContentValidationCatchesBinary(t *testing.T) {
+	// This test demonstrates that path validation alone is insufficient:
+	// a file with .cm extension and valid path passes validateReadFilePath,
+	// but content validation catches the binary data.
+	tmpDir := t.TempDir()
+	gifData := []byte("GIF89a\x01\x00\x01\x00\x80\x00\x00\xff\xff\xff")
+	path := createTempBinaryCMFile(t, tmpDir, "malicious.cm", gifData)
+
+	// Path validation passes (valid extension, valid path, small file)
+	if err := validateReadFilePath(path); err != nil {
+		t.Fatalf("path validation should pass for .cm file: %v", err)
+	}
+
+	// Content validation catches the binary data
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := validateFileContent(content); err == nil {
+		t.Fatal("content validation should reject binary GIF data")
+	}
+}

--- a/cmd/calcmark/cmd/tui.go
+++ b/cmd/calcmark/cmd/tui.go
@@ -70,6 +70,11 @@ func loadDocument(path string) (*document.Document, error) {
 		return nil, fmt.Errorf("read file: %w", err)
 	}
 
+	// Security: Reject binary/non-text content before parsing
+	if err := validateFileContent(content); err != nil {
+		return nil, err
+	}
+
 	doc, err := document.NewDocument(string(content))
 	if err != nil {
 		return nil, fmt.Errorf("parse document: %w", err)

--- a/cmd/calcmark/filecheck/filecheck.go
+++ b/cmd/calcmark/filecheck/filecheck.go
@@ -1,0 +1,76 @@
+// Package filecheck validates that file content is safe to interpret as CalcMark.
+// It provides defense-in-depth against binary files renamed with .cm extensions.
+package filecheck
+
+import (
+	"bytes"
+	"fmt"
+	"unicode/utf8"
+)
+
+// binarySignature maps a human-readable format name to its magic bytes.
+type binarySignature struct {
+	name  string
+	magic []byte
+}
+
+// knownBinarySignatures lists magic-byte prefixes for common binary formats.
+// Checked in order; the first match wins.
+var knownBinarySignatures = []binarySignature{
+	{"PNG", []byte{0x89, 0x50, 0x4E, 0x47}},
+	{"JPEG", []byte{0xFF, 0xD8, 0xFF}},
+	{"GIF", []byte("GIF8")},
+	{"PDF", []byte("%PDF")},
+	{"ZIP", []byte("PK\x03\x04")},
+	{"GZIP", []byte{0x1F, 0x8B}},
+	{"ELF", []byte{0x7F, 0x45, 0x4C, 0x46}},
+	{"PE/MZ", []byte("MZ")},
+	{"WASM", []byte{0x00, 0x61, 0x73, 0x6D}},
+	{"RIFF", []byte("RIFF")},                         // WAV, AVI, WebP
+	{"OGG", []byte("OggS")},                          // Ogg Vorbis
+	{"FLAC", []byte("fLaC")},                         // FLAC audio
+	{"BMP", []byte("BM")},                            // Bitmap image
+	{"TIFF-LE", []byte{0x49, 0x49, 0x2A, 0x00}},      // TIFF little-endian
+	{"TIFF-BE", []byte{0x4D, 0x4D, 0x00, 0x2A}},      // TIFF big-endian
+	{"SQLite", []byte("SQLite format 3\x00")},        // SQLite database
+	{"7Z", []byte{'7', 'z', 0xBC, 0xAF, 0x27, 0x1C}}, // 7-Zip archive
+	{"RAR", []byte("Rar!\x1A\x07")},                  // RAR archive
+	{"class", []byte{0xCA, 0xFE, 0xBA, 0xBE}},        // Java class
+	{"Mach-O 32", []byte{0xFE, 0xED, 0xFA, 0xCE}},    // macOS executable
+	{"Mach-O 64", []byte{0xFE, 0xED, 0xFA, 0xCF}},    // macOS 64-bit executable
+}
+
+// nullScanLimit caps the number of bytes scanned for null bytes.
+// 8 KB is enough to reliably detect binary content without scanning
+// the entire file, keeping the check O(1) for large inputs.
+const nullScanLimit = 8 * 1024
+
+// ValidateContent checks that data is valid text suitable for CalcMark.
+// It rejects known binary formats (magic-number check), null bytes, and
+// data that is not valid UTF-8. This is a defense-in-depth measure: even
+// if a file has a .cm extension, its content must be safe to interpret.
+func ValidateContent(data []byte) error {
+	// 1. Magic-number check: reject known binary file formats.
+	for _, sig := range knownBinarySignatures {
+		if bytes.HasPrefix(data, sig.magic) {
+			return fmt.Errorf("file is not valid CalcMark: detected %s binary content", sig.name)
+		}
+	}
+
+	// 2. Null-byte check: text files must not contain 0x00.
+	scanLen := len(data)
+	if scanLen > nullScanLimit {
+		scanLen = nullScanLimit
+	}
+	if bytes.ContainsRune(data[:scanLen], '\x00') {
+		return fmt.Errorf("file is not valid CalcMark: contains null bytes (binary content)")
+	}
+
+	// 3. UTF-8 validation: CalcMark is a text format; all content must be
+	// valid UTF-8.
+	if !utf8.Valid(data) {
+		return fmt.Errorf("file is not valid CalcMark: content is not valid UTF-8 text")
+	}
+
+	return nil
+}

--- a/cmd/calcmark/filecheck/filecheck_test.go
+++ b/cmd/calcmark/filecheck/filecheck_test.go
@@ -1,0 +1,379 @@
+package filecheck
+
+import (
+	"strings"
+	"testing"
+)
+
+// --- Magic number rejection tests ---
+
+func TestValidateContent_RejectsPNG(t *testing.T) {
+	// Minimal PNG header
+	data := []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A}
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for PNG data, got nil")
+	}
+	if !strings.Contains(err.Error(), "PNG") {
+		t.Fatalf("expected PNG in error, got: %v", err)
+	}
+}
+
+func TestValidateContent_RejectsJPEG(t *testing.T) {
+	data := []byte{0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10}
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for JPEG data, got nil")
+	}
+	if !strings.Contains(err.Error(), "JPEG") {
+		t.Fatalf("expected JPEG in error, got: %v", err)
+	}
+}
+
+func TestValidateContent_RejectsGIF(t *testing.T) {
+	data := []byte("GIF89a\x01\x00\x01\x00\x80\x00\x00")
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for GIF data, got nil")
+	}
+	if !strings.Contains(err.Error(), "GIF") {
+		t.Fatalf("expected GIF in error, got: %v", err)
+	}
+}
+
+func TestValidateContent_RejectsPDF(t *testing.T) {
+	data := []byte("%PDF-1.4 fake pdf content")
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for PDF data, got nil")
+	}
+	if !strings.Contains(err.Error(), "PDF") {
+		t.Fatalf("expected PDF in error, got: %v", err)
+	}
+}
+
+func TestValidateContent_RejectsZIP(t *testing.T) {
+	data := []byte("PK\x03\x04some zip data")
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for ZIP data, got nil")
+	}
+	if !strings.Contains(err.Error(), "ZIP") {
+		t.Fatalf("expected ZIP in error, got: %v", err)
+	}
+}
+
+func TestValidateContent_RejectsGZIP(t *testing.T) {
+	data := []byte{0x1F, 0x8B, 0x08, 0x00}
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for GZIP data, got nil")
+	}
+	if !strings.Contains(err.Error(), "GZIP") {
+		t.Fatalf("expected GZIP in error, got: %v", err)
+	}
+}
+
+func TestValidateContent_RejectsELF(t *testing.T) {
+	data := []byte{0x7F, 0x45, 0x4C, 0x46, 0x02, 0x01, 0x01, 0x00}
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for ELF data, got nil")
+	}
+	if !strings.Contains(err.Error(), "ELF") {
+		t.Fatalf("expected ELF in error, got: %v", err)
+	}
+}
+
+func TestValidateContent_RejectsPE(t *testing.T) {
+	data := []byte("MZ\x90\x00\x03\x00\x00\x00")
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for PE/MZ data, got nil")
+	}
+	if !strings.Contains(err.Error(), "PE/MZ") {
+		t.Fatalf("expected PE/MZ in error, got: %v", err)
+	}
+}
+
+func TestValidateContent_RejectsWASM(t *testing.T) {
+	data := []byte{0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00}
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for WASM data, got nil")
+	}
+	if !strings.Contains(err.Error(), "WASM") {
+		t.Fatalf("expected WASM in error, got: %v", err)
+	}
+}
+
+func TestValidateContent_RejectsRIFF(t *testing.T) {
+	data := []byte("RIFF\x24\x00\x00\x00WAVEfmt ")
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for RIFF data, got nil")
+	}
+	if !strings.Contains(err.Error(), "RIFF") {
+		t.Fatalf("expected RIFF in error, got: %v", err)
+	}
+}
+
+func TestValidateContent_RejectsSQLite(t *testing.T) {
+	data := []byte("SQLite format 3\x00")
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for SQLite data, got nil")
+	}
+	if !strings.Contains(err.Error(), "SQLite") {
+		t.Fatalf("expected SQLite in error, got: %v", err)
+	}
+}
+
+func TestValidateContent_RejectsJavaClass(t *testing.T) {
+	data := []byte{0xCA, 0xFE, 0xBA, 0xBE, 0x00, 0x00, 0x00, 0x34}
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for Java class data, got nil")
+	}
+	if !strings.Contains(err.Error(), "class") {
+		t.Fatalf("expected class in error, got: %v", err)
+	}
+}
+
+func TestValidateContent_RejectsMachO(t *testing.T) {
+	// Mach-O 64-bit
+	data := []byte{0xFE, 0xED, 0xFA, 0xCF, 0x00, 0x00, 0x00, 0x00}
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for Mach-O data, got nil")
+	}
+	if !strings.Contains(err.Error(), "Mach-O") {
+		t.Fatalf("expected Mach-O in error, got: %v", err)
+	}
+}
+
+// --- Null byte rejection tests ---
+
+func TestValidateContent_RejectsNullBytes(t *testing.T) {
+	data := []byte("hello\x00world")
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for null bytes, got nil")
+	}
+	if !strings.Contains(err.Error(), "null bytes") {
+		t.Fatalf("expected null bytes error, got: %v", err)
+	}
+}
+
+func TestValidateContent_RejectsNullBytesAtStart(t *testing.T) {
+	data := []byte("\x00 = some value")
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for leading null byte, got nil")
+	}
+}
+
+func TestValidateContent_RejectsNullBytesWithinScanLimit(t *testing.T) {
+	// Null byte at position 4096 (within 8KB scan limit)
+	data := make([]byte, 8*1024)
+	for i := range data {
+		data[i] = 'x'
+	}
+	data[4096] = 0x00
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for null byte within scan limit, got nil")
+	}
+}
+
+func TestValidateContent_NullBytesBeyondScanLimit(t *testing.T) {
+	// Null byte well beyond the 8KB scan limit — still caught by UTF-8
+	// check if the byte appears in an invalid UTF-8 sequence, but a lone
+	// 0x00 is valid UTF-8 (U+0000). This tests the scan-limit boundary.
+	data := make([]byte, 16*1024)
+	for i := range data {
+		data[i] = 'x'
+	}
+	data[9000] = 0x00
+	// A lone null byte is technically valid UTF-8, so only the scan-window
+	// catches it. Bytes past 8KB won't be scanned for nulls.
+	err := ValidateContent(data)
+	if err != nil {
+		t.Fatalf("null byte beyond scan limit should not be caught by null scan, got: %v", err)
+	}
+}
+
+// --- UTF-8 validation tests ---
+
+func TestValidateContent_RejectsInvalidUTF8(t *testing.T) {
+	// Invalid UTF-8: 0xFE is never valid in UTF-8
+	data := []byte{0xFE, 0xFE, 0xFF, 0xFF}
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for invalid UTF-8, got nil")
+	}
+	if !strings.Contains(err.Error(), "UTF-8") {
+		t.Fatalf("expected UTF-8 error, got: %v", err)
+	}
+}
+
+func TestValidateContent_RejectsInvalidUTF8Continuation(t *testing.T) {
+	// Start of a 2-byte UTF-8 sequence but missing continuation byte
+	data := []byte("valid text\xC0")
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for truncated UTF-8 sequence, got nil")
+	}
+	if !strings.Contains(err.Error(), "UTF-8") {
+		t.Fatalf("expected UTF-8 error, got: %v", err)
+	}
+}
+
+func TestValidateContent_RejectsLatin1(t *testing.T) {
+	// ISO-8859-1 encoded text (0xE9 = 'é' in Latin-1, invalid alone in UTF-8)
+	data := []byte("caf\xe9")
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for Latin-1 encoded text, got nil")
+	}
+	if !strings.Contains(err.Error(), "UTF-8") {
+		t.Fatalf("expected UTF-8 error, got: %v", err)
+	}
+}
+
+// --- Valid content tests ---
+
+func TestValidateContent_AcceptsEmptyInput(t *testing.T) {
+	if err := ValidateContent([]byte{}); err != nil {
+		t.Fatalf("expected no error for empty input, got: %v", err)
+	}
+}
+
+func TestValidateContent_AcceptsSimpleCalcMark(t *testing.T) {
+	data := []byte("x = 10\ny = x + 5\n")
+	if err := ValidateContent(data); err != nil {
+		t.Fatalf("expected no error for valid CalcMark, got: %v", err)
+	}
+}
+
+func TestValidateContent_AcceptsUTF8Text(t *testing.T) {
+	data := []byte("prix = 10\n// café: résultat\ntotal = prix * 2\n")
+	if err := ValidateContent(data); err != nil {
+		t.Fatalf("expected no error for UTF-8 text, got: %v", err)
+	}
+}
+
+func TestValidateContent_AcceptsMarkdownWithCalcMark(t *testing.T) {
+	data := []byte("# Budget\n\nrent = 1200\nutilities = 150\ntotal = rent + utilities\n")
+	if err := ValidateContent(data); err != nil {
+		t.Fatalf("expected no error for markdown + calcmark, got: %v", err)
+	}
+}
+
+func TestValidateContent_AcceptsBOM(t *testing.T) {
+	// UTF-8 BOM is valid UTF-8
+	data := []byte("\xEF\xBB\xBFx = 1\n")
+	if err := ValidateContent(data); err != nil {
+		t.Fatalf("expected no error for UTF-8 BOM text, got: %v", err)
+	}
+}
+
+func TestValidateContent_AcceptsCJK(t *testing.T) {
+	// Chinese/Japanese/Korean characters are valid UTF-8
+	data := []byte("// 計算\n価格 = 100\n")
+	if err := ValidateContent(data); err != nil {
+		t.Fatalf("expected no error for CJK text, got: %v", err)
+	}
+}
+
+func TestValidateContent_AcceptsEmoji(t *testing.T) {
+	data := []byte("// 📊 Budget\ntotal = 42\n")
+	if err := ValidateContent(data); err != nil {
+		t.Fatalf("expected no error for emoji in text, got: %v", err)
+	}
+}
+
+// --- Edge cases ---
+
+func TestValidateContent_RejectsBinaryGarbage(t *testing.T) {
+	// Random binary bytes that are not valid UTF-8
+	data := []byte{0x80, 0x81, 0x82, 0x83, 0x84, 0x85}
+	err := ValidateContent(data)
+	if err == nil {
+		t.Fatal("expected error for random binary bytes, got nil")
+	}
+}
+
+func TestValidateContent_AcceptsTextStartingWithM(t *testing.T) {
+	// "M" is the first byte of a PE/MZ signature, but "M" alone (or "My")
+	// should not be rejected. Only "MZ" prefix triggers rejection.
+	data := []byte("My budget = 100\n")
+	if err := ValidateContent(data); err != nil {
+		t.Fatalf("expected no error for text starting with 'M', got: %v", err)
+	}
+}
+
+func TestValidateContent_AcceptsTextStartingWithB(t *testing.T) {
+	// "B" is the first byte of BMP signature "BM", but "Budget" should pass.
+	data := []byte("Budget = 500\n")
+	if err := ValidateContent(data); err != nil {
+		t.Fatalf("expected no error for text starting with 'B', got: %v", err)
+	}
+}
+
+func TestValidateContent_AcceptsTextStartingWithPercent(t *testing.T) {
+	// "%" followed by non-"PDF" text should pass.
+	data := []byte("% this is a comment\nx = 1\n")
+	if err := ValidateContent(data); err != nil {
+		t.Fatalf("expected no error for text starting with '%%', got: %v", err)
+	}
+}
+
+// --- Table-driven test for all magic signatures ---
+
+func TestValidateContent_RejectsAllKnownSignatures(t *testing.T) {
+	for _, sig := range knownBinarySignatures {
+		t.Run(sig.name, func(t *testing.T) {
+			// Pad with valid UTF-8 text so only the magic-number check triggers
+			data := make([]byte, len(sig.magic)+20)
+			copy(data, sig.magic)
+			for i := len(sig.magic); i < len(data); i++ {
+				data[i] = 'A'
+			}
+			err := ValidateContent(data)
+			if err == nil {
+				t.Fatalf("expected error for %s signature, got nil", sig.name)
+			}
+			if !strings.Contains(err.Error(), sig.name) {
+				t.Fatalf("expected %q in error, got: %v", sig.name, err)
+			}
+		})
+	}
+}
+
+// --- Fuzz test ---
+
+func FuzzValidateContent(f *testing.F) {
+	// Seed with valid CalcMark
+	f.Add([]byte("x = 1\n"))
+	f.Add([]byte("# Title\nprice = 100\ntax = price * 0.1\n"))
+	// Seed with known binary headers
+	f.Add([]byte{0x89, 0x50, 0x4E, 0x47})
+	f.Add([]byte{0xFF, 0xD8, 0xFF})
+	f.Add([]byte("GIF89a"))
+	f.Add([]byte("%PDF-1.7"))
+	f.Add([]byte{0x00, 0x61, 0x73, 0x6D})
+	// Seed with null bytes
+	f.Add([]byte{0x00})
+	f.Add([]byte("abc\x00def"))
+	// Seed with invalid UTF-8
+	f.Add([]byte{0xFE, 0xFF})
+	f.Add([]byte{0xC0, 0xAF})
+	// Seed with empty
+	f.Add([]byte{})
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// ValidateContent must not panic on any input.
+		_ = ValidateContent(data)
+	})
+}

--- a/cmd/calcmark/tui/editor/file_operations.go
+++ b/cmd/calcmark/tui/editor/file_operations.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/CalcMark/go-calcmark/cmd/calcmark/filecheck"
 	"github.com/CalcMark/go-calcmark/format"
 	implDoc "github.com/CalcMark/go-calcmark/impl/document"
 	"github.com/CalcMark/go-calcmark/spec/document"
@@ -167,6 +168,13 @@ func (m *Model) openFile(filename string) {
 	// Read file
 	content, err := os.ReadFile(absPath)
 	if err != nil {
+		m.statusMsg = fmt.Sprintf("Open failed: %v", err)
+		m.statusIsErr = true
+		return
+	}
+
+	// Security: Reject binary/non-text content before parsing
+	if err := filecheck.ValidateContent(content); err != nil {
 		m.statusMsg = fmt.Sprintf("Open failed: %v", err)
 		m.statusIsErr = true
 		return


### PR DESCRIPTION
## Summary

This PR adds comprehensive file content validation across all CLI entry points and the TUI editor to prevent binary files (e.g., images, executables) from being interpreted as CalcMark code. This is a defense-in-depth security measure that catches attacks where a binary file is renamed with a `.cm` extension.

## Key Changes

- **New `filecheck` package** (`cmd/calcmark/filecheck/filecheck.go`): Implements `ValidateContent()` function that performs three-layer validation:
  1. **Magic number detection**: Rejects 21 known binary format signatures (PNG, JPEG, GIF, PDF, ZIP, GZIP, ELF, PE/MZ, WASM, RIFF, OGG, FLAC, BMP, TIFF, SQLite, 7Z, RAR, Java class, Mach-O)
  2. **Null byte detection**: Scans first 8 KB for null bytes (0x00), which never appear in valid text
  3. **UTF-8 validation**: Rejects content that is not valid UTF-8 text

- **Integration into CLI commands**:
  - `eval.go`: Validates file and stdin content before parsing
  - `convert.go`: Validates file content before parsing
  - `tui.go`: Validates file content in `loadDocument()`
  - `editor/file_operations.go`: Validates content when opening files in the TUI editor

- **Security wrapper functions** (`cmd/calcmark/cmd/security.go`):
  - `validateFileContent()`: Validates file input
  - `validateStdinContent()`: Validates piped stdin input
  - Both delegate to the shared `filecheck.ValidateContent()` for consistency

- **Comprehensive test coverage** (`filecheck/filecheck_test.go`):
  - 379 lines of tests covering all binary signatures, null bytes, UTF-8 validation, edge cases, and valid content
  - Includes fuzz testing to ensure robustness against arbitrary input
  - Integration tests in `cmd/security_test.go` verify the validation works through CLI wrappers

- **Documentation updates** (`SECURITY.md`): Documents the three-layer validation approach and its purpose

## Implementation Details

- The null-byte scan is limited to 8 KB for performance (O(1) for large files)
- Magic number checks are performed first (fastest rejection path)
- UTF-8 validation is performed last (most comprehensive check)
- All validation is performed before any parsing or interpretation of content
- The validation is applied consistently across file input, stdin input, and the TUI editor

https://claude.ai/code/session_01JF7y996qteCCCtCHsN6xyj