### PR TITLE
fix: render fractions with custom units as Unicode in HTML

### DIFF
--- a/format/display/formatter.go
+++ b/format/display/formatter.go
@@ -82,9 +82,15 @@ func (f Formatter) Format(t types.Type) string {
 	case *types.Boolean:
 		return v.String()
 	case *types.Fraction:
-		// Fractions with units delegate to Quantity formatting for unit normalization
-		// (e.g., 287 1/2 pint → ~36 gal). Dimensionless fractions format directly.
+		// Fractions with units: use Unicode fraction if normalization won't change the unit
+		// (e.g., "1/2 tomato" → "½ tomato"). For known physical units where normalization
+		// selects a better display unit (e.g., 287/2 pint → ~18 gal), delegate to
+		// FormatQuantity which handles auto-scaling.
 		if v.Unit != "" {
+			_, normUnit := NormalizeForDisplay(v.ToDecimal(), v.Unit)
+			if f.cfg.UnicodeFractions && normUnit == v.Unit {
+				return FormatFractionUnicode(v)
+			}
 			return f.FormatQuantity(&types.Quantity{Value: v.ToDecimal(), Unit: v.Unit})
 		}
 		if f.cfg.UnicodeFractions {

--- a/format/display/fraction_unicode_test.go
+++ b/format/display/fraction_unicode_test.go
@@ -98,6 +98,37 @@ func TestFormatterUnicodeFlagRouting(t *testing.T) {
 	}
 }
 
+func TestFractionWithCustomUnitUnicode(t *testing.T) {
+	// Custom units (not known to NormalizeForDisplay) should use Unicode
+	// fractions when UnicodeFractions is enabled: "1/2 tomato" → "½ tomato".
+	cfg := DefaultConfig()
+	cfg.UnicodeFractions = true
+	formatter := NewFormatter(cfg)
+
+	tests := []struct {
+		name  string
+		num   int64
+		denom int64
+		unit  string
+		want  string
+	}{
+		{"half tomato", 1, 2, "tomato", "½ tomato"},
+		{"third cup (known unit, normalizes to tbsp)", 1, 3, "cup", "5.33 tbsp"},
+		{"two-thirds cookie", 2, 3, "cookie", "⅔ cookie"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f, _ := types.NewFraction(tt.num, tt.denom)
+			f.Unit = tt.unit
+			got := formatter.Format(f)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFractionWithUnitNormalization(t *testing.T) {
 	// Fractions with units must go through the same display normalization
 	// as Quantities. Large values should auto-convert to appropriate units

--- a/format/html_formatter.go
+++ b/format/html_formatter.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/CalcMark/go-calcmark/format/display"
 	"github.com/CalcMark/go-calcmark/spec/document"
 )
 
@@ -83,6 +84,12 @@ func (f *HTMLFormatter) Format(w io.Writer, doc *document.Document, opts Options
 	}{}
 
 	df := opts.getFormatter()
+	// HTML output should use Unicode fractions (½, ⅓, ¾) for readability.
+	cfg := df.Config()
+	if !cfg.UnicodeFractions {
+		cfg.UnicodeFractions = true
+		df = display.NewFormatter(cfg)
+	}
 
 	// Build frontmatter data if present
 	if fm := doc.GetFrontmatter(); fm != nil {

--- a/format/html_formatter_test.go
+++ b/format/html_formatter_test.go
@@ -43,6 +43,38 @@ func TestHTMLFormatterSimple(t *testing.T) {
 	}
 }
 
+// TestHTMLFormatterFractionWithCustomUnit tests that fractions with custom units
+// render using Unicode symbols in HTML output (e.g., "1/2 tomato" → "½ tomato").
+func TestHTMLFormatterFractionWithCustomUnit(t *testing.T) {
+	source := "half = 1/2 tomato\n"
+	doc, err := document.NewDocument(source)
+	if err != nil {
+		t.Fatalf("Failed to create document: %v", err)
+	}
+
+	eval := implDoc.NewEvaluator()
+	if err := eval.Evaluate(doc); err != nil {
+		t.Fatalf("Failed to evaluate: %v", err)
+	}
+
+	var buf bytes.Buffer
+	formatter := &HTMLFormatter{}
+	opts := Options{}
+
+	err = formatter.Format(&buf, doc, opts)
+	if err != nil {
+		t.Fatalf("Format failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "½ tomato") {
+		t.Errorf("Expected HTML to contain '½ tomato', got: %s", output)
+	}
+	if strings.Contains(output, "0.5 tomato") {
+		t.Errorf("HTML should not contain '0.5 tomato' (decimal fallback)")
+	}
+}
+
 // TestHTMLFormatterWithError tests error display in HTML
 func TestHTMLFormatterWithError(t *testing.T) {
 	source := "y = x + 1\n"


### PR DESCRIPTION
## Summary

`1/2 tomato` was rendering as `0.5 tomato` in HTML output because fractions with units unconditionally delegated to `FormatQuantity`, which converts to decimal.

**Two fixes:**

1. **Fraction formatting logic** (`format/display/formatter.go`): When `UnicodeFractions` is enabled and the unit wouldn't change during normalization (i.e., custom units like "tomato", "cookie"), use `FormatFractionUnicode` directly. Known physical units where normalization selects a better display unit (e.g., `287/2 pint` → `~18 gal`) still delegate to `FormatQuantity`.

2. **HTML formatter** (`format/html_formatter.go`): Enable `UnicodeFractions` for all HTML output. Previously it was only enabled in the TUI.

## Before / After

| Input | Before | After |
|-------|--------|-------|
| `1/2 tomato` | `0.5 tomato` | `½ tomato` |
| `2/3 cookie` | `0.666667 cookie` | `⅔ cookie` |
| `1/3 cup` | `5.33 tbsp` (normalized) | `5.33 tbsp` (still normalizes) |
| `1/2` (no unit) | `1/2` | `½` |

## Test plan

- [x] `go test ./format/display/` — all fraction tests pass
- [x] `go test ./format/` — HTML formatter test verifies `½ tomato` in output
- [x] `go test ./cmd/doceval/` — passes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>