### PR TITLE
fix: JSON error output on stdout for agent/pipeline consumption

### DIFF
--- a/cmd/calcmark/cmd/eval.go
+++ b/cmd/calcmark/cmd/eval.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/CalcMark/go-calcmark/format"
@@ -50,15 +53,15 @@ func runEval(args []string) error {
 
 		// Read from file
 		if err := validateReadFilePath(filename); err != nil {
-			return fmt.Errorf("invalid file: %w", err)
+			return returnError("invalid file: %w", err)
 		}
 
 		bytes, err := os.ReadFile(filename)
 		if err != nil {
-			return fmt.Errorf("read file: %w", err)
+			return returnError("read file: %w", err)
 		}
 		if err := validateFileContent(bytes); err != nil {
-			return fmt.Errorf("invalid file: %w", err)
+			return returnError("invalid file: %w", err)
 		}
 		input = string(bytes)
 	}
@@ -69,31 +72,31 @@ func runEval(args []string) error {
 		const maxStdinSize = 1*1024*1024 + 1 // 1MB + 1 byte to detect overflow
 		bytes, err := io.ReadAll(io.LimitReader(os.Stdin, maxStdinSize))
 		if err != nil {
-			return fmt.Errorf("read stdin: %w", err)
+			return returnError("read stdin: %w", err)
 		}
 		if len(bytes) >= maxStdinSize {
-			return fmt.Errorf("stdin input too large (max 1MB)")
+			return returnErrorMsg("stdin input too large (max 1MB)")
 		}
 		if err := validateStdinContent(bytes); err != nil {
-			return fmt.Errorf("invalid input: %w", err)
+			return returnError("invalid input: %w", err)
 		}
 		input = string(bytes)
 
 		if strings.TrimSpace(input) == "" {
-			return fmt.Errorf("no input — pipe a document or pass a filename (run 'cm eval --help' for details)")
+			return returnErrorMsg("no input — pipe a document or pass a filename (run 'cm eval --help' for details)")
 		}
 	}
 
 	// Parse and evaluate
 	doc, err := document.NewDocument(input)
 	if err != nil {
-		return fmt.Errorf("parse error: %w", err)
+		return returnError("parse error: %w", err)
 	}
 
 	eval := implDoc.NewEvaluator()
 	eval.SetDisplayFormatter(localeFormatter())
 	if err := eval.Evaluate(doc); err != nil {
-		return fmt.Errorf("evaluation error: %w", err)
+		return returnError("evaluation error: %w", err)
 	}
 
 	// Use the selected formatter for eval output (defaults to "text")
@@ -105,8 +108,89 @@ func runEval(args []string) error {
 	}
 
 	if err := formatter.Format(os.Stdout, doc, opts); err != nil {
-		return fmt.Errorf("format error: %w", err)
+		return returnError("format error: %w", err)
 	}
 
 	return nil
