### PR TITLE
Support arithmetic operations between currency and plain numbers

### DIFF
--- a/impl/interpreter/currency_number_test.go
+++ b/impl/interpreter/currency_number_test.go
@@ -1,0 +1,93 @@
+package interpreter_test
+
+import (
+	"testing"
+
+	"github.com/CalcMark/go-calcmark/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/spec/parser"
+)
+
+// TestCurrencyNumberOperations verifies currency +/-/* /÷ number operations.
+// Issue #16: Adding a number to a currency value should work.
+func TestCurrencyNumberOperations(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		// Currency + Number → Currency (keeps currency unit)
+		{"EUR addition", "a = 10 EUR\nb = a + 2\n", "EUR12.00"},
+		{"USD addition", "$100 + 5\n", "$105.00"},
+		{"GBP addition", "£50 + 10\n", "£60.00"},
+
+		// Currency - Number → Currency
+		{"EUR subtraction", "a = 10 EUR\nb = a - 3\n", "EUR7.00"},
+		{"USD subtraction", "$100 - 25\n", "$75.00"},
+
+		// Currency / Number → Currency
+		{"EUR division", "a = 10 EUR\nb = a / 2\n", "EUR5.00"},
+		{"USD division", "$100 / 4\n", "$25.00"},
+
+		// Currency * Number → Currency (already works, verify it still does)
+		{"EUR multiplication", "a = 10 EUR\nb = a * 3\n", "EUR30.00"},
+		{"USD multiplication", "$100 * 2\n", "$200.00"},
+
+		// Number + Currency → Currency
+		{"number + EUR", "a = 10 EUR\nb = 2 + a\n", "EUR12.00"},
+		{"number + USD", "5 + $100\n", "$105.00"},
+
+		// Number - Currency → Currency
+		{"number - EUR", "a = 10 EUR\nb = 20 - a\n", "EUR10.00"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, err := parser.Parse(tt.input)
+			if err != nil {
+				t.Fatalf("Parse error: %v", err)
+			}
+
+			interp := interpreter.NewInterpreter()
+			results, err := interp.Eval(nodes)
+			if err != nil {
+				t.Fatalf("Eval error: %v", err)
+			}
+
+			if len(results) == 0 {
+				t.Fatal("No results returned")
+			}
+
+			// Use the last result (for multi-line inputs with assignments)
+			actual := results[len(results)-1].String()
+			if actual != tt.expected {
+				t.Errorf("Result = %s, expected %s", actual, tt.expected)
+			}
+		})
+	}
+}
+
+// TestCurrencyNumberErrors verifies that mixing different currencies still fails.
+func TestCurrencyNumberErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"USD + EUR", "$100 + 50 EUR\n"},
+		{"EUR - GBP", "10 EUR - 5 GBP\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, err := parser.Parse(tt.input)
+			if err != nil {
+				return // Parse error is fine
+			}
+
+			interp := interpreter.NewInterpreter()
+			_, err = interp.Eval(nodes)
+			if err == nil {
+				t.Errorf("Expected error for %q but got none", tt.input)
+			}
+		})
+	}
+}

--- a/impl/interpreter/multipliers_test.go
+++ b/impl/interpreter/multipliers_test.go
@@ -57,7 +57,7 @@ func TestCurrencyMixing(t *testing.T) {
 		input    string
 		shouldOK bool
 	}{
-		{"$100 + 50 USD", "$100 + 50\n", false}, // This won't work - "50" is just a number
+		{"$100 + 50", "$100 + 50\n", true}, // Currency + Number works (issue #16)
 		{"$100 + $50", "$100 + $50\n", true},
 		// Need to verify if "100 USD" postfix syntax works first
 	}

--- a/impl/interpreter/operators.go
+++ b/impl/interpreter/operators.go
@@ -78,10 +78,16 @@ func evalBinaryOperation(left, right types.Type, operator string) (types.Type, e
 			// So we'll handle this in a special case if needed
 			return evalNumberOperation(leftNum, rightNum, operator)
 		}
