### PR TITLE
fix: grow() and depreciate() convert mixed compatible units

### DIFF
--- a/docs/plans/2026-03-18-001-fix-grow-function-mixed-unit-conversion-plan.md
+++ b/docs/plans/2026-03-18-001-fix-grow-function-mixed-unit-conversion-plan.md
@@ -1,0 +1,83 @@
+---
+title: "fix: grow() ignores unit conversion for mixed compatible quantities"
+type: fix
+status: completed
+date: 2026-03-18
+---
+
+# fix: grow() ignores unit conversion for mixed compatible quantities
+
+## Overview
+
+`grow(50GB, 20TB, 6 months)` returns `170 GB` instead of the expected `122,930 GB`. The function strips units via `extractDecimalValue()`, treating `20 TB` as bare `20` rather than converting it to the amount's unit (GB) first. The same stripping means `6 months` is correctly treated as `6` periods, but this behavior is undocumented.
+
+## Problem Statement
+
+Two issues in `evalGrowFunc` (`impl/interpreter/growth_functions.go:231-268`):
+
+### Root Cause 1: `extractDecimalValue` discards units without conversion
+
+Both `amountVal` and `incrementVal` go through `extractDecimalValue()` which extracts `.Value` and discards the unit. So `50 GB` → `50`, `20 TB` → `20`. The math becomes `50 + (20 × 6) = 170`, wrapped with the first argument's unit → `170 GB`.
+
+**Expected**: Convert `20 TB` to `20,480 GB` (first-unit-wins), then `50 + (20480 × 6) = 122,930 GB`.
+
+The regular arithmetic path (`50 GB + 20 TB`) correctly handles this via `evalQuantityOperation` → `convertQuantity()`. The `grow()` function bypasses this entirely.
+
+### Root Cause 2: Period unit silently ignored
+
+`6 months` is a `*types.Duration{Value: 6, Unit: "months"}`. `extractPeriodsFromDuration` returns `6` and discards `"months"`. This is actually correct semantics for `grow()` (6 periods of linear addition), but the unit is silently dropped with no validation or documentation.
+
+## Proposed Solution
+
+Modify `evalGrowFunc` to convert the increment to the amount's unit when both are `*types.Quantity` with compatible but different units, using the existing `convertQuantity()` infrastructure.
+
+### Implementation
+
+In `impl/interpreter/growth_functions.go`, after evaluating both `amountVal` and `incrementVal`:
+
+1. If both are `*types.Quantity` and units differ → call `convertQuantity(incrementQty, amountQty.Unit)` before extracting the decimal
+2. If both are `*types.Currency` and symbols differ → return an error (mixing `$` and `€` is not meaningful)
+3. If types are mismatched (e.g., Quantity + Currency) → current behavior is fine (extract raw values)
+
+The `convertQuantity` function already handles compatibility checking and returns a clear error for incompatible units.
+
+### Files to Modify
+
+1. **`impl/interpreter/growth_functions.go`** — `evalGrowFunc`: Add unit conversion between amount and increment when both are `*types.Quantity`
+2. **`impl/interpreter/growth_functions_test.go`** — Add test cases for mixed-unit `grow()` calls
+3. **`testdata/eval/success/features/growth_functions.cm`** — Add golden test cases
+4. **`testdata/spec/valid/features/growth_functions.cm`** — Add valid spec examples
+
+### Also affected: `evalDepreciateFunc`
+
+`depreciate()` uses the same `extractDecimalValue` pattern for its value parameter. If the salvage value has different units than the initial value (e.g., `depreciate(1TB, 10%, 5, 100GB)`), the same bug applies. Should be fixed in the same pass.
+
+## Acceptance Criteria
+
+- [ ] `grow(50GB, 20TB, 6)` returns `122,930 GB` (converts TB→GB before multiplication)
+- [ ] `grow(50GB, 20TB, 6 months)` returns `122,930 GB` (duration period count extracted correctly)
+- [ ] `grow(50GB, 500GB, 3)` returns `1,550 GB` (same-unit still works)
+- [ ] `grow(100, 20, 5)` returns `200` (plain numbers unchanged)
+- [ ] `grow($500, $100, 36)` returns `$4,100.00` (currency unchanged)
+- [ ] `grow(50GB, 20 incompatible_unit, 6)` returns a clear error about incompatible units
+- [ ] NL syntax `grow 50GB by 20TB over 6 months` produces the same result as functional form
+- [ ] `depreciate()` also handles mixed compatible units correctly
+- [ ] All existing tests continue to pass
+
+## Technical Considerations
+
+- **First-unit-wins rule**: Matches existing arithmetic behavior (`50 GB + 20 TB = 20,530 GB`)
+- **`convertQuantity` reuse**: Already handles unit compatibility checking and conversion via `units.Convert`
+- **Binary data units**: In this codebase, `1 TB = 1024 GB` (binary/IEC convention per `spec/units/conversion.go`)
+- **NL/functional parity**: Per learnings doc, "every fix is two fixes" — must verify both parser paths produce identical results
+- **`IsExplicit`/`IsNapkin` flags**: Per learnings, when constructing Quantity values, propagate metadata flags from the original. The existing `wrapResult` already handles this correctly by copying the unit from the original amount.
+
+## Sources
+
+- Implementation: `impl/interpreter/growth_functions.go:231-268`
+- Unit conversion: `impl/interpreter/unit_conversion.go:13-44` (`evalQuantityOperation`, `convertQuantity`)
+- Tests: `impl/interpreter/growth_functions_test.go:263-289`
+- Spec: `spec/features/registry.go:668-678`
+- Param types: `spec/types/param_types.go:151-158`
+- Learning: `docs/solutions/logic-errors/compound-bare-frequency-modifier-silently-ignored.md`
+- Learning: `docs/solutions/integration-issues/nl-functional-syntax-parity-and-doc-staleness.md`