+}
+
+// returnError wraps an error and, when JSON format is active, writes a JSON
+// error envelope to stdout so that agents and pipelines always receive valid
+// JSON. The error is still returned for Cobra to print on stderr and set
+// exit code 1.
+func returnError(wrapFmt string, inner error) error {
+	wrapped := fmt.Errorf(wrapFmt, inner)
+	if evalFormat == "json" {
+		writeJSONError(os.Stdout, wrapped)
+	}
+	return wrapped
+}
+
+// returnErrorMsg is like returnError but for errors without a wrapped inner error.
+func returnErrorMsg(msg string) error {
+	err := fmt.Errorf("%s", msg)
+	if evalFormat == "json" {
+		writeJSONError(os.Stdout, err)
+	}
+	return err
+}
+
+// jsonErrorEnvelope wraps an error for JSON output on stdout.
+type jsonErrorEnvelope struct {
+	Error jsonError `json:"error"`
+}
+
+// jsonError represents a structured error in JSON output.
+type jsonError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+	Line    int    `json:"line,omitempty"`
+	Code    string `json:"code,omitempty"`
+}
+
+// lineCodeMessageRe matches "line N: code: message" patterns in error messages.
+var lineCodeMessageRe = regexp.MustCompile(`^line (\d+): (\w+): (.+)$`)
+
+// parseEvalError extracts structured fields from an error message.
+// Error messages follow patterns like:
+//
+//	"evaluation error: line 2: variable_redefinition: cannot reassign 'x'"
+//	"parse error: <details>"
+//	"frontmatter error: <details>"
+func parseEvalError(err error) jsonError {
+	msg := err.Error()
+
+	// Extract error type from prefix
+	errType := "unknown_error"
+	remainder := msg
+	for _, prefix := range []string{"evaluation error: ", "parse error: ", "frontmatter error: ", "format error: "} {
+		if strings.HasPrefix(msg, prefix) {
+			// "evaluation error: " → "evaluation_error"
+			errType = strings.ReplaceAll(strings.TrimSuffix(prefix, ": "), " ", "_")
+			remainder = msg[len(prefix):]
+			break
+		}
+	}
+
+	je := jsonError{
+		Type:    errType,
+		Message: remainder,
+	}
+
+	// Try to extract "line N: code: message" from remainder
+	if m := lineCodeMessageRe.FindStringSubmatch(remainder); m != nil {
+		je.Line, _ = strconv.Atoi(m[1])
+		je.Code = m[2]
+		je.Message = m[3]
+	}
+
+	return je
+}
+
+// writeJSONError writes a JSON error envelope to w.
+func writeJSONError(w io.Writer, err error) {
+	envelope := jsonErrorEnvelope{Error: parseEvalError(err)}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(envelope)
 }

