### PR TITLE
feat(site): Add Guides section and cross-link documentation pillars

### DIFF
--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -5,3 +5,14 @@ weight: 10
 ---
 
 CalcMark is a calculation language that blends seamlessly with markdown. Write your thinking in plain text, add calculations that reference each other, and watch results update as you type.
+
+## Where to Start
+
+| If you want to... | Go to... |
+|-------------------|----------|
+| Install and try CalcMark | [Getting Started](/docs/getting-started/) |
+| Learn through a real-world scenario | [Guides](/guides/) — system sizing, budgets, recipes, unit conversion |
+| Look up a specific feature | [User Guide](/docs/user-guide/) — task-oriented sub-pages |
+| Find the exact specification | [Language Reference](/docs/language-reference/) — formal spec with deep-linkable anchors |
+| Copy a working document | [Examples](/docs/examples/) — complete worked problems |
+| Try without installing | [CalcMark Lark](https://lark.calcmark.org) — browser playground |

--- a/site/content/docs/getting-started.md
+++ b/site/content/docs/getting-started.md
@@ -132,9 +132,19 @@ See [Sharing with GitHub Gist](/docs/user-guide/#sharing-gist) in the User Guide
 
 ## Next Steps
 
-- Read the full [User Guide]({{< ref "docs/user-guide" >}}) for all features
-- Learn about [The Editor]({{< ref "docs/editor" >}}) — preview modes, shortcuts, autocomplete
-- Explore the [Examples]({{< ref "docs/examples" >}}) to see CalcMark in action
-- Check the [Language Reference]({{< ref "docs/language-reference" >}}) for the formal specification
-- Use CalcMark from code or AI agents — see [Agent & API Integration]({{< ref "docs/agent-integration" >}})
-- Embed CalcMark in your Go application — see [Go Package]({{< ref "docs/go-package" >}})
+**Learn by domain** — pick a [Guide](/guides/) that matches your use case:
+- [System Sizing](/guides/system-sizing/) — capacity planning, bandwidth, SLA budgets
+- [Business Planning](/guides/business-planning/) — P&L, budgets, financial modeling
+- [Recipe Scaling](/guides/recipe-scaling/) — fractions, measurement conventions, scaling
+- [Unit Conversion](/guides/unit-conversion/) — measurement systems, ambiguous units
+
+**Go deeper:**
+- [User Guide](/docs/user-guide/) — task-oriented reference for every feature
+- [The Editor](/docs/editor/) — preview modes, shortcuts, autocomplete
+- [Examples](/docs/examples/) — complete worked documents
+- [Language Reference](/docs/language-reference/) — formal specification
+
+**Integrate:**
+- [Agent & API Integration](/docs/agent-integration/) — use CalcMark from code or AI agents
+- [Go Package](/docs/go-package/) — embed in your Go application
+- [CalcMark Lark](https://lark.calcmark.org) — try in your browser, no install needed

--- a/site/content/docs/user-guide/currency.md
+++ b/site/content/docs/user-guide/currency.md
@@ -24,3 +24,7 @@ salary_gbp = salary in GBP
 ```
 
 Exchange rates use the format `FROM_TO: rate` where 1 unit of FROM equals `rate` units of TO.
+
+---
+
+**Related guide:** [Business Planning](/guides/business-planning/) — currency arithmetic, ratios, and financial modeling

--- a/site/content/docs/user-guide/functions.md
+++ b/site/content/docs/user-guide/functions.md
@@ -420,3 +420,7 @@ depreciate $50000 by 15% over 5 years to $5000
 | 2 | rate | Depreciation rate as percentage |
 | 3 | periods | Number of periods (number or duration) |
 | 4 | salvage | Optional: minimum floor value |
+
+---
+
+**Related guides:** [System Sizing](/guides/system-sizing/) (network/storage functions) | [Business Planning](/guides/business-planning/) (growth functions)

--- a/site/content/docs/user-guide/units.md
+++ b/site/content/docs/user-guide/units.md
@@ -88,4 +88,8 @@ measurement:
   strict: false
 ```
 
-Measurement conventions compose with `scale` and `convert_to` -- see the [Language Reference](/docs/language-reference/#measurement-conventions) for the full composition table and pipeline order.
+Measurement conventions compose with `scale` and `convert_to` — see the [Language Reference](/docs/language-reference/#measurement-conventions) for the full composition table and pipeline order.
+
+---
+
+**Related guides:** [Unit Conversion & Measurement](/guides/unit-conversion/) | [Recipe Scaling](/guides/recipe-scaling/)

--- a/site/content/guides/_index.md
+++ b/site/content/guides/_index.md
@@ -1,0 +1,40 @@
+---
+title: "Guides"
+summary: "Domain-specific tutorials that teach CalcMark through real-world problem-solving."
+---
+
+# Guides
+
+These tutorials teach CalcMark through real-world scenarios. Each guide walks through a domain-specific problem, introduces the relevant language features along the way, and ends with a complete worked example.
+
+**New to CalcMark?** Start with [Getting Started](/docs/getting-started/) for installation and core concepts, then come back here to solve a real problem.
+
+**Want to try without installing?** Open the [CalcMark Lark playground](https://lark.calcmark.org) in your browser and paste any example.
+
+---
+
+## Choose Your Domain
+
+### [System Sizing & Capacity Planning](/guides/system-sizing/)
+
+Model server fleets, bandwidth requirements, storage capacity, and SLA budgets. Uses rates, `at...per` capacity syntax, and napkin math.
+
+### [Business Planning & Financial Modeling](/guides/business-planning/)
+
+Build P&L statements, budgets, and financial projections. Uses currency arithmetic, `number()` for ratios, `sum of`, and template interpolation.
+
+### [Recipe Scaling & Cooking](/guides/recipe-scaling/)
+
+Scale recipes with fractions, measurement conventions (US vs Imperial), and the `scale` directive. Uses `measurement:` frontmatter for UK/US unit handling.
+
+### [Unit Conversion & Measurement](/guides/unit-conversion/)
+
+Convert between unit systems, handle ambiguous units (US gallon vs Imperial gallon, standard ounce vs troy ounce), and use inline qualifiers. The definitive guide to CalcMark's measurement conventions.
+
+---
+
+## Reference
+
+- [User Guide](/docs/user-guide/) — Task-oriented how-to pages for each feature area
+- [Language Reference](/docs/language-reference/) — Formal specification with deep-linkable anchors
+- [Examples](/docs/examples/) — Complete worked documents ready to copy and modify

--- a/site/content/guides/business-planning/_index.md
+++ b/site/content/guides/business-planning/_index.md
@@ -1,0 +1,94 @@
+---
+title: "Business Planning & Financial Modeling"
+summary: "Build P&L statements, budgets, and financial projections with CalcMark."
+weight: 20
+---
+
+# Business Planning & Financial Modeling
+
+Revenue forecasts, cost breakdowns, margin analysis, budget health checks — financial models are just calculations embedded in narrative. CalcMark makes the narrative and the math live in one document.
+
+**Try it now:** Open the [Household Budget in Lark](https://lark.calcmark.org) or run `cm remote household-budget` in the editor.
+
+---
+
+## Key Features for This Domain
+
+| Feature | What It Does | Reference |
+|---------|-------------|-----------|
+| Currency arithmetic (`$100 + $50`) | Add, subtract, multiply currencies naturally | [Currency](/docs/user-guide/currency/) |
+| `sum of a, b, c` | Sum multiple line items without long `+` chains | [Functions](/docs/user-guide/functions/#function-reference) |
+| `number()` for ratios | Strip currency for dimensionless ratios: `number($500) / number($1000)` → `0.5` | [Formatting](/docs/user-guide/formatting/) |
+| `% of` syntax | `20% of income` → percentage calculation | [Percentages](/docs/user-guide/formatting/#percentages) |
+| `{{variable}}` interpolation | Embed results in prose: "Total: {{revenue}}" | [Templates](/docs/user-guide/frontmatter/#template-variables) |
+| Exchange rates | Convert between currencies with frontmatter rates | [Currency](/docs/user-guide/currency/) |
+| Growth functions | `compound($1000, 7%, 10 years)` for projections | [Growth Functions](/docs/user-guide/functions/#growth-functions) |
+
+---
+
+## Walkthrough: Budget Health Check
+
+### Step 1: Income
+
+Start with gross income and deductions:
+
+```calcmark
+salary_1 = $6500
+salary_2 = $5200
+total_gross = salary_1 + salary_2
+
+tax_rate = 0.24
+net_income = total_gross * (1 - tax_rate)
+```
+
+Currency arithmetic preserves the `$` through every operation.
+
+### Step 2: Expenses with `sum of`
+
+Group expenses and total them without long addition chains:
+
+```calcmark
+rent = $1800
+utilities = $250
+insurance = $150
+groceries = $600
+dining_out = $300
+
+fixed_costs = sum of rent, utilities, insurance
+variable_costs = sum of groceries, dining_out
+total_expenses = fixed_costs + variable_costs
+```
+
+### Step 3: Ratios with `number()`
+
+Dividing currency by currency is an error — dollars divided by dollars doesn't produce a dollar amount. Wrap both sides with `number()` to get a dimensionless ratio:
+
+```calcmark
+savings = net_income - total_expenses
+savings_rate = number(savings) / number(net_income) * 100
+```
+
+`savings_rate` is a plain number (e.g., `41.5`) representing a percentage. Which side you wrap matters — `$100 / number($50)` gives `$2.00` (currency), while `number($100) / number($50)` gives `2` (plain number). See [number() reference](/docs/language-reference/#functions) for the full type rules.
+
+### Step 4: Inline Results with Templates
+
+Put a summary at the top of your document that updates automatically:
+
+```text
+## Monthly Summary
+
+Net income: {{net_income}}
+Total expenses: {{total_expenses}}
+Savings: {{savings}} ({{savings_rate}}%)
+```
+
+The `{{variable}}` tags are replaced with formatted values after all calculations run. Forward references work — your summary can appear before the calculations.
+
+---
+
+## What to Read Next
+
+- **Complete examples:** [Household Budget](/docs/examples/household-budget/), [Services P&L](/docs/examples/services-pl/), [Job Offer Comparison](/docs/examples/job-offer/)
+- **Investment modeling:** [Investment Growth](/docs/examples/investment-growth/) — compound growth, depreciation
+- **Functions reference:** [Growth Functions](/docs/user-guide/functions/#growth-functions)
+- **Language spec:** [Type Arithmetic Rules](/docs/language-reference/#type-arithmetic-rules), [Template Interpolation](/docs/language-reference/#template-interpolation)

--- a/site/content/guides/recipe-scaling/_index.md
+++ b/site/content/guides/recipe-scaling/_index.md
@@ -1,0 +1,111 @@
+---
+title: "Recipe Scaling & Cooking"
+summary: "Scale recipes with fractions, measurement conventions, and the scale directive."
+weight: 30
+---
+
+# Recipe Scaling & Cooking
+
+A recipe is a CalcMark document waiting to happen — quantities with units, scaling by servings, cost per portion. CalcMark handles fractions (`2/3 cup`), measurement conventions (US vs Imperial), and document-wide scaling with a single frontmatter directive.
+
+**Try it now:** Open the [Recipe Scaling example in Lark](https://lark.calcmark.org) or run `cm remote recipe-scaling` in the editor.
+
+---
+
+## Key Features for This Domain
+
+| Feature | What It Does | Reference |
+|---------|-------------|-----------|
+| Fractions (`2/3 cup`, `1/4 tsp`) | Exact rational numbers with units | [Language Reference](/docs/language-reference/#type-system) |
+| `scale` directive | Multiply all quantities by a factor: `scale: 3` triples everything | [Frontmatter](/docs/user-guide/frontmatter/#scale-convert) |
+| `measurement:` conventions | `volume: imperial` makes `1 cup` = 284 mL (UK) instead of 240 mL (US) | [Units](/docs/user-guide/units/#measurement-conventions) |
+| Inline qualifiers (`imp pt`, `us cup`) | Override the document convention for a single line | [Units](/docs/user-guide/units/#measurement-conventions) |
+| `convert_to: si` | Convert all quantities to metric in output | [Frontmatter](/docs/user-guide/frontmatter/#scale-convert) |
+| `@scale` reference | Use the scale factor in expressions: `per_loaf = total / @scale` | [Frontmatter](/docs/user-guide/frontmatter/#directive-references) |
+
+---
+
+## Walkthrough: Scaling a UK Scone Recipe
+
+### Step 1: Base Recipe with Imperial Measurements
+
+Declare the document uses Imperial volume (UK cups, pints, fluid ounces):
+
+```calcmark
+---
+measurement:
+  volume: imperial
+scale:
+  factor: 2
+  unit_categories: [Mass, Volume]
+---
+
+# Scones (makes 8)
+
+flour = 8 oz
+butter = 2 oz
+sugar = 1 oz
+milk = 5 fl oz
+```
+
+With `volume: imperial`, the `5 fl oz` of milk is 142 mL (Imperial fluid ounce), not 148 mL (US). The `scale: 2` doubles all Mass and Volume quantities — `flour` displays as `16 oz`, `milk` as `10 fl oz`.
+
+### Step 2: Cost Per Batch
+
+Currency is not in `unit_categories`, so prices stay at single-batch values:
+
+```calcmark
+flour_cost = $2.50
+butter_cost = $1.80
+sugar_cost = $0.40
+milk_cost = $0.60
+total_cost = sum of flour_cost, butter_cost, sugar_cost, milk_cost
+per_scone = total_cost / (8 * @scale)
+```
+
+`per_scone` divides by `8 * @scale` (16 scones for a doubled batch). The `@scale` reference reads the factor from frontmatter.
+
+### Step 3: Metric Conversion
+
+Add `convert_to: si` to see everything in metric:
+
+```yaml
+---
+measurement:
+  volume: imperial
+scale:
+  factor: 2
+  unit_categories: [Mass, Volume]
+convert_to: si
+---
+```
+
+Now `flour` displays as `454 g` (16 oz → SI), `milk` as `284 ml` (10 imp fl oz → SI). The three directives compose: **measurement** resolves unit identity → **scale** multiplies → **convert_to** changes the output system.
+
+---
+
+## US vs Imperial: What Changes?
+
+The `measurement:` directive affects how bare unit names are interpreted:
+
+| Unit | US (default) | Imperial |
+|------|-------------|----------|
+| `1 cup` | 240 mL | 284 mL |
+| `1 pint` | 473 mL | 568 mL |
+| `1 fl oz` | 29.6 mL | 28.4 mL |
+| `1 gallon` | 3.785 L | 4.546 L |
+
+Use inline qualifiers when a recipe mixes conventions:
+
+```text
+us_butter = 1 us cup       → always 240 mL
+uk_cream = 1 imp pt        → always 568 mL
+```
+
+---
+
+## What to Read Next
+
+- **Complete example:** [Recipe Scaling](/docs/examples/recipe-scaling/) — full walkthrough with `@scale`, fractions, and cost analysis
+- **Measurement conventions:** [Units & Measurement](/docs/user-guide/units/) — all three axes (volume, mass, ton)
+- **Language spec:** [Measurement Conventions](/docs/language-reference/#measurement-conventions), [Scale](/docs/language-reference/#scale)

--- a/site/content/guides/system-sizing/_index.md
+++ b/site/content/guides/system-sizing/_index.md
@@ -1,0 +1,85 @@
+---
+title: "System Sizing & Capacity Planning"
+summary: "Model server fleets, bandwidth, storage, and SLA budgets with CalcMark."
+weight: 10
+---
+
+# System Sizing & Capacity Planning
+
+How many servers do you need? How much bandwidth? What's the storage budget for the next quarter? These are napkin-math problems — you need rough answers fast, not exact answers slow.
+
+CalcMark is built for this. Write your assumptions in plain text, let the math flow, and change any number to see the cascade.
+
+**Try it now:** Open the [System Sizing example in Lark](https://lark.calcmark.org) or run `cm remote system-sizing` in the editor.
+
+---
+
+## Key Features for This Domain
+
+| Feature | What It Does | Reference |
+|---------|-------------|-----------|
+| Rates (`100 MB/s`, `$50/hour`) | Model throughput, cost rates, request rates | [Rates](/docs/user-guide/formatting/#rates) |
+| `at...per` capacity syntax | "10 TB at 2 TB per disk" → 5 disks | [Capacity Planning](/docs/user-guide/formatting/#capacity-planning) |
+| `as napkin` | Round to 2 sig figs for back-of-envelope estimates | [Napkin Math](/docs/user-guide/formatting/#napkin-math) |
+| Multiplier suffixes (`10K`, `1.5M`) | Compact notation for large numbers | [Multipliers](/docs/user-guide/formatting/#multiplier-suffixes) |
+| `over` keyword | Accumulate a rate over time: `100 MB/s over 1 day` | [Rates](/docs/user-guide/formatting/#rates) |
+| Network functions (`rtt`, `throughput`) | Model latency, bandwidth, transfer time | [Network Functions](/docs/user-guide/functions/#network-functions) |
+| Storage functions (`read`, `seek`) | Model disk I/O by device type | [Storage Functions](/docs/user-guide/functions/#storage-functions) |
+
+---
+
+## Walkthrough: Sizing a Web Service
+
+### Step 1: Traffic Assumptions
+
+Start with what you know — expected requests per second and growth rate:
+
+```calcmark
+peak_rps = 10K
+avg_rps = peak_rps * 0.4
+daily_requests = avg_rps over 1 day
+growth_rate = 25%
+```
+
+`daily_requests` uses `over` to accumulate the average rate across a full day. `growth_rate` is a percentage — CalcMark tracks the type.
+
+### Step 2: Compute Capacity
+
+Each server handles a known number of requests. How many servers for the peak?
+
+```calcmark
+capacity_per_server = 2K
+servers_needed = peak_rps at capacity_per_server
+```
+
+The `at...per` syntax divides and rounds up — you can't run half a server.
+
+### Step 3: Storage Budget
+
+Estimate storage from request volume and payload size:
+
+```calcmark
+avg_payload = 4 KB
+daily_storage = daily_requests * avg_payload as napkin
+monthly_storage = daily_storage * 30 as napkin
+```
+
+`as napkin` rounds to 2 significant figures — perfect for planning where `~14 GB` is more useful than `13.8240 GB`.
+
+### Step 4: Network I/O
+
+Use the built-in `throughput` and `transfer_time` functions:
+
+```calcmark
+link_speed = 10 gigabits
+burst_transfer = transfer_time 50 GB at link_speed
+```
+
+---
+
+## What to Read Next
+
+- **Complete example:** [System Sizing](/docs/examples/system-sizing/) — full worked document with servers, storage, and bandwidth
+- **Datacenter costs:** [Datacenter Cost](/docs/examples/datacenter-cost/) — power, cooling, and rack-level modeling
+- **Functions reference:** [Network Functions](/docs/user-guide/functions/#network-functions) and [Storage Functions](/docs/user-guide/functions/#storage-functions)
+- **Language spec:** [Rates](/docs/language-reference/#rates), [Napkin Math](/docs/language-reference/#as-napkin)

--- a/site/content/guides/unit-conversion/_index.md
+++ b/site/content/guides/unit-conversion/_index.md
@@ -1,0 +1,108 @@
+---
+title: "Unit Conversion & Measurement"
+summary: "Convert between unit systems, handle ambiguous units, and use measurement conventions."
+weight: 40
+---
+
+# Unit Conversion & Measurement
+
+CalcMark knows about physical units — length, mass, volume, temperature, speed, energy, power, area, and data sizes. You can convert between them with the `in` keyword, declare document-wide measurement conventions, and use inline qualifiers to be explicit about which definition you mean.
+
+**Try it now:** Open the [Unit Conversion example in Lark](https://lark.calcmark.org) or run `cm remote unit-conversion` in the editor.
+
+---
+
+## Key Features for This Domain
+
+| Feature | What It Does | Reference |
+|---------|-------------|-----------|
+| `in` keyword | `10 meters in feet` → `32.81 feet` | [Units](/docs/user-guide/units/#unit-conversion) |
+| `measurement:` frontmatter | Declare which gallon, ounce, or ton you mean | [Units](/docs/user-guide/units/#measurement-conventions) |
+| Inline qualifiers | `10 troy oz`, `1 imp gal`, `5 short ton` | [Units](/docs/user-guide/units/#measurement-conventions) |
+| Strict annotation | Output shows `2 us oz` so readers know which definition is active | [Language Reference](/docs/language-reference/#measurement-conventions) |
+| `convert_to: si` / `imperial` | Convert all quantities in the document to a target system | [Frontmatter](/docs/user-guide/frontmatter/#scale-convert) |
+| `number()` | Strip units for dimensionless ratios: `number(10 kg) / number(5 kg)` → `2` | [Language Reference](/docs/language-reference/#functions) |
+
+---
+
+## The Ambiguity Problem
+
+Some unit names have different definitions depending on country or domain:
+
+| Unit | US Customary | Imperial (UK) | Difference |
+|------|-------------|---------------|------------|
+| gallon | 3.785 L | 4.546 L | ~20% |
+| pint | 473 mL | 568 mL | ~20% |
+| fluid ounce | 29.6 mL | 28.4 mL | ~4% |
+| cup | 240 mL | 284 mL | ~18% |
+
+| Unit | Standard (avoirdupois) | Troy (precious metals) | Difference |
+|------|----------------------|----------------------|------------|
+| ounce | 28.35 g | 31.10 g | ~10% |
+| pound | 453.6 g | 373.2 g | ~18% |
+
+| Unit | Short (US) | Long (Imperial) | Metric |
+|------|-----------|----------------|--------|
+| ton | 907 kg | 1,016 kg | 1,000 kg |
+
+By default, CalcMark uses US Customary. A 4% error on fluid ounces compounds across a recipe. A 20% error on gallons is the difference between a full tank and running out of fuel.
+
+---
+
+## Declaring Your Convention
+
+Use `measurement:` in frontmatter to declare what you mean:
+
+```yaml
+---
+measurement:
+  volume: imperial    # gallon, pint, fl oz → UK definitions
+  mass: troy          # ounce, pound → precious metals
+  ton: long           # ton → 2240 lb (Imperial)
+---
+```
+
+Only specify axes that differ from US defaults. Each axis is independent — a UK jeweler might use `volume: imperial` with `mass: troy`.
+
+**What is "standard" mass?** Standard means avoirdupois — the everyday weight system (1 oz = 28.35g, 1 lb = 16 oz). This is what your grocery store and bathroom scale use. Troy weight is only for precious metals and gemstones (1 troy oz = 31.10g, 1 troy lb = 12 troy oz).
+
+---
+
+## Inline Qualifiers
+
+Override the document convention for a single expression:
+
+```calcmark
+gold = 10 troy oz in grams
+milk = 2 imp pt in ml
+cargo = 5 short ton in kg
+us_milk = 1 us gal in liters
+```
+
+Prefixes: `us`, `imp`/`imperial`, `troy`, `short`, `long`, `metric`. These work regardless of frontmatter — always available.
+
+---
+
+## How Directives Compose
+
+All three directives compose cleanly. Here's how `1 gallon` flows through each combination:
+
+| Directives | Result | What happened |
+|-----------|--------|---------------|
+| (none) | `1 gal` | US gallon, default display |
+| `measurement: { volume: imperial }` | `1 imperial gallon` | Resolved as imperial |
+| `convert_to: si` | `3.79 l` | US gallon → liters |
+| `measurement: { volume: imperial }` + `convert_to: si` | `4.55 l` | Imperial gallon → liters |
+| `measurement: { volume: imperial }` + `scale: 3` + `convert_to: si` | `13.6 l` | Imperial × 3 → liters |
+| `1 us gal` (inline) + `measurement: { volume: imperial }` | `3.79 l` | Inline overrides convention |
+
+Pipeline order: **measurement** (resolve names) → **evaluate** → **scale** (multiply) → **convert_to** (change system) → **annotate** (strict mode display).
+
+---
+
+## What to Read Next
+
+- **Complete example:** [Measurement Conventions](/docs/examples/) — inline qualifiers, imperial volume, troy mass
+- **Formal spec:** [Measurement Conventions](/docs/language-reference/#measurement-conventions) — full axis table, precedence rules, strict annotation
+- **User guide:** [Units & Measurement](/docs/user-guide/units/) — quick reference for unit conversion and measurement
+- **Recipe guide:** [Recipe Scaling](/guides/recipe-scaling/) — measurement conventions in a cooking context

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -37,6 +37,9 @@ menus:
     - name: Docs
       url: /docs/
       weight: 10
+    - name: Guides
+      url: /guides/
+      weight: 15
     - name: Examples
       url: /docs/examples/
       weight: 20


### PR DESCRIPTION
## Summary

Completes the documentation restructure (Phases 3 + 4).

**Phase 3 — Guides section:**
- New top-level `/guides/` with 4 domain tutorials
- System Sizing, Business Planning, Recipe Scaling, Unit Conversion
- Each guide teaches CalcMark through a real-world domain, links to reference docs and Lark playground

**Phase 4 — Cross-linking:**
- "Guides" in top nav between Docs and Examples
- Getting-started.md reorganized: domain → depth → integrate
- Docs landing page adds "Where to Start" routing table
- User guide sub-pages get "Related guides" footer links

## Three-pillar structure

```
Docs (reference) | Guides (tutorials) | Examples (worked problems)
```

49 pages total, zero build errors, doceval clean (279 blocks from 48 files).

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: static site content only.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>