--- a/impl/interpreter/growth_functions.go
+++ b/impl/interpreter/growth_functions.go
@@ -86,6 +86,25 @@ func wrapResult(result decimal.Decimal, original types.Type) types.Type {
 	}
 }
 
+// convertToMatchingUnit converts val to match target's unit when both are
+// compatible quantities (first-unit-wins). Returns val unchanged if types
+// don't both have units. Returns an error for incompatible quantity units.
+func convertToMatchingUnit(target, val types.Type) (types.Type, error) {
+	targetQty, targetIsQty := target.(*types.Quantity)
+	valQty, valIsQty := val.(*types.Quantity)
+	if !targetIsQty || !valIsQty {
+		return val, nil
+	}
+	if targetQty.Unit == valQty.Unit {
+		return val, nil
+	}
+	converted, err := convertQuantity(valQty, targetQty.Unit)
+	if err != nil {
+		return nil, fmt.Errorf("incompatible units %s and %s", targetQty.Unit, valQty.Unit)
+	}
+	return converted, nil
+}
+
 // validateRate checks that rate is within (-1, 1] i.e. (-100%, 100%].
 func validateRate(rate decimal.Decimal) error {
 	if rate.GreaterThan(decOne) || rate.LessThanOrEqual(decNegOne) {
@@ -248,6 +267,13 @@ func evalGrowFunc(interp *Interpreter, f *ast.FunctionCall) (types.Type, error) 
 	if err != nil {
 		return nil, err
 	}
+
+	// Convert increment to amount's unit when both are compatible quantities
+	incrementVal, err = convertToMatchingUnit(amountVal, incrementVal)
+	if err != nil {
+		return nil, fmt.Errorf("grow: %w", err)
+	}
+
 	increment, err := extractDecimalValue(incrementVal)
 	if err != nil {
 		return nil, fmt.Errorf("grow: invalid increment: %w", err)
@@ -318,6 +344,13 @@ func evalDepreciateFunc(interp *Interpreter, f *ast.FunctionCall) (types.Type, e
 		if err != nil {
 			return nil, err
 		}
+
+		// Convert salvage to principal's unit when both are compatible quantities
+		salvageVal, err = convertToMatchingUnit(valueVal, salvageVal)
+		if err != nil {
+			return nil, fmt.Errorf("depreciate: %w", err)
+		}
+
 		salvage, err := extractDecimalValue(salvageVal)
 		if err != nil {
 			return nil, fmt.Errorf("depreciate: invalid salvage value: %w", err)

--- a/impl/interpreter/growth_functions_test.go
+++ b/impl/interpreter/growth_functions_test.go
@@ -277,6 +277,26 @@ func TestLinearGrow(t *testing.T) {
 			input: "grow($500, $100, 36)",
 			want:  "$4100.00",
 		},
+		{
+			name:  "same-unit quantity",
+			input: "grow(50 GB, 500 GB, 3)",
+			want:  "1550 GB",
+		},
+		{
+			name:  "mixed-unit quantity TB to GB",
+			input: "grow(50 GB, 20 TB, 6)",
+			want:  "122930 GB",
+		},
+		{
+			name:  "mixed-unit quantity with duration periods",
+			input: "grow(50 GB, 20 TB, 6 months)",
+			want:  "122930 GB",
+		},
+		{
+			name:  "NL syntax mixed-unit quantity",
+			input: "grow 50 GB by 20 TB over 6 months",
+			want:  "122930 GB",
+		},
 	}
 
 	for _, tt := range tests {
@@ -312,6 +332,17 @@ func TestDepreciateWithSalvage(t *testing.T) {
 	}
 }
 
+// TestDepreciateWithMixedUnitSalvage tests that depreciate converts salvage to principal's unit.
+func TestDepreciateWithMixedUnitSalvage(t *testing.T) {
+	// depreciate(1 TB, 15%, 20, 100 GB) — salvage 100 GB = 0.09765625 TB
+	// After 20 years at 15%, 1 TB becomes ~$0.03875... TB, which is below salvage
+	got := evalGrowthLine(t, "depreciate(1 TB, 15%, 20, 100 GB)")
+	// 100 GB in TB = 100/1024 ≈ 0.09765625 TB, result should be clamped to salvage
+	if got != "0.1 TB" {
+		t.Errorf("got %q, want %q", got, "0.1 TB")
+	}
+}
+
 // TestGrowthErrors tests error cases
 func TestGrowthErrors(t *testing.T) {
 	tests := []struct {
@@ -343,6 +374,11 @@ func TestGrowthErrors(t *testing.T) {
 			name:    "compound unknown frequency",
 			input:   "compound($1000, 5%, 10 years, compounded biweekly)",
 			wantErr: "unknown compounding frequency",
+		},
+		{
+			name:    "grow incompatible units",
+			input:   "grow(50 GB, 20 kg, 6)",
+			wantErr: "incompatible units",
 		},
 	}
 

--- a/testdata/eval/success/features/growth_functions.cm
+++ b/testdata/eval/success/features/growth_functions.cm
@@ -36,8 +36,13 @@ compound $1000 by 5% per month over 12 months
 # Natural language compound with compounded modifier
 compound $1000 by 12% compounded monthly over 10 years
 
+# Linear growth with mixed compatible units (first-unit-wins)
+grow(50 GB, 20 TB, 6)
+grow(50 GB, 20 TB, 6 months)
+
 # Natural language grow
 grow 100 by 20 over 5 months
+grow 50 GB by 20 TB over 6 months
 
 # Natural language depreciate
 depreciate $50000 by 15% over 5 years

--- a/testdata/spec/valid/features/growth_functions.cm
+++ b/testdata/spec/valid/features/growth_functions.cm
@@ -36,8 +36,13 @@ compound $1000 by 5% per month over 12 months
 # Natural language compound with compounded modifier
 compound $1000 by 12% compounded monthly over 10 years
 
+# Linear growth with mixed compatible units
+grow(50 GB, 20 TB, 6)
+grow(50 GB, 20 TB, 6 months)
+
 # Natural language grow
 grow 100 by 20 over 5 months
+grow 50 GB by 20 TB over 6 months
 
 # Natural language depreciate
 depreciate $50000 by 15% over 5 years


### PR DESCRIPTION
## Summary

- **Bug**: `grow(50GB, 20TB, 6 months)` returned `170 GB` instead of `122,930 GB` because `extractDecimalValue()` stripped units without converting
- **Fix**: Added `convertToMatchingUnit()` helper that uses first-unit-wins conversion (matching arithmetic operator behavior) before extracting decimal values
- **Also fixed**: `depreciate()` salvage parameter had the same unit-stripping bug
- Incompatible units (e.g., `grow(50 GB, 20 kg, 6)`) now return a clear error

Fixes #77

## Testing

- Added 4 new `TestLinearGrow` cases: same-unit, mixed-unit (TB→GB), duration periods, NL syntax parity
- Added `TestDepreciateWithMixedUnitSalvage` for depreciate mixed-unit conversion
- Added `TestGrowthErrors/grow_incompatible_units` for error path
- Golden test cases added to both `testdata/eval/success/` and `testdata/spec/valid/`
- Full `task test` and `task quality` pass clean

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a pure computation fix in the interpreter with no runtime/infrastructure impact.

---

🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code) + Compound Engineering v2.44.0

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>