### PR TITLE
feat: enable GFM table rendering in HTML output

### DIFF
--- a/format/templates/default.html
+++ b/format/templates/default.html
@@ -116,6 +116,23 @@
             margin: 0.5em 0;
         }
 
+        .text-block table {
+            border-collapse: collapse;
+            width: 100%;
+            margin: 1em 0;
+        }
+
+        .text-block th, .text-block td {
+            border: 1px solid #d0d7de;
+            padding: 0.5em 0.75em;
+            text-align: left;
+        }
+
+        .text-block th {
+            background: #f0f4f8;
+            font-weight: 600;
+        }
+
         .frontmatter {
             margin-bottom: 2em;
             padding: 1em 1.5em;

--- a/spec/document/markdown.go
+++ b/spec/document/markdown.go
@@ -43,8 +43,8 @@ func renderMarkdown(source string) string {
 		source += "\n"
 	}
 
-	// CommonMark-only parser extensions (no GFM: Tables, Strikethrough, DefinitionLists excluded)
-	extensions := parser.NoIntraEmphasis | parser.FencedCode | parser.Autolink |
+	// CommonMark + GFM tables parser extensions
+	extensions := parser.NoIntraEmphasis | parser.Tables | parser.FencedCode | parser.Autolink |
 		parser.SpaceHeadings | parser.HeadingIDs | parser.BackslashLineBreak |
 		parser.AutoHeadingIDs
 	p := parser.NewWithExtensions(extensions)

--- a/spec/document/markdown_test.go
+++ b/spec/document/markdown_test.go
@@ -113,8 +113,7 @@ func TestMarkdownRawHTMLBlocks(t *testing.T) {
 	}
 }
 
-func TestMarkdownGFMTableNotRendered(t *testing.T) {
-	// GFM tables should not render as HTML tables (CommonMark only)
+func TestMarkdownGFMTableRendered(t *testing.T) {
 	source := []string{
 		"| Header | Value |",
 		"|--------|-------|",
@@ -124,11 +123,40 @@ func TestMarkdownGFMTableNotRendered(t *testing.T) {
 	block := NewTextBlock(source)
 	html := block.Render()
 
-	if strings.Contains(html, "<table") {
-		t.Error("GFM tables must not render as <table> (CommonMark only)")
+	if !strings.Contains(html, "<table") {
+		t.Error("GFM tables must render as <table>")
 	}
-	if strings.Contains(html, "<th") {
-		t.Error("GFM tables must not render <th> elements")
+	if !strings.Contains(html, "<th") {
+		t.Error("GFM tables must render <th> elements for header row")
+	}
+	if !strings.Contains(html, "<td") {
+		t.Error("GFM tables must render <td> elements for data rows")
+	}
+	if !strings.Contains(html, "Header") {
+		t.Error("Table header content must be preserved")
+	}
+	if !strings.Contains(html, "A") || !strings.Contains(html, "1") {
+		t.Error("Table cell content must be preserved")
+	}
+}
+
+func TestMarkdownGFMTableWithInterpolation(t *testing.T) {
+	// Tables with {{variable}} interpolation must render as HTML tables
+	source := []string{
+		"| Metric | Value |",
+		"|--------|-------|",
+		"| Revenue | $1M |",
+		"| Cost | $500K |",
+	}
+
+	block := NewTextBlock(source)
+	html := block.Render()
+
+	if !strings.Contains(html, "<table") {
+		t.Error("Table with data must render as <table>")
+	}
+	if !strings.Contains(html, "Revenue") {
+		t.Error("Table must contain Revenue cell")
 	}
 }
 


### PR DESCRIPTION
## Summary

Markdown tables (GFM pipe syntax) were rendering as raw text instead of `<table>` elements. The parser was restricted to CommonMark-only extensions.

**Fix:** Enable `parser.Tables` extension in the gomarkdown parser. Add table CSS to the default HTML template.

## Before / After

| Before | After |
|--------|-------|
| `\| Metric \| Value \|` as raw text | Proper `<table>` with borders |

## Test plan

- [x] `TestMarkdownGFMTableRendered` — verifies `<table>`, `<th>`, `<td>` in output
- [x] `TestMarkdownGFMTableWithInterpolation` — verifies tables with data render correctly
- [x] All existing tests pass