--- a/cmd/calcmark/cmd/json_error_test.go
+++ b/cmd/calcmark/cmd/json_error_test.go
@@ -1,0 +1,274 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// jsonErrorEnvelopeTest mirrors the JSON error structure we expect on stdout.
+type jsonErrorEnvelopeTest struct {
+	Error struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+		Line    int    `json:"line,omitempty"`
+		Code    string `json:"code,omitempty"`
+	} `json:"error"`
+}
+
+// TestJSONError_EvalErrorProducesJSONOnStdout verifies that when --format json
+// is active and an evaluation error occurs (e.g., variable redefinition),
+// stdout contains a valid JSON error envelope instead of being empty.
+// This is the core behavior requested in issue #53.
+func TestJSONError_EvalErrorProducesJSONOnStdout(t *testing.T) {
+	binary := buildCM(t)
+
+	// variable_redefinition: x defined twice in same block
+	input := "x = 10\nx = 20\n"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binary, "eval", "--format", "json")
+	cmd.Stdin = strings.NewReader(input)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit code for variable redefinition")
+	}
+
+	// stdout must contain valid JSON
+	if !json.Valid(stdout.Bytes()) {
+		t.Fatalf("stdout should be valid JSON when --format json is used, got:\nstdout: %q\nstderr: %q", stdout.String(), stderr.String())
+	}
+
+	// Parse and verify the error envelope
+	var envelope jsonErrorEnvelopeTest
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("failed to unmarshal JSON error: %v\nstdout: %s", err, stdout.String())
+	}
+
+	if envelope.Error.Type == "" {
+		t.Error("error.type should not be empty")
+	}
+	if envelope.Error.Message == "" {
+		t.Error("error.message should not be empty")
+	}
+}
+
+// TestJSONError_EvalErrorHasStructuredFields verifies that the JSON error
+// envelope includes type, line, code, and message fields extracted from
+// structured error messages.
+func TestJSONError_EvalErrorHasStructuredFields(t *testing.T) {
+	binary := buildCM(t)
+
+	input := "x = 10\nx = 20\n"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binary, "eval", "--format", "json")
+	cmd.Stdin = strings.NewReader(input)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	cmd.Run() //nolint:errcheck // we expect failure
+
+	var envelope jsonErrorEnvelopeTest
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("failed to unmarshal JSON error: %v\nstdout: %s", err, stdout.String())
+	}
+
+	if envelope.Error.Type != "evaluation_error" {
+		t.Errorf("error.type = %q, want %q", envelope.Error.Type, "evaluation_error")
+	}
+	if envelope.Error.Code != "variable_redefinition" {
+		t.Errorf("error.code = %q, want %q", envelope.Error.Code, "variable_redefinition")
+	}
+	if envelope.Error.Line == 0 {
+		t.Error("error.line should be non-zero for variable_redefinition")
+	}
+	if !strings.Contains(envelope.Error.Message, "reassign") {
+		t.Errorf("error.message should mention reassignment, got %q", envelope.Error.Message)
+	}
+}
+
+// TestJSONError_UndefinedVariableProducesJSON verifies that undefined variable
+// errors also produce JSON on stdout when --format json is active.
+func TestJSONError_UndefinedVariableProducesJSON(t *testing.T) {
+	binary := buildCM(t)
+
+	// undefined_variable: y is never defined
+	input := "x = y + 1\n"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binary, "eval", "--format", "json")
+	cmd.Stdin = strings.NewReader(input)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err == nil {
+		t.Skip("input did not produce an error, skipping")
+	}
+
+	if stdout.Len() == 0 {
+		t.Fatal("stdout should not be empty when --format json is used with an error")
+	}
+
+	if !json.Valid(stdout.Bytes()) {
+		t.Fatalf("stdout should be valid JSON, got:\nstdout: %q\nstderr: %q", stdout.String(), stderr.String())
+	}
+
+	var envelope jsonErrorEnvelopeTest
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if envelope.Error.Type == "" {
+		t.Error("error.type should not be empty")
+	}
+}
+
+// TestJSONError_PipedStdinErrorProducesJSON verifies that the piped-stdin
+// path (cm --format json, without eval subcommand) also produces JSON errors.
+func TestJSONError_PipedStdinErrorProducesJSON(t *testing.T) {
+	binary := buildCM(t)
+
+	input := "x = 10\nx = 20\n"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Note: no "eval" subcommand — using root command piped stdin path
+	cmd := exec.CommandContext(ctx, binary, "--format", "json")
+	cmd.Stdin = strings.NewReader(input)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected error for variable redefinition")
+	}
+
+	if !json.Valid(stdout.Bytes()) {
+		t.Fatalf("stdout should be valid JSON via piped path, got:\nstdout: %q\nstderr: %q", stdout.String(), stderr.String())
+	}
+
+	var envelope jsonErrorEnvelopeTest
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if envelope.Error.Type == "" {
+		t.Error("error.type should not be empty")
+	}
+}
+
+// TestJSONError_NonJSONFormatDoesNotWriteJSON verifies that errors without
+// --format json do NOT produce JSON on stdout (no regression).
+func TestJSONError_NonJSONFormatDoesNotWriteJSON(t *testing.T) {
+	binary := buildCM(t)
+
+	input := "x = 10\nx = 20\n"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binary, "eval")
+	cmd.Stdin = strings.NewReader(input)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	cmd.Run() //nolint:errcheck // we expect failure
+
+	// stdout should be empty (default text format, error only on stderr)
+	if stdout.Len() > 0 {
+		t.Errorf("stdout should be empty for text format errors, got: %q", stdout.String())
+	}
+
+	// stderr should have the error
+	if !strings.Contains(stderr.String(), "Error") {
+		t.Errorf("stderr should contain error message, got: %q", stderr.String())
+	}
+}
+
+// TestJSONError_SuccessStillProducesNormalJSON verifies that successful
+// evaluation with --format json still produces normal JSONDocument output
+// (no regression from error handling changes).
+func TestJSONError_SuccessStillProducesNormalJSON(t *testing.T) {
+	binary := buildCM(t)
+
+	input := "x = 42\n"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binary, "eval", "--format", "json")
+	cmd.Stdin = strings.NewReader(input)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("expected success, got error: %v\nstderr: %s", err, stderr.String())
+	}
+
+	if !json.Valid(stdout.Bytes()) {
+		t.Fatalf("stdout should be valid JSON, got: %q", stdout.String())
+	}
+
+	// Should have "blocks" key (normal JSONDocument), NOT "error" key
+	var result map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if _, ok := result["blocks"]; !ok {
+		t.Error("successful JSON output should have 'blocks' key")
+	}
+	if _, ok := result["error"]; ok {
+		t.Error("successful JSON output should NOT have 'error' key")
+	}
+}
+
+// TestJSONError_ExitCodeStillNonZero verifies that the exit code is still
+// non-zero when an error occurs, even with JSON output on stdout.
+func TestJSONError_ExitCodeStillNonZero(t *testing.T) {
+	binary := buildCM(t)
+
+	input := "x = 10\nx = 20\n"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binary, "eval", "--format", "json")
+	cmd.Stdin = strings.NewReader(input)
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
+	err := cmd.Run()
+	if err == nil {
+		t.Fatal("expected non-zero exit code")
+	}
+
+	// Verify it's an exit error with code 1
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		if exitErr.ExitCode() != 1 {
+			t.Errorf("exit code = %d, want 1", exitErr.ExitCode())
+		}
+	}
+}

