### PR TITLE
refactor(site): Add table of contents and deep-linkable anchors to docs

### DIFF
--- a/site/assets/css/components.css
+++ b/site/assets/css/components.css
@@ -688,3 +688,43 @@ h6:hover .heading-anchor {
     gap: var(--space-2);
   }
 }
+
+/* Page Table of Contents */
+.page-toc {
+  margin-bottom: var(--space-6);
+  padding: var(--space-4);
+  background: color-mix(in srgb, var(--color-bg-muted) 50%, transparent);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+}
+
+.page-toc summary {
+  cursor: pointer;
+  font-weight: 600;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.page-toc nav#TableOfContents ul {
+  list-style: none;
+  padding-left: 0;
+  margin: var(--space-2) 0 0;
+}
+
+.page-toc nav#TableOfContents ul ul {
+  padding-left: var(--space-4);
+}
+
+.page-toc nav#TableOfContents a {
+  display: block;
+  padding: 2px 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+}
+
+.page-toc nav#TableOfContents a:hover {
+  color: var(--color-primary);
+}

--- a/site/content/docs/language-reference.md
+++ b/site/content/docs/language-reference.md
@@ -97,13 +97,13 @@ A CalcMark document is a sequence of **lines**. Each line is independently:
 
 ---
 
-## Frontmatter
+## Frontmatter {#frontmatter}
 
 A CalcMark document can begin with a YAML frontmatter block delimited by `---`. Frontmatter defines document-level configuration that is available to all calculations.
 
 {{< feature-table category="frontmatter" >}}
 
-### Exchange Rates
+### Exchange Rates {#exchange-rates}
 
 Define currency conversion rates using `FROM_TO: rate` format (underscore separator):
 
@@ -119,7 +119,7 @@ exchange:
 
 Rates are not automatically reversed. If you define `USD_EUR`, you must also define `EUR_USD` to convert in the other direction.
 
-### Global Variables
+### Global Variables {#global-variables}
 
 Define values available throughout the document:
 
@@ -135,7 +135,7 @@ globals:
 
 Globals support all CalcMark literal types (numbers, currencies, quantities, dates, durations, rates, booleans, percentages). Expressions like `1 + 1` are not allowed -- only literal values.
 
-### Scale
+### Scale {#scale}
 
 Multiply all quantity results by a factor. Applied after evaluation, before display.
 
@@ -192,7 +192,7 @@ tax = income * @globals.tax_rate
 
 `@scale` always resolves to a `Number`. `@globals.name` resolves to whatever type the global is (Number, Currency, Quantity, etc.).
 
-### Convert To
+### Convert To {#convert-to}
 
 Convert quantity results to a target measurement system. Applied after scale.
 
@@ -222,7 +222,7 @@ convert_to:
 
 Valid categories: `All`, `Area`, `Currency`, `Custom`, `DataSize`, `Energy`, `Length`, `Mass`, `Number`, `Power`, `Speed`, `Temperature`, `Volume`.
 
-### Measurement Conventions
+### Measurement Conventions {#measurement-conventions}
 
 Some unit names are ambiguous — a "gallon" in the US (3.785 L) is different from a "gallon" in the UK (4.546 L). Similarly, an "ounce" of gold (troy, 31.10g) differs from an "ounce" of flour (standard, 28.35g).
 
@@ -297,7 +297,7 @@ All three directives compose. Here's how `1 gallon` flows through each combinati
 | `1 us gal` (inline) + `measurement: { volume: imperial }` + `convert_to: si` | `3.79 l` | Inline qualifier overrides convention |
 | `1 gallon in ml` (explicit) + `convert_to: si` | `3,785 ml` | Explicit `in` skips `convert_to` |
 
-### Transform Order
+### Transform Order {#transform-order}
 
 When frontmatter directives are present, they apply in this order:
 
@@ -722,7 +722,7 @@ area = PI * radius ^ 2
 
 ---
 
-## Operators
+## Operators {#operators}
 
 ### Arithmetic
 
@@ -1084,7 +1084,7 @@ See the [User Guide: Growth Functions](/docs/user-guide/#growth-functions) for t
 
 ---
 
-## Validation & Diagnostics
+## Validation & Diagnostics {#diagnostics}
 
 ### Diagnostic Levels
 

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -27,6 +27,10 @@ markup:
     codeFences: true
     guessSyntax: false
     tabWidth: 4
+  tableOfContents:
+    startLevel: 2
+    endLevel: 3
+    ordered: false
 
 menus:
   main:

--- a/site/layouts/_default/page.html
+++ b/site/layouts/_default/page.html
@@ -6,6 +6,12 @@
     <h1>{{ .Title }}<img src="{{ $lark.RelPermalink }}" alt="" class="page-lark" aria-hidden="true"></h1>
     {{ with .Params.summary }}<p class="text-muted">{{ . | markdownify }}</p>{{ end }}
     {{ if .Params.build }}{{ if eq .Params.build.list "never" }}<p class="full-doc-link"><a href="../">← Back to walkthrough</a></p>{{ end }}{{ end }}
+    {{ with .TableOfContents }}
+    <details class="page-toc" open>
+      <summary>On this page</summary>
+      {{ . }}
+    </details>
+    {{ end }}
     {{ .Content }}
     {{ if .GitInfo }}
     <footer class="page-meta">


### PR DESCRIPTION
## Summary

- Add Hugo auto-generated Table of Contents to all docs pages
- Collapsible `<details>` element at top of page ("On this page")
- TOC includes h2 and h3 headings for granular navigation
- Add explicit `{#anchor}` IDs to key Language Reference sections
- Every section is now deep-linkable and shareable

## Deep-link examples

- [Measurement Conventions](/docs/language-reference/#measurement-conventions)
- [Functions](/docs/language-reference/#functions)  
- [Type Arithmetic Rules](/docs/language-reference/#type-arithmetic-rules)
- [Frontmatter](/docs/language-reference/#frontmatter)

## Phase 1 of docs restructure

This is the first phase of the [documentation restructure plan](docs/plans/2026-03-14-003-refactor-documentation-restructure-plan.md). Quick win — makes the existing long pages navigable while the sub-page restructure is planned.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: static site content change only.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>