-		// Number * Currency → Currency
-		if rightCur, ok := right.(*types.Currency); ok && operator == "*" {
-			result := leftNum.Value.Mul(rightCur.Value)
-			return types.NewCurrency(result, rightCur.Symbol), nil
+		// Number op Currency → Currency (e.g., "2 + $10" = "$12", "2 * $10" = "$20")
+		if rightCur, ok := right.(*types.Currency); ok {
+			switch operator {
+			case "+":
+				return types.NewCurrency(leftNum.Value.Add(rightCur.Value), rightCur.Symbol), nil
+			case "-":
+				return types.NewCurrency(leftNum.Value.Sub(rightCur.Value), rightCur.Symbol), nil
+			case "*":
+				return types.NewCurrency(leftNum.Value.Mul(rightCur.Value), rightCur.Symbol), nil
+			}
 		}
 		// Number * Duration → Duration
 		if rightDur, ok := right.(*types.Duration); ok && operator == "*" {
@@ -92,10 +98,21 @@ func evalBinaryOperation(left, right types.Type, operator string) (types.Type, e
 
 	// Currency operations
 	if leftCur, ok := left.(*types.Currency); ok {
-		// Currency * Number → Currency
-		if rightNum, ok := right.(*types.Number); ok && operator == "*" {
-			result := leftCur.Value.Mul(rightNum.Value)
-			return types.NewCurrency(result, leftCur.Symbol), nil
+		// Currency op Number → Currency (e.g., "10 EUR + 2" = "12 EUR")
+		if rightNum, ok := right.(*types.Number); ok {
+			switch operator {
+			case "+":
+				return types.NewCurrency(leftCur.Value.Add(rightNum.Value), leftCur.Symbol), nil
+			case "-":
+				return types.NewCurrency(leftCur.Value.Sub(rightNum.Value), leftCur.Symbol), nil
+			case "*":
+				return types.NewCurrency(leftCur.Value.Mul(rightNum.Value), leftCur.Symbol), nil
+			case "/":
+				if rightNum.Value.IsZero() {
+					return nil, fmt.Errorf("division by zero")
+				}
+				return types.NewCurrency(leftCur.Value.Div(rightNum.Value), leftCur.Symbol), nil
+			}
 		}
 		// Currency op Currency (same type)
 		if rightCur, ok := right.(*types.Currency); ok {

--- a/testdata/eval/success/features/currency_number_arithmetic.cm
+++ b/testdata/eval/success/features/currency_number_arithmetic.cm
@@ -1,0 +1,34 @@
+# Currency and Number Arithmetic
+
+A currency value combined with a plain number produces a currency result.
+The currency unit is preserved from whichever operand carries it.
+
+## Addition
+
+price = 10 EUR
+total = price + 2
+
+tip = $100 + 15
+
+## Subtraction
+
+discount = $50 - 10
+
+remainder = 20 EUR - 5
+
+## Division
+
+split = $100 / 4
+
+per_item = 30 EUR / 3
+
+## Multiplication
+
+doubled = $25 * 2
+
+scaled = 3 * 10 EUR
+
+## Chained operations
+
+base = 100 EUR
+adjusted = base + 20 - 5


### PR DESCRIPTION
## Summary
Extends the interpreter to support arithmetic operations between currency values and plain numbers, allowing expressions like `$100 + 5` or `10 EUR / 2` to work correctly. The currency unit is preserved from the currency operand in the result.

## Changes
- **Extended binary operations in `operators.go`**:
  - Added support for `+`, `-`, `/` operators between Currency and Number (previously only `*` was supported)
  - Added support for `+`, `-`, `*` operators between Number and Currency (previously only `*` was supported)
  - Currency unit is preserved from whichever operand carries it
  - Added division by zero check for currency division operations

- **Added comprehensive test coverage**:
  - New test file `currency_number_test.go` with 12 test cases covering:
    - Currency + Number operations (EUR, USD, GBP)
    - Currency - Number operations
    - Currency / Number operations
    - Currency * Number operations (verification)
    - Number + Currency operations (commutative)
    - Number - Currency operations
    - Error cases for mixing different currencies
  - New test data file `currency_number_arithmetic.cm` documenting the feature with examples

- **Updated existing test**:
  - Modified `multipliers_test.go` to reflect that `$100 + 50` now succeeds (resolves issue #16)

## Implementation Details
- Operations follow the rule: when mixing currency and number types, the result is currency with the unit from the currency operand
- Subtraction with number on left and currency on right produces currency (e.g., `20 - 10 EUR = 10 EUR`)
- Division is supported for currency/number (e.g., `$100 / 4 = $25`)
- Mixing different currency types still correctly fails with an error

https://claude.ai/code/session_011yGHHs187xQB8D5SwdniFG