--- a/cmd/calcmark/cmd/parse_eval_error_test.go
+++ b/cmd/calcmark/cmd/parse_eval_error_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParseEvalError(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     error
+		wantTyp string
+		wantMsg string
+		wantLn  int
+		wantCd  string
+	}{
+		{
+			name:    "evaluation_error_with_line_and_code",
+			err:     fmt.Errorf("evaluation error: line 2: variable_redefinition: cannot reassign 'x'"),
+			wantTyp: "evaluation_error",
+			wantMsg: "cannot reassign 'x'",
+			wantLn:  2,
+			wantCd:  "variable_redefinition",
+		},
+		{
+			name:    "evaluation_error_with_extended_detail",
+			err:     fmt.Errorf("evaluation error: line 1: undefined_variable: undefined variable \"y\" — did you mean 'x'?"),
+			wantTyp: "evaluation_error",
+			wantMsg: "undefined variable \"y\" — did you mean 'x'?",
+			wantLn:  1,
+			wantCd:  "undefined_variable",
+		},
+		{
+			name:    "parse_error_plain",
+			err:     fmt.Errorf("parse error: unexpected token"),
+			wantTyp: "parse_error",
+			wantMsg: "unexpected token",
+			wantLn:  0,
+			wantCd:  "",
+		},
+		{
+			name:    "parse_error_with_line_and_code",
+			err:     fmt.Errorf("parse error: line 5: syntax_error: unexpected ')'"),
+			wantTyp: "parse_error",
+			wantMsg: "unexpected ')'",
+			wantLn:  5,
+			wantCd:  "syntax_error",
+		},
+		{
+			name:    "frontmatter_error",
+			err:     fmt.Errorf("frontmatter error: invalid YAML"),
+			wantTyp: "frontmatter_error",
+			wantMsg: "invalid YAML",
+			wantLn:  0,
+			wantCd:  "",
+		},
+		{
+			name:    "format_error",
+			err:     fmt.Errorf("format error: template execution failed"),
+			wantTyp: "format_error",
+			wantMsg: "template execution failed",
+			wantLn:  0,
+			wantCd:  "",
+		},
+		{
+			name:    "unknown_error",
+			err:     fmt.Errorf("something unexpected happened"),
+			wantTyp: "unknown_error",
+			wantMsg: "something unexpected happened",
+			wantLn:  0,
+			wantCd:  "",
+		},
+		{
+			name:    "read_file_error",
+			err:     fmt.Errorf("read file: no such file or directory"),
+			wantTyp: "unknown_error",
+			wantMsg: "read file: no such file or directory",
+			wantLn:  0,
+			wantCd:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseEvalError(tt.err)
+			if got.Type != tt.wantTyp {
+				t.Errorf("Type = %q, want %q", got.Type, tt.wantTyp)
+			}
+			if got.Message != tt.wantMsg {
+				t.Errorf("Message = %q, want %q", got.Message, tt.wantMsg)
+			}
+			if got.Line != tt.wantLn {
+				t.Errorf("Line = %d, want %d", got.Line, tt.wantLn)
+			}
+			if got.Code != tt.wantCd {
+				t.Errorf("Code = %q, want %q", got.Code, tt.wantCd)
+			}
+		})
+	}
+}

