### PR TITLE
Fix lexer to distinguish multiplier suffixes from unit prefixes

### DIFF
--- a/spec/lexer/lexer.go
+++ b/spec/lexer/lexer.go
@@ -248,8 +248,13 @@ func (l *Lexer) readNumber() Token {
 	}
 
 	// Check for multipliers (no space)
+	// Multipliers are single-character suffixes: k/K (thousand), M (million), B (billion), T (trillion), % (percent)
+	// If the suffix character is followed by another identifier character, it's a unit prefix (e.g., kg, km, kW),
+	// not a multiplier. In that case, fall through to the unit-adjacent-to-number handling below.
 	if l.pos < len(l.text) {
 		char := l.currentChar()
+		nextChar := l.peek(1)
+		isNextIdentChar := l.isIdentifierChar(nextChar, false)
 		var tokenType TokenType = NUMBER // Default
 
 		switch char {
@@ -258,27 +263,65 @@ func (l *Lexer) readNumber() Token {
 			l.advance()
 			value += "%"
 		case 'k', 'K':
-			tokenType = NUMBER_K
-			l.advance()
-			value += string(char)
+			if !isNextIdentChar {
+				tokenType = NUMBER_K
+				l.advance()
+				value += string(char)
+			}
 		case 'M':
-			tokenType = NUMBER_M
-			l.advance()
-			value += "M"
+			if !isNextIdentChar {
+				tokenType = NUMBER_M
+				l.advance()
+				value += "M"
+			}
 		case 'B':
-			tokenType = NUMBER_B
-			l.advance()
-			value += "B"
+			if !isNextIdentChar {
+				tokenType = NUMBER_B
+				l.advance()
+				value += "B"
+			}
 		case 'T':
-			tokenType = NUMBER_T
-			l.advance()
-			value += "T"
+			if !isNextIdentChar {
+				tokenType = NUMBER_T
+				l.advance()
+				value += "T"
+			}
 		}
 
 		if tokenType != NUMBER {
 			return Token{
 				Type:         tokenType,
 				Value:        value,
+				OriginalText: string(l.text[startPos:l.pos]),
+				Line:         startLine,
+				Column:       startColumn,
+				StartPos:     startPos,
+				EndPos:       l.pos,
+			}
+		}
+	}
+
+	// Check for unit directly adjacent to number (no space), e.g., 2kg, 5km, 10kW
+	if l.isIdentifierChar(l.currentChar(), true) {
+		savedUnitPos := l.pos
+		savedUnitLine := l.line
+		savedUnitCol := l.column
+		unit := l.readIdentifier()
+		unitStr := unit.Value
+
+		if _, isReserved := ReservedKeywords[strings.ToLower(unitStr)]; isReserved {
+			l.pos = savedUnitPos
+			l.line = savedUnitLine
+			l.column = savedUnitCol
+		} else if BooleanKeywords[strings.ToLower(unitStr)] {
+			l.pos = savedUnitPos
+			l.line = savedUnitLine
+			l.column = savedUnitCol
+		} else {
+			quantityValue := fmt.Sprintf("%s:%s", value, unitStr)
+			return Token{
+				Type:         QUANTITY,
+				Value:        quantityValue,
 				OriginalText: string(l.text[startPos:l.pos]),
 				Line:         startLine,
 				Column:       startColumn,

--- a/spec/lexer/lexer_multipliers_test.go
+++ b/spec/lexer/lexer_multipliers_test.go
@@ -93,6 +93,77 @@ func TestMultiplierTokens(t *testing.T) {
 	}
 }
 
+// TestMultiplierPrefixedUnits tests that units starting with multiplier characters
+// (e.g., kg, km, kW) are NOT incorrectly consumed as multipliers.
+// Bug: https://github.com/CalcMark/go-calcmark/issues/14
+func TestMultiplierPrefixedUnits(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedType  TokenType
+		expectedValue string
+	}{
+		{
+			name:          "2kg should be quantity not multiplier",
+			input:         "2kg",
+			expectedType:  QUANTITY,
+			expectedValue: "2:kg",
+		},
+		{
+			name:          "5km should be quantity not multiplier",
+			input:         "5km",
+			expectedType:  QUANTITY,
+			expectedValue: "5:km",
+		},
+		{
+			name:          "10kW should be quantity not multiplier",
+			input:         "10kW",
+			expectedType:  QUANTITY,
+			expectedValue: "10:kW",
+		},
+		{
+			name:          "3kJ should be quantity not multiplier",
+			input:         "3kJ",
+			expectedType:  QUANTITY,
+			expectedValue: "3:kJ",
+		},
+		{
+			name:          "standalone 2k is still a multiplier",
+			input:         "2k",
+			expectedType:  NUMBER_K,
+			expectedValue: "2k",
+		},
+		{
+			name:          "standalone 5K is still a multiplier",
+			input:         "5K",
+			expectedType:  NUMBER_K,
+			expectedValue: "5K",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			l := NewLexer(tt.input)
+			tokens, err := l.Tokenize()
+			if err != nil {
+				t.Fatalf("Tokenize() error = %v", err)
+			}
+
+			if len(tokens) < 1 {
+				t.Fatalf("Expected at least 1 token, got %d", len(tokens))
+			}
+
+			tok := tokens[0]
+			if tok.Type != tt.expectedType {
+				t.Errorf("Token type = %v, want %v (tokens: %v)", tok.Type, tt.expectedType, tokens)
+			}
+			if tok.Value != tt.expectedValue {
+				t.Errorf("Token value = %q, want %q", tok.Value, tt.expectedValue)
+			}
+		})
+	}
+}
+
 // TestMultiplierVsUnit tests the critical distinction between multipliers (no space)
 // and units (with space). This is essential for the CalcMark language.
 func TestMultiplierVsUnit(t *testing.T) {


### PR DESCRIPTION
## Summary
Fixed a bug where the lexer incorrectly consumed unit prefixes (e.g., kg, km, kW) as multipliers. The lexer now properly distinguishes between multiplier suffixes (k, K, M, B, T when standalone) and unit prefixes (when followed by additional identifier characters).

## Key Changes
- **Enhanced multiplier detection logic**: Added lookahead check to verify that multiplier characters (k, K, M, B, T) are not followed by additional identifier characters before treating them as multipliers
- **Added unit-adjacent-to-number handling**: Implemented new code path to recognize units directly adjacent to numbers without spaces (e.g., "2kg", "5km", "10kW") and emit them as QUANTITY tokens with the format "number:unit"
- **Added comprehensive test coverage**: Created `TestMultiplierPrefixedUnits` test function with 6 test cases covering:
  - Units with k prefix (kg)
  - Units with k prefix (km)
  - Units with k prefix (kW)
  - Units with k prefix (kJ)
  - Standalone multipliers (2k, 5K) to ensure they still work correctly

## Implementation Details
- The fix checks if the character following a potential multiplier is an identifier character using `isNextIdentChar`
- If a multiplier character is followed by another identifier character, the lexer skips the multiplier consumption and falls through to unit handling
- Reserved keywords and boolean keywords are excluded from being treated as units to prevent incorrect tokenization
- The quantity token format follows the pattern "number:unit" (e.g., "2:kg")

Fixes: https://github.com/CalcMark/go-calcmark/issues/14

https://claude.ai/code/session_015MbDAZmMbj29rVgZsKmb3T