### PR TITLE
fix(tui): record autocomplete acceptance on undo stack

### DIFF
--- a/cmd/calcmark/tui/editor/catwalk_test.go
+++ b/cmd/calcmark/tui/editor/catwalk_test.go
@@ -91,6 +91,7 @@ z = 30`
 			"open_from_unsaved",                   // TestEditorCatwalkOpenFromUnsaved
 			"context_footer_refs",                 // TestEditorCatwalkContextFooterRefs
 			"context_footer_self_ref",             // TestEditorCatwalkContextFooterSelfRef
+			"autocomplete_undo",                   // TestEditorCatwalkAutocompleteUndo
 		}
 		for _, skip := range skipTests {
 			if strings.HasSuffix(path, skip) {
@@ -1727,6 +1728,43 @@ z = 30`
 		RunModelV2(t, path, m,
 			WithObserverV2("debug", func(out io.Writer, m tea.Model) error {
 				_, err := out.Write([]byte(m.(Model).Debug()))
+				return err
+			}),
+		)
+	})
+}
+
+// TestEditorCatwalkAutocompleteUndo tests undo/redo after accepting autocomplete.
+// Verifies: Issue #15 - autocomplete acceptance must be recorded on the undo stack.
+// Uses a fresh document to avoid shared mutation pollution from other catwalk tests.
+func TestEditorCatwalkAutocompleteUndo(t *testing.T) {
+	content := `# Header
+x = 10
+y = 20
+z = 30`
+
+	doc, err := document.NewDocument(content)
+	if err != nil {
+		t.Fatalf("Failed to create document: %v", err)
+	}
+
+	datadriven.Walk(t, "testdata", func(t *testing.T, path string) {
+		if !strings.HasSuffix(path, "/autocomplete_undo") {
+			return
+		}
+
+		m := New(doc)
+		m.width = 80
+		m.height = 24
+		m.previewMode = PreviewFull
+
+		RunModelV2(t, path, m,
+			WithObserverV2("debug", func(out io.Writer, m tea.Model) error {
+				_, err := out.Write([]byte(m.(Model).Debug()))
+				return err
+			}),
+			WithObserverV2("lines", func(out io.Writer, m tea.Model) error {
+				_, err := out.Write([]byte(m.(Model).DebugLines()))
 				return err
 			}),
 		)

--- a/cmd/calcmark/tui/editor/context_footer_render_test.go
+++ b/cmd/calcmark/tui/editor/context_footer_render_test.go
@@ -13,9 +13,9 @@ import (
 // Model → GetLineResults → getLineReferences → renderContextFooter.
 func TestContextFooterShowsVariableReferences(t *testing.T) {
 	tests := []struct {
-		name       string
-		source     string
-		cursorLine int
+		name         string
+		source       string
+		cursorLine   int
 		wantInOutput []string // substrings expected in footer output
 	}{
 		{

--- a/cmd/calcmark/tui/editor/model.go
+++ b/cmd/calcmark/tui/editor/model.go
@@ -1002,6 +1002,7 @@ func isWordRune(ch rune) bool {
 }
 
 // acceptAutocomplete inserts the selected suggestion at the cursor.
+// Records an OpReplace on the undo stack so the acceptance can be undone.
 func (m Model) acceptAutocomplete() (tea.Model, tea.Cmd) {
 	if m.autocompleteState.Selected < 0 ||
 		m.autocompleteState.Selected >= len(m.autocompleteState.Suggestions) {
@@ -1022,9 +1023,16 @@ func (m Model) acceptAutocomplete() (tea.Model, tea.Cmd) {
 		insertText += "("
 	}
 
+	// Capture state BEFORE the edit for undo
+	beforeCol := m.cursorCol
+	beforeScroll := m.scrollOffset
+
 	// Replace prefix with selected suggestion (UTF-8 safe)
 	prefix := m.autocompleteState.Prefix
 	prefixStart := max(m.cursorCol-runeLen(prefix), 0)
+
+	// Commit any pending typing batch as a separate undo step
+	m.undoManager.ForceBoundary()
 
 	// Delete the prefix, then insert the completion text
 	beforePrefix, _ := runeSlice(m.editBuf, prefixStart)
@@ -1032,6 +1040,22 @@ func (m Model) acceptAutocomplete() (tea.Model, tea.Cmd) {
 	m.editBuf = beforePrefix + insertText + afterCursor
 	m.cursorCol = prefixStart + runeLen(insertText)
 
+	// Record the replacement for undo (Col = where replacement starts, not cursor)
+	m.undoManager.AddOperation(EditOperation{
+		Type:         OpReplace,
+		Line:         m.cursorLine,
+		Col:          prefixStart,
+		OldText:      prefix,
+		NewText:      insertText,
+		CursorLine:   m.cursorLine,
+		CursorCol:    beforeCol,
+		ScrollOffset: beforeScroll,
+	})
+
+	// Commit as a discrete undo step (like paste)
+	m.undoManager.ForceBoundary()
+
+	m.modified = true
 	m.exitAutocomplete()
 	m.transitionToEditing()
 	return m.debounceUpdate()

--- a/cmd/calcmark/tui/editor/testdata/autocomplete_undo
+++ b/cmd/calcmark/tui/editor/testdata/autocomplete_undo
@@ -1,0 +1,100 @@
+# Test: Undo/Redo after accepting autocomplete suggestions
+# Verifies: Issue #15 - autocomplete acceptance recorded on undo stack
+# Document: # Header\nx = 10\ny = 20\nz = 30 (4 lines)
+# IMPORTANT: Each test block is cumulative - state persists between blocks
+
+# Initial state
+run observe=debug
+----
+-- debug:
+mode=StateDefault cursorLine=0 cursorCol=0 cursorVisual=0 cursorHighlight=0 scrollOffset=0 totalSource=4 totalVisual=4 editBuf="" selectionAnchorLine=-1 selectionAnchorCol=-1 sourcePreviewMatch=true cursorInBounds=true highlightMatch=true mappingComplete=true
+
+# Test 1: Type "av" to trigger autocomplete, then TAB to accept "avg("
+# The function suggestion gets "(" appended
+run observe=debug
+type av
+----
+-- debug:
+mode=StateAutocomplete cursorLine=0 cursorCol=2 cursorVisual=0 cursorHighlight=0 scrollOffset=0 totalSource=4 totalVisual=4 editBuf="av# Header" selectionAnchorLine=-1 selectionAnchorCol=-1 sourcePreviewMatch=true cursorInBounds=true highlightMatch=true mappingComplete=true
+
+# Accept autocomplete: "av" -> "avg("
+run observe=debug
+key tab
+----
+-- debug:
+mode=StateDefault cursorLine=0 cursorCol=4 cursorVisual=0 cursorHighlight=0 scrollOffset=0 totalSource=4 totalVisual=4 editBuf="avg(# Header" selectionAnchorLine=-1 selectionAnchorCol=-1 sourcePreviewMatch=true cursorInBounds=true highlightMatch=true mappingComplete=true
+
+# Test 2: Undo should revert autocomplete acceptance, restoring "av"
+# Force boundary by navigating first (commits any pending undo batch)
+run observe=debug
+key down
+key ctrl+z
+----
+-- debug:
+mode=StateDefault cursorLine=0 cursorCol=2 cursorVisual=0 cursorHighlight=0 scrollOffset=0 totalSource=4 totalVisual=4 editBuf="av# Header" selectionAnchorLine=-1 selectionAnchorCol=-1 sourcePreviewMatch=true cursorInBounds=true highlightMatch=true mappingComplete=true
+
+# Test 3: Redo should re-apply the autocomplete, restoring "avg("
+run observe=debug
+key ctrl+y
+----
+-- debug:
+mode=StateDefault cursorLine=0 cursorCol=4 cursorVisual=0 cursorHighlight=0 scrollOffset=0 totalSource=4 totalVisual=4 editBuf="avg(# Header" selectionAnchorLine=-1 selectionAnchorCol=-1 sourcePreviewMatch=true cursorInBounds=true highlightMatch=true mappingComplete=true
+
+# Test 4: Undo the autocomplete again, then undo the typing ("av")
+# First undo: "avg(" -> "av"
+run observe=debug
+key ctrl+z
+----
+-- debug:
+mode=StateDefault cursorLine=0 cursorCol=2 cursorVisual=0 cursorHighlight=0 scrollOffset=0 totalSource=4 totalVisual=4 editBuf="av# Header" selectionAnchorLine=-1 selectionAnchorCol=-1 sourcePreviewMatch=true cursorInBounds=true highlightMatch=true mappingComplete=true
+
+# Second undo: "av" -> "" (restores original "# Header")
+run observe=debug
+key ctrl+z
+----
+-- debug:
+mode=StateDefault cursorLine=0 cursorCol=0 cursorVisual=0 cursorHighlight=0 scrollOffset=0 totalSource=4 totalVisual=4 editBuf="# Header" selectionAnchorLine=-1 selectionAnchorCol=-1 sourcePreviewMatch=true cursorInBounds=true highlightMatch=true mappingComplete=true
+
+# Test 5: Type, accept, type more, then sequential undo
+# Type "sq" to trigger autocomplete for sqrt
+run observe=debug
+type sq
+----
+-- debug:
+mode=StateAutocomplete cursorLine=0 cursorCol=2 cursorVisual=0 cursorHighlight=0 scrollOffset=0 totalSource=4 totalVisual=4 editBuf="sq# Header" selectionAnchorLine=-1 selectionAnchorCol=-1 sourcePreviewMatch=true cursorInBounds=true highlightMatch=true mappingComplete=true
+
+# Accept "sqrt("
+run observe=debug
+key tab
+----
+-- debug:
+mode=StateDefault cursorLine=0 cursorCol=5 cursorVisual=0 cursorHighlight=0 scrollOffset=0 totalSource=4 totalVisual=4 editBuf="sqrt(# Header" selectionAnchorLine=-1 selectionAnchorCol=-1 sourcePreviewMatch=true cursorInBounds=true highlightMatch=true mappingComplete=true
+
+# Type more after accepting: "9)"
+run observe=debug
+type 9)
+----
+-- debug:
+mode=StateDefault cursorLine=0 cursorCol=7 cursorVisual=0 cursorHighlight=0 scrollOffset=0 totalSource=4 totalVisual=4 editBuf="sqrt(9)# Header" selectionAnchorLine=-1 selectionAnchorCol=-1 sourcePreviewMatch=true cursorInBounds=true highlightMatch=true mappingComplete=true
+
+# First undo: should remove the typed "9)" (restoring "sqrt(")
+run observe=debug
+key down
+key ctrl+z
+----
+-- debug:
+mode=StateDefault cursorLine=0 cursorCol=5 cursorVisual=0 cursorHighlight=0 scrollOffset=0 totalSource=4 totalVisual=4 editBuf="sqrt(# Header" selectionAnchorLine=-1 selectionAnchorCol=-1 sourcePreviewMatch=true cursorInBounds=true highlightMatch=true mappingComplete=true
+
+# Second undo: should revert autocomplete (restoring "sq")
+run observe=debug
+key ctrl+z
+----
+-- debug:
+mode=StateDefault cursorLine=0 cursorCol=2 cursorVisual=0 cursorHighlight=0 scrollOffset=0 totalSource=4 totalVisual=4 editBuf="sq# Header" selectionAnchorLine=-1 selectionAnchorCol=-1 sourcePreviewMatch=true cursorInBounds=true highlightMatch=true mappingComplete=true
+
+# Third undo: should remove the typed "sq" (restoring "# Header")
+run observe=debug
+key ctrl+z
+----
+-- debug:
+mode=StateDefault cursorLine=0 cursorCol=0 cursorVisual=0 cursorHighlight=0 scrollOffset=0 totalSource=4 totalVisual=4 editBuf="# Header" selectionAnchorLine=-1 selectionAnchorCol=-1 sourcePreviewMatch=true cursorInBounds=true highlightMatch=true mappingComplete=true

--- a/docs/plans/2026-03-03-fix-autocomplete-undo-stack-plan.md
+++ b/docs/plans/2026-03-03-fix-autocomplete-undo-stack-plan.md
@@ -1,0 +1,131 @@
+---
+title: "fix: Autocomplete acceptance not recorded on undo stack"
+type: fix
+status: completed
+date: 2026-03-03
+issue: https://github.com/CalcMark/go-calcmark/issues/15
+---
+
+# fix: Autocomplete acceptance not recorded on undo stack
+
+## Overview
+
+When a user accepts an autosuggest via TAB, the text replacement (prefix -> completion) is not recorded on the undo stack. Pressing Cmd+Z/Ctrl+Z after accepting an autocomplete corrupts the buffer instead of reverting the completion.
+
+## Problem Statement
+
+`acceptAutocomplete()` in `cmd/calcmark/tui/editor/model.go:1004-1038` directly mutates `editBuf` via string slicing without:
+1. Capturing before-state for undo
+2. Calling `ForceBoundary()` to isolate the operation
+3. Recording an `EditOperation` via `AddOperation()`
+
+Every other editing operation (typing, paste, backspace, delete, enter) properly records operations. Autocomplete acceptance is the only mutation path that bypasses the undo system.
+
+**Repro** (from issue #15):
+1. Open empty cm editor
+2. Type `2 cm` — observe autosuggest for centimeters
+3. Press TAB to accept — text updates to `2 centimeter`
+4. Press Cmd+Z to undo
+5. **Expected**: `centimeter` disappears, second Cmd+Z restores `cm`
+6. **Observed**: Buffer shows `2 cntimeter` — the `e` (where `m` was) is deleted instead
+
+## Proposed Solution
+
+Follow the paste handler pattern from `clipboard.go:100-141`:
+
+1. Capture before-state (`cursorLine`, `cursorCol`, `scrollOffset`)
+2. Call `m.undoManager.ForceBoundary()` before the edit (commits any pending typing batch)
+3. Perform the text replacement (unchanged from current code)
+4. Record `OpReplace` with the exact field mapping below
+5. Set `m.modified = true`
+6. Call `m.undoManager.ForceBoundary()` after the edit (commits the autocomplete batch)
+
+### EditOperation Field Mapping
+
+```
+Op.Type         = OpReplace
+Op.Line         = m.cursorLine        // line where edit occurs
+Op.Col          = prefixStart          // rune position where replacement STARTS
+Op.OldText      = prefix               // typed prefix being replaced (e.g., "cm")
+Op.NewText      = insertText           // completion text incl. "(" for functions
+Op.CursorLine   = m.cursorLine        // for undo cursor restore
+Op.CursorCol    = m.cursorCol         // cursor pos BEFORE edit (end of prefix)
+Op.ScrollOffset = m.scrollOffset      // for undo scroll restore
+```
+
+**Critical distinction**: `Op.Col` = `prefixStart` (where the replacement begins), NOT `m.cursorCol` (cursor at end of prefix). The undo system uses `Op.Col` to locate the text for deletion/insertion, while `CursorCol` is only used for cursor restoration.
+
+### Implementation Choices
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Use `AddOperation` vs `recordEdit` | `AddOperation` directly | `ForceBoundary()` already commits the batch; `recordEdit`'s grouping timer is unnecessary |
+| Set `m.modified` | Explicitly `= true` | Matches paste handler; ensures save indicator updates before debounce fires |
+| Call `reEvaluate()` | No — rely on debounce | Current behavior; delay is ~150ms and acceptable |
+
+## Technical Considerations
+
+### Undo/Redo Correctness
+
+The `OpReplace` undo/redo paths in `undo_operations.go` handle this correctly:
+
+- **Undo** (line 242): Deletes `runeLen(NewText)` chars at `Col`, inserts `OldText` at `Col`
+- **Redo** (line 318): Deletes `runeLen(OldText)` chars at `Col`, inserts `NewText` at `Col`
+- **Redo cursor** (line 129): Places cursor at `Col + runeLen(NewText)` — correct end-of-completion position
+
+### Undo Grouping Interaction
+
+When the user types "cm" then TABs to accept "centimeter":
+
+1. Typing "c" and "m" create `OpInsert` operations in the current undo batch
+2. First `ForceBoundary()` commits batch 1: `[OpInsert("c"), OpInsert("m")]`
+3. `OpReplace(OldText="cm", NewText="centimeter")` is recorded
+4. Second `ForceBoundary()` commits batch 2: `[OpReplace]`
+
+Result: Ctrl+Z undoes the autocomplete (restores "cm"), second Ctrl+Z undoes the typing (removes "cm"). This matches user expectations.
+
+### Institutional Learnings Applied
+
+From `docs/solutions/ui-bugs/bubble-tea-v2-migration-selection-undo-clipboard-fixes.md`:
+- Value receiver calling `m.undoManager.ForceBoundary()` is safe — `undoManager` is a pointer field, mutations persist through the returned model copy
+- The paste handler already proves this pattern works with the Bubble Tea v2 architecture
+
+## Acceptance Criteria
+
+### Core Requirements
+- [x]`acceptAutocomplete()` records `OpReplace` on the undo stack (`model.go`)
+- [x]Ctrl+Z after autocomplete accept restores the typed prefix
+- [x]Ctrl+Y after undo re-applies the completion
+- [x]Function completions (with appended "(") undo completely including the paren
+- [x]Prior typing commits as a separate undo batch before the autocomplete
+
+### Edge Cases
+- [x]Prefix at start of line (col 0) — `prefixStart` = 0
+- [x]Multiple consecutive autocomplete acceptances undo in reverse order
+- [x]Redo cursor positions at end of completion text
+
+### Testing (TDD per CLAUDE.md)
+- [x]New catwalk test `testdata/autocomplete_undo` — reproduces bug first (fails), then validates fix (passes)
+- [x]Test: type prefix -> TAB accept -> verify text -> Ctrl+Z -> verify prefix restored
+- [x]Test: accept -> Ctrl+Z -> Ctrl+Y -> verify redo
+- [x]Test: accept function (with "(") -> Ctrl+Z -> verify prefix without paren
+- [x]Test: type -> accept -> type more -> Ctrl+Z sequence (grouped correctly)
+- [x]`task test` passes with zero regressions
+- [x]`task quality` passes
+
+## Files to Modify
+
+| File | Change |
+|---|---|
+| `cmd/calcmark/tui/editor/model.go` | Add undo recording to `acceptAutocomplete()` (~15 lines) |
+| `cmd/calcmark/tui/editor/testdata/autocomplete_undo` | New catwalk test file |
+| `cmd/calcmark/tui/editor/catwalk_test.go` | Register dedicated test function for `autocomplete_undo` |
+
+## References
+
+- Issue: [#15](https://github.com/CalcMark/go-calcmark/issues/15)
+- Paste handler pattern: `cmd/calcmark/tui/editor/clipboard.go:100-141`
+- Undo system: `cmd/calcmark/tui/editor/undo.go`, `undo_operations.go`
+- Existing autocomplete tests: `cmd/calcmark/tui/editor/testdata/autocomplete`
+- Catwalk testing docs: `cmd/calcmark/tui/editor/TESTING.md`
+- Learnings: `docs/solutions/ui-bugs/bubble-tea-v2-migration-selection-undo-clipboard-fixes.md`


### PR DESCRIPTION
## Summary

Fixes #15 — Accepting an autosuggest via TAB was not recorded on the undo stack, causing Ctrl+Z to corrupt the buffer instead of reverting the completion.

**Root cause**: `acceptAutocomplete()` in `model.go` directly mutated `editBuf` without recording an `EditOperation`.

**Fix**: Follow the paste handler pattern from `clipboard.go`:
- `ForceBoundary()` before/after to isolate as a discrete undo step
- `OpReplace` with `OldText=prefix`, `NewText=completion` at `prefixStart`
- Set `m.modified = true` explicitly

## Test plan

- [x] New catwalk test `testdata/autocomplete_undo` covering:
  - Type prefix → TAB accept → Ctrl+Z restores prefix
  - Ctrl+Y re-applies completion (redo)
  - Full undo chain: completion → prefix → original line
  - Function completion with "(" undoes completely
  - Type → accept → type more → sequential undo (3 separate batches)
- [x] `task test` — full suite passes with zero regressions
- [x] `task quality` — all quality gates pass (fmt, vet, modernize, staticcheck)

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: This is a client-side TUI editor fix with no server/runtime impact.

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)