--- a/docs/plans/2026-03-12-003-fix-json-error-output-plan.md
+++ b/docs/plans/2026-03-12-003-fix-json-error-output-plan.md
@@ -1,0 +1,112 @@
+---
+title: "fix: JSON error output on stdout for agent/pipeline consumption"
+type: fix
+status: active
+date: 2026-03-12
+---
+
+# fix: JSON error output on stdout for agent/pipeline consumption
+
+## Overview
+
+When `cm` encounters an error with `--format json`, the error goes to stderr as plain text while stdout gets nothing. Agents and pipelines piping `cm` output to a JSON parser get empty input and a confusing parse error instead of the actual CalcMark error.
+
+Fix: when `--format json` is active, output a JSON error envelope on stdout so parsers always receive valid JSON. Exit code still signals the error for shell scripts.
+
+Closes #53.
+
+## Problem Statement
+
+```bash
+echo "x = 10\nx = 20" | cm --format json
+# stdout: (empty)
+# stderr: Error: evaluation error: line 2: variable_redefinition: cannot reassign 'x'
+# exit code: 1
+```
+
+An agent piping this to `jq` gets a parse error instead of the actual CalcMark error.
+
+## Proposed Solution
+
+In `cmd/calcmark/cmd/eval.go`, catch errors from the evaluation pipeline. When `--format json` is active, serialize the error as a JSON object to stdout before returning the error (which still goes to stderr via Cobra and sets exit code 1).
+
+### JSON Error Envelope
+
+```json
+{
+  "error": {
+    "type": "evaluation_error",
+    "message": "cannot reassign 'x'",
+    "line": 2,
+    "code": "variable_redefinition"
+  }
+}
+```
+
+Error types map to the existing error wrapping prefixes:
+- `"parse_error"` — from `fmt.Errorf("parse error: %w", ...)`
+- `"evaluation_error"` — from `fmt.Errorf("evaluation error: %w", ...)`
+- `"frontmatter_error"` — from `fmt.Errorf("frontmatter error: %w", ...)`
+
+### Architecture
+
+The change is localized to the command layer — the error handling in `eval.go` and `root.go` (piped stdin path). No changes to the format package, eval pipeline, or public API.
+
+**Error parsing approach**: The error messages from `eval.go` follow a structured pattern: `"<category> error: line N: <code>: <message>"`. Parse this with a regex or string splitting to extract type, line, code, and message. If parsing fails, fall back to the raw error string with type `"unknown_error"`.
+
+The JSON formatter's existing `JSONDiagnostic` struct is close but not quite right — it's for per-block semantic diagnostics, not top-level fatal errors. A new lightweight `JSONError` struct at the command layer is cleaner.
+
+## Technical Approach
+
+### Phase 1: JSON Error Output
+
+**Tasks:**
+
+- [ ] Add `JSONErrorEnvelope` and `JSONError` structs in `cmd/calcmark/cmd/eval.go` (or a small helper file)
+  ```go
+  type JSONErrorEnvelope struct {
+      Error JSONError `json:"error"`
+  }
+  type JSONError struct {
+      Type    string `json:"type"`
+      Message string `json:"message"`
+      Line    int    `json:"line,omitempty"`
+      Code    string `json:"code,omitempty"`
+  }
+  ```
+- [ ] Add `parseEvalError(err error) JSONError` function that extracts type/line/code/message from the structured error string
+- [ ] Add `writeJSONError(w io.Writer, err error)` function that serializes the error envelope
+- [ ] In `runEval()`: when format is JSON and an error occurs, call `writeJSONError(os.Stdout, err)` before returning the error
+- [ ] In root `RunE` (piped stdin path): same treatment — when format is JSON and `runEval` would be called, handle errors the same way
+- [ ] Cobra still prints to stderr and sets exit code 1 — this is additive, not replacing
+- [ ] Table-driven tests for `parseEvalError` covering all error patterns
+- [ ] Integration test: pipe invalid input with `--format json`, verify stdout contains valid JSON error
+
+**Files:**
+- `cmd/calcmark/cmd/eval.go` (modify)
+- `cmd/calcmark/cmd/root.go` (modify — piped stdin path calls runEval, same handling)
+- `cmd/calcmark/cmd/eval_test.go` (new or modify)
+
+### Phase 2: Patch Release
+
+- [ ] Verify `task test` passes
+- [ ] Verify `task quality` passes
+- [ ] Tag `v1.8.1` (patch release — backwards-compatible fix)
+- [ ] Push tag to trigger GoReleaser workflow
+
+## Acceptance Criteria
+
+- [ ] `echo "x = 10\nx = 20" | cm --format json` outputs valid JSON on stdout with error details
+- [ ] Exit code is still 1 on error
+- [ ] Stderr still shows the error (Cobra behavior unchanged)
+- [ ] `echo "1 + 1" | cm --format json` still outputs normal JSON (no regression)
+- [ ] JSON error envelope includes `type`, `message`, and where available `line` and `code`
+- [ ] All existing tests pass
+- [ ] `task quality` passes
+
+## Sources & References
+
+- Issue: https://github.com/CalcMark/go-calcmark/issues/53
+- Error wrapping: `eval.go` lines using `fmt.Errorf("parse error: %w", ...)` etc.
+- JSON format: `format/json_formatter.go`
+- Command error handling: `cmd/calcmark/cmd/eval.go`, `cmd/calcmark/cmd/root.go`


