### PR TITLE
feat: add repo-file shortcode to make example links configurable

### DIFF
--- a/site/content/docs/examples/_index.md
+++ b/site/content/docs/examples/_index.md
@@ -21,7 +21,7 @@ cm testdata/examples/<filename>.cm
 
 ## Feature Reference
 
-These examples are drawn from the project's [golden test suite](https://github.com/CalcMark/go-calcmark/tree/main/testdata/eval/success/features) and demonstrate every language feature:
+These examples are drawn from the project's {{< repo-file path="testdata/eval/success/features" type="tree" text="golden test suite" >}} and demonstrate every language feature:
 
 - [Functions & Natural Language](functions-and-nl/) -- All function call styles
 - [Network & Storage](network-and-storage/) -- Latency, throughput, read/seek, compression

--- a/site/content/docs/examples/datacenter-cost.md
+++ b/site/content/docs/examples/datacenter-cost.md
@@ -6,7 +6,7 @@ weight: 55
 
 Should you build a small dedicated datacenter or rent space in someone else's? This walkthrough models the full lifecycle cost using CalcMark, showcasing exchange rates, growth functions, depreciation, and napkin math along the way.
 
-The complete CalcMark file is available at [`testdata/examples/datacenter-cost.cm`](https://github.com/AKinetix/go-calcmark/blob/main/testdata/examples/datacenter-cost.cm).
+The complete CalcMark file is available at {{< repo-file path="testdata/examples/datacenter-cost.cm" >}}.
 
 ---
 
@@ -254,6 +254,8 @@ This example showcases the following CalcMark features:
 - **Markdown prose** -- headings, paragraphs, and inline comments between calculations
 
 ## Try It
+
+{{< repo-file path="testdata/examples/datacenter-cost.cm" >}}
 
 ```bash
 cm testdata/examples/datacenter-cost.cm

--- a/site/content/docs/examples/dates-and-durations.md
+++ b/site/content/docs/examples/dates-and-durations.md
@@ -4,7 +4,7 @@ summary: "Date keywords, literals, arithmetic, and duration calculations."
 weight: 45
 ---
 
-From [`testdata/eval/success/features/dates.cm`](https://github.com/CalcMark/go-calcmark/blob/main/testdata/eval/success/features/dates.cm).
+From {{< repo-file path="testdata/eval/success/features/dates.cm" >}}.
 
 ## Date Keywords
 

--- a/site/content/docs/examples/functions-and-nl.md
+++ b/site/content/docs/examples/functions-and-nl.md
@@ -4,9 +4,9 @@ summary: "All function call styles: traditional, natural language, nested, and m
 weight: 10
 ---
 
-From [`testdata/eval/success/features/functions.cm`](https://github.com/CalcMark/go-calcmark/blob/main/testdata/eval/success/features/functions.cm),
-[`testdata/eval/success/features/natural_language.cm`](https://github.com/CalcMark/go-calcmark/blob/main/testdata/eval/success/features/natural_language.cm),
-and [`testdata/eval/success/features/growth_functions.cm`](https://github.com/CalcMark/go-calcmark/blob/main/testdata/eval/success/features/growth_functions.cm).
+From {{< repo-file path="testdata/eval/success/features/functions.cm" >}},
+{{< repo-file path="testdata/eval/success/features/natural_language.cm" >}},
+and {{< repo-file path="testdata/eval/success/features/growth_functions.cm" >}}.
 
 ## Traditional Function Syntax
 

--- a/site/content/docs/examples/household-budget.md
+++ b/site/content/docs/examples/household-budget.md
@@ -129,6 +129,8 @@ daily_discretionary = $500/month per day
 
 ## Try It
 
+{{< repo-file path="testdata/examples/household-budget.cm" >}}
+
 ```bash
 cm testdata/examples/household-budget.cm
 ```

--- a/site/content/docs/examples/job-offer.md
+++ b/site/content/docs/examples/job-offer.md
@@ -150,6 +150,8 @@ required_appreciation = required_total_stock / option_value_b
 
 ## Try It
 
+{{< repo-file path="testdata/examples/job-offer.cm" >}}
+
 ```bash
 cm testdata/examples/job-offer.cm
 ```

--- a/site/content/docs/examples/napkin-math.md
+++ b/site/content/docs/examples/napkin-math.md
@@ -4,7 +4,7 @@ summary: "Quick estimation with human-readable rounding using 'as napkin'."
 weight: 40
 ---
 
-From [`testdata/eval/success/features/napkin.cm`](https://github.com/CalcMark/go-calcmark/blob/main/testdata/eval/success/features/napkin.cm).
+From {{< repo-file path="testdata/eval/success/features/napkin.cm" >}}.
 
 ## Basic Numbers
 

--- a/site/content/docs/examples/network-and-storage.md
+++ b/site/content/docs/examples/network-and-storage.md
@@ -4,9 +4,9 @@ summary: "Latency, throughput, transfer time, read/seek, and compression functio
 weight: 20
 ---
 
-From [`testdata/eval/success/features/network_functions.cm`](https://github.com/CalcMark/go-calcmark/blob/main/testdata/eval/success/features/network_functions.cm),
-[`testdata/eval/success/features/storage_functions.cm`](https://github.com/CalcMark/go-calcmark/blob/main/testdata/eval/success/features/storage_functions.cm),
-and [`testdata/eval/success/features/compression.cm`](https://github.com/CalcMark/go-calcmark/blob/main/testdata/eval/success/features/compression.cm).
+From {{< repo-file path="testdata/eval/success/features/network_functions.cm" >}},
+{{< repo-file path="testdata/eval/success/features/storage_functions.cm" >}},
+and {{< repo-file path="testdata/eval/success/features/compression.cm" >}}.
 
 ## Network Latency (RTT)
 

--- a/site/content/docs/examples/project-workback.md
+++ b/site/content/docs/examples/project-workback.md
@@ -139,6 +139,8 @@ needed_time = total_planned + risk_buffer
 
 ## Try It
 
+{{< repo-file path="testdata/examples/project-workback.cm" >}}
+
 ```bash
 cm testdata/examples/project-workback.cm
 ```

--- a/site/content/docs/examples/rates-and-capacity.md
+++ b/site/content/docs/examples/rates-and-capacity.md
@@ -4,9 +4,9 @@ summary: "Rate expressions, accumulation with 'over', rate conversion, and capac
 weight: 30
 ---
 
-From [`testdata/eval/success/features/rates.cm`](https://github.com/CalcMark/go-calcmark/blob/main/testdata/eval/success/features/rates.cm),
-[`testdata/eval/success/features/rate_functions.cm`](https://github.com/CalcMark/go-calcmark/blob/main/testdata/eval/success/features/rate_functions.cm),
-and [`testdata/eval/success/features/capacity_at.cm`](https://github.com/CalcMark/go-calcmark/blob/main/testdata/eval/success/features/capacity_at.cm).
+From {{< repo-file path="testdata/eval/success/features/rates.cm" >}},
+{{< repo-file path="testdata/eval/success/features/rate_functions.cm" >}},
+and {{< repo-file path="testdata/eval/success/features/capacity_at.cm" >}}.
 
 ## Rate Expressions
 

--- a/site/content/docs/examples/recipe-scaling.md
+++ b/site/content/docs/examples/recipe-scaling.md
@@ -122,6 +122,8 @@ calories_per_slice = calories_per_loaf / slices_per_loaf
 
 ## Try It
 
+{{< repo-file path="testdata/examples/recipe-scaling.cm" >}}
+
 ```bash
 cm testdata/examples/recipe-scaling.cm
 ```

--- a/site/content/docs/examples/system-sizing.md
+++ b/site/content/docs/examples/system-sizing.md
@@ -151,6 +151,8 @@ servers_napkin = total_db_servers as napkin
 
 ## Try It
 
+{{< repo-file path="testdata/examples/system-sizing.cm" >}}
+
 ```bash
 cm testdata/examples/system-sizing.cm
 ```

--- a/site/layouts/shortcodes/repo-file.html
+++ b/site/layouts/shortcodes/repo-file.html
@@ -1,0 +1,5 @@
+{{- $path := .Get "path" -}}
+{{- $text := .Get "text" | default $path -}}
+{{- $type := .Get "type" | default "blob" -}}
+{{- $branch := site.Params.githubBranch | default "main" -}}
+[`{{ $text }}`]({{ site.Params.githubURL }}/{{ $type }}/{{ $branch }}/{{ $path }})


### PR DESCRIPTION
Replace hardcoded GitHub URLs across all example pages with a new repo-file Hugo shortcode that reads the repo URL from hugo.yaml params.githubURL. This also fixes the datacenter-cost.md page which pointed to the wrong GitHub org (AKinetix instead of CalcMark).

Closes #27

https://claude.ai/code/session_01DCywFDfsTTBESy1azFuLEZ