### PR TITLE
feat: support duration conversion with 'as' and 'in' operators

### DIFF
--- a/impl/interpreter/unit_conversion_eval.go
+++ b/impl/interpreter/unit_conversion_eval.go
@@ -38,10 +38,19 @@ func (interp *Interpreter) evalUnitConversion(u *ast.UnitConversion) (types.Type
 			u.TargetUnit, rate.String(), rate.Amount.Unit, u.TargetUnit, rate.String(), u.TargetUnit)
 	}
 
+	// Duration conversion: "1 day in seconds", "2 weeks in hours"
+	if duration, ok := result.(*types.Duration); ok {
+		converted, err := duration.Convert(u.TargetUnit)
+		if err != nil {
+			return nil, fmt.Errorf("cannot convert duration: %w", err)
+		}
+		return converted, nil
+	}
+
 	// Standard quantity conversion
 	qty, ok := result.(*types.Quantity)
 	if !ok {
-		return nil, fmt.Errorf("'in' conversion requires a quantity, got %T", result)
+		return nil, fmt.Errorf("'in' conversion requires a quantity or duration, got %T", result)
 	}
 
 	// Use existing unit conversion logic

--- a/impl/interpreter/unit_conversion_test.go
+++ b/impl/interpreter/unit_conversion_test.go
@@ -266,6 +266,159 @@ func TestRateUnitConversion(t *testing.T) {
 	}
 }
 