### PR DESCRIPTION
## Summary

- When `--format json` is active and an error occurs, stdout now contains a structured JSON error envelope instead of being empty
- Exit code and stderr behavior unchanged — Cobra still prints errors to stderr and exits with code 1
- Structured error fields: `type`, `message`, `line` (when available), `code` (when available)

Closes #53

## Example

```bash
echo "x = 10\nx = 20" | cm --format json
```

**Before:** stdout empty, stderr has plain text error
**After:**
```json
{
  "error": {
    "type": "evaluation_error",
    "message": "cannot reassign 'x' — variables are immutable (first defined at line 1)",
    "line": 2,
    "code": "variable_redefinition"
  }
}
```

## Test plan

- [x] `TestJSONError_EvalErrorProducesJSONOnStdout` — core behavior: JSON on stdout when error + `--format json`
- [x] `TestJSONError_EvalErrorHasStructuredFields` — type, code, line, message extracted correctly
- [x] `TestJSONError_UndefinedVariableProducesJSON` — undefined variable errors produce JSON
- [x] `TestJSONError_PipedStdinErrorProducesJSON` — piped stdin path (root command) also produces JSON errors
- [x] `TestJSONError_NonJSONFormatDoesNotWriteJSON` — no regression: text format errors don't produce JSON on stdout
- [x] `TestJSONError_SuccessStillProducesNormalJSON` — no regression: success still produces normal JSONDocument
- [x] `TestJSONError_ExitCodeStillNonZero` — exit code still 1 on error
- [x] `TestParseEvalError` — table-driven unit tests for error message parsing (8 cases)
- [x] `task test` — full test suite passes
- [x] `task quality` — lint + modernize + staticcheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)