### PR TITLE
Fix unitless quantity multiplication with quantities

### DIFF
--- a/impl/interpreter/compound_units_test.go
+++ b/impl/interpreter/compound_units_test.go
@@ -431,3 +431,79 @@ func TestRateTypePreservation(t *testing.T) {
 		})
 	}
 }
+
+// TestUnitlessQuantityMultiplication verifies that a unitless quantity
+// (from accumulating a unitless rate) can multiply with a quantity that has units.
+// Regression test for https://github.com/CalcMark/go-calcmark/issues/8
+func TestUnitlessQuantityMultiplication(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		expectedUnit string
+	}{
+		{
+			name: "unitless rate accumulated then multiplied by quantity",
+			input: `mau = 1M / month
+w = mau over 1 week
+avg_session_data = 500 KB
+monthly_data = w * avg_session_data
+`,
+			expectedUnit: "KB",
+		},
+		{
+			name: "quantity multiplied by unitless rate accumulation",
+			input: `mau = 1M / month
+w = mau over 1 week
+avg_session_data = 500 KB
+monthly_data = avg_session_data * w
+`,
+			expectedUnit: "KB",
+		},
+		{
+			name: "unitless quantity times unitless quantity",
+			input: `a = 1M / month
+b = a over 1 week
+c = 2M / month
+d = c over 1 week
+result = b * d
+`,
+			expectedUnit: "", // both unitless, result is unitless quantity
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, err := parser.Parse(tt.input)
+			if err != nil {
+				t.Fatalf("Parse error: %v", err)
+			}
+
+			interp := NewInterpreter()
+			results, err := interp.Eval(nodes)
+			if err != nil {
+				t.Fatalf("Eval error: %v", err)
+			}
+
+			if len(results) == 0 {
+				t.Fatal("No results returned")
+			}
+
+			result := results[len(results)-1]
+
+			qty, ok := result.(*types.Quantity)
+			if !ok {
+				t.Fatalf("Expected *types.Quantity, got %T (%v)", result, result)
+			}
+
+			if qty.Unit != tt.expectedUnit {
+				t.Errorf("Expected unit %q, got %q", tt.expectedUnit, qty.Unit)
+			}
+
+			if qty.Value.IsZero() {
+				t.Error("Result value should not be zero")
+			}
+
+			t.Logf("Result: %s", qty.String())
+		})
+	}
+}

--- a/impl/interpreter/operators.go
+++ b/impl/interpreter/operators.go
@@ -169,6 +169,14 @@ func evalBinaryOperation(left, right types.Type, operator string) (types.Type, e
 	// Quantity operations (with unit conversion - USER REQUIREMENT: first-unit-wins)
 	if leftQty, ok := left.(*types.Quantity); ok {
 		if rightQty, ok := right.(*types.Quantity); ok {
+			// Unitless quantities (e.g., from accumulating a unitless rate like "1M / month")
+			// act as scalars for arithmetic. Re-dispatch as Number to reuse existing paths.
+			if leftQty.Unit == "" {
+				return evalBinaryOperation(types.NewNumber(leftQty.Value), right, operator)
+			}
+			if rightQty.Unit == "" {
+				return evalBinaryOperation(left, types.NewNumber(rightQty.Value), operator)
+			}
 			return evalQuantityOperation(leftQty, rightQty, operator)
 		}
 		// Quantity op Number (e.g., "10 dogs * 2" = "20 dogs", "5 dogs + 3" = "8 dogs")

--- a/testdata/eval/success/features/rate_functions.cm
+++ b/testdata/eval/success/features/rate_functions.cm
@@ -23,6 +23,12 @@ $5/day over 365 days
 1000 req/s per minute
 100k/hour per second
 
+# Unitless rate accumulated then multiplied by quantity (issue #8)
+mau = 1M / month
+w = mau over 1 week
+avg_session_data = 500 KB
+monthly_data = w * avg_session_data
+
 # Combined examples
 # bandwidth = 100 MB/s
 # daily_total = bandwidth over 1 day


### PR DESCRIPTION
## Summary
Fixes handling of unitless quantities (resulting from accumulating unitless rates) when multiplied with quantities that have units. Previously, this operation would fail or produce incorrect results.

## Key Changes
- **operators.go**: Added special handling in `evalBinaryOperation` to treat unitless quantities as scalars. When either operand is a unitless quantity, the operation is re-dispatched as a Number operation to reuse existing arithmetic paths that correctly handle quantity-number interactions.
- **compound_units_test.go**: Added comprehensive regression test `TestUnitlessQuantityMultiplication` covering three scenarios:
  - Unitless rate accumulation multiplied by a quantity with units
  - Quantity with units multiplied by unitless rate accumulation (reverse order)
  - Two unitless quantities multiplied together
- **rate_functions.cm**: Added test case demonstrating the fix for issue #8

## Implementation Details
The fix recognizes that a unitless quantity (e.g., from `(1M / month) over 1 week`) should behave as a scalar in arithmetic operations. Rather than treating it as a special case in quantity-quantity operations, the code converts it to a Number and leverages the existing quantity-number multiplication logic, which correctly preserves the units of the quantity operand.

https://claude.ai/code/session_01V4w4CSYywai1WNfQL2YVaP