+// TestDurationConversion tests duration-to-duration conversion using "in" and "as" keywords.
+// Examples: "1 day in seconds", "2 weeks as hours", "1 year in days"
+func TestDurationConversion(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		expected  float64
+		tolerance float64
+		wantUnit  string // Expected unit in output
+	}{
+		// "in" keyword conversions
+		{
+			name:      "1 day in seconds",
+			input:     "1 day in seconds\n",
+			expected:  86400,
+			tolerance: 0.001,
+			wantUnit:  "seconds",
+		},
+		{
+			name:      "1 week in days",
+			input:     "1 week in days\n",
+			expected:  7,
+			tolerance: 0.001,
+			wantUnit:  "days",
+		},
+		{
+			name:      "2 hours in minutes",
+			input:     "2 hours in minutes\n",
+			expected:  120,
+			tolerance: 0.001,
+			wantUnit:  "minutes",
+		},
+		{
+			name:      "1 year in days",
+			input:     "1 year in days\n",
+			expected:  365,
+			tolerance: 0.001,
+			wantUnit:  "days",
+		},
+		{
+			name:      "1 month in hours",
+			input:     "1 month in hours\n",
+			expected:  720, // 30 days * 24 hours
+			tolerance: 0.001,
+			wantUnit:  "hours",
+		},
+		// "as" keyword conversions
+		{
+			name:      "1 day as seconds",
+			input:     "1 day as seconds\n",
+			expected:  86400,
+			tolerance: 0.001,
+			wantUnit:  "seconds",
+		},
+		{
+			name:      "3 hours as minutes",
+			input:     "3 hours as minutes\n",
+			expected:  180,
+			tolerance: 0.001,
+			wantUnit:  "minutes",
+		},
+		// Variable assignment with duration conversion
+		{
+			name:      "assigned duration conversion with in",
+			input:     "tt = 1 day in seconds\n",
+			expected:  86400,
+			tolerance: 0.001,
+			wantUnit:  "seconds",
+		},
+		{
+			name:      "assigned duration conversion with as",
+			input:     "tt = 2 weeks as days\n",
+			expected:  14,
+			tolerance: 0.001,
+			wantUnit:  "days",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, err := parser.Parse(tt.input)
+			if err != nil {
+				t.Fatalf("Parse error: %v", err)
+			}
+
+			interp := interpreter.NewInterpreter()
+			results, err := interp.Eval(nodes)
+			if err != nil {
+				t.Fatalf("Eval error: %v", err)
+			}
+
+			if len(results) == 0 {
+				t.Fatal("No results returned")
+			}
+
+			result := results[0].String()
+			t.Logf("Result: %s", result)
+
+			// Extract numeric value
+			var actual float64
+			_, err = fmt.Sscanf(result, "%f", &actual)
+			if err != nil {
+				t.Fatalf("Could not parse result %q as number: %v", result, err)
+			}
+
+			diff := math.Abs(actual - tt.expected)
+			if diff > tt.tolerance {
+				t.Errorf("Value = %f, expected %f (diff: %f, tolerance: %f)",
+					actual, tt.expected, diff, tt.tolerance)
+			}
+
+			// Check output contains expected unit
+			if !strings.Contains(result, tt.wantUnit) {
+				t.Errorf("Result %q does not contain expected unit %q", result, tt.wantUnit)
+			}
+		})
+	}
+}
+
+// TestDurationConversionErrors tests error cases for duration conversion.
+func TestDurationConversionErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantErrPart string
+	}{
+		{
+			name:        "duration to invalid unit",
+			input:       "1 day in meters\n",
+			wantErrPart: "invalid duration unit",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, err := parser.Parse(tt.input)
+			if err != nil {
+				t.Fatalf("Parse error: %v", err)
+			}
+
+			interp := interpreter.NewInterpreter()
+			_, err = interp.Eval(nodes)
+			if err == nil {
+				t.Fatal("Expected error but got none")
+			}
+
+			if !strings.Contains(err.Error(), tt.wantErrPart) {
+				t.Errorf("Error %q does not contain %q", err.Error(), tt.wantErrPart)
+			}
+		})
+	}
+}
+
 // TestRateUnitConversionErrors tests error cases for rate unit conversion.
 func TestRateUnitConversionErrors(t *testing.T) {
 	tests := []struct {

--- a/spec/parser/rdparser.go
+++ b/spec/parser/rdparser.go
@@ -352,17 +352,30 @@ func (p *RecursiveDescentParser) parseAdditive() (ast.Node, error) {
 		}
 	}
 
-	// Check for "as napkin" keyword: "1234567 as napkin" or "(100 + 50) as napkin"
+	// Check for "as napkin" or "as <unit>" keyword: "1234567 as napkin", "1 day as seconds"
 	// Do this at expression level to allow it to apply to entire sub-expressions
 	// including those in parentheses
 	if p.match(lexer.AS) {
-		if !p.match(lexer.NAPKIN) {
-			return nil, p.error("expected 'napkin' after 'as'")
+		if p.match(lexer.NAPKIN) {
+			return &ast.NapkinConversion{
+				Expression: left,
+				Range:      &ast.Range{},
+			}, nil
 		}
-		return &ast.NapkinConversion{
-			Expression: left,
-			Range:      &ast.Range{},
-		}, nil
+		// Check for "as <unit>" for unit/duration conversion: "1 day as seconds"
+		if p.check(lexer.IDENTIFIER) {
+			targetUnit := string(p.peek().Value)
+			_, isQuantityUnit := units.NormalizeUnitName(targetUnit)
+			if types.IsValidDurationUnit(targetUnit) || isQuantityUnit {
+				p.advance() // consume the target unit
+				return &ast.UnitConversion{
+					Quantity:   left,
+					TargetUnit: targetUnit,
+					Range:      &ast.Range{},
+				}, nil
+			}
+		}
+		return nil, p.error("expected 'napkin' or a valid unit after 'as'")
 	}
 
 	return left, nil
@@ -705,8 +718,9 @@ func (p *RecursiveDescentParser) parseUnary() (ast.Node, error) {
 		return nil, err
 	}
 
-	// Check for "as napkin" postfix (higher precedence than unary operators)
-	// Need to check for "as" identifier followed by "napkin" keyword
+	// Check for "as napkin" or "as <unit>" postfix (higher precedence than unary operators)
+	// "as napkin" → NapkinConversion
+	// "as seconds" → UnitConversion (for duration conversion like "1 day as seconds")
 	// This ensures "-47 as napkin" parses as "napkin(-47)" not "-(napkin(47))"
 	if p.check(lexer.IDENTIFIER) && string(p.peek().Value) == "as" {
 		p.advance() // consume "as"
@@ -716,8 +730,20 @@ func (p *RecursiveDescentParser) parseUnary() (ast.Node, error) {
 				Range:      &ast.Range{},
 			}, nil
 		}
-		// If we saw "as" but not "napkin", that's an error
-		return nil, p.error("expected 'napkin' after 'as'")
+		// Check for "as <unit>" for unit/duration conversion: "1 day as seconds"
+		if p.check(lexer.IDENTIFIER) {
+			targetUnit := string(p.peek().Value)
+			_, isQuantityUnit := units.NormalizeUnitName(targetUnit)
+			if types.IsValidDurationUnit(targetUnit) || isQuantityUnit {
+				p.advance() // consume the target unit
+				return &ast.UnitConversion{
+					Quantity:   result,
+					TargetUnit: targetUnit,
+					Range:      &ast.Range{},
+				}, nil
+			}
+		}
+		return nil, p.error("expected 'napkin' or a valid unit after 'as'")
 	}
 
 	return result, nil

--- a/spec/types/duration.go
+++ b/spec/types/duration.go
@@ -52,8 +52,8 @@ var durationToSecondsDecimal = map[string]decimal.Decimal{
 	"years":        decimal.NewFromInt(31536000),
 }
 
-// isValidDurationUnit checks if the unit is a valid duration unit.
-func isValidDurationUnit(unit string) bool {
+// IsValidDurationUnit checks if the unit is a valid duration unit.
+func IsValidDurationUnit(unit string) bool {
 	_, ok := durationToSecondsDecimal[unit]
 	return ok
 }
@@ -61,7 +61,7 @@ func isValidDurationUnit(unit string) bool {
 // NewDuration creates a new Duration with the given value and unit.
 func NewDuration(value decimal.Decimal, unit string) (*Duration, error) {
 	// Validate unit using the decimal map (includes milliseconds)
-	if !isValidDurationUnit(unit) {
+	if !IsValidDurationUnit(unit) {
 		return nil, fmt.Errorf("invalid duration unit: %s", unit)
 	}
 
@@ -95,7 +95,7 @@ func (d *Duration) ToSeconds() decimal.Decimal {
 // Convert converts the duration to a different unit.
 func (d *Duration) Convert(targetUnit string) (*Duration, error) {
 	// Validate target unit
-	if !isValidDurationUnit(targetUnit) {
+	if !IsValidDurationUnit(targetUnit) {
 		return nil, fmt.Errorf("invalid duration unit: %s", targetUnit)
 	}
 

--- a/testdata/eval/success/features/durations.cm
+++ b/testdata/eval/success/features/durations.cm
@@ -41,6 +41,20 @@ Tests all valid duration literal formats.
 1 month - 1 week
 5 days + 12 hours
 
+## Duration Conversions with 'in'
+
+1 day in seconds
+1 week in days
+2 hours in minutes
+1 year in days
+1 month in hours
+
+## Duration Conversions with 'as'
+
+1 day as seconds
+3 hours as minutes
+tt = 2 weeks as days
+
 ## Durations in Context
 
 deadline = today + 2 weeks

--- a/testdata/spec/valid/features/durations.cm
+++ b/testdata/spec/valid/features/durations.cm
@@ -41,6 +41,20 @@ Tests all valid duration literal formats.
 1 month - 1 week
 5 days + 12 hours
 
+## Duration Conversions with 'in'
+
+1 day in seconds
+1 week in days
+2 hours in minutes
+1 year in days
+1 month in hours
+
+## Duration Conversions with 'as'
+
+1 day as seconds
+3 hours as minutes
+tt = 2 weeks as days
+
 ## Durations in Context
 
 deadline = today + 2 weeks


### PR DESCRIPTION
Closes #21 — adds 'in'/'as' conversion between duration units (e.g., 1 day in seconds, 2 weeks as days)