### PR TITLE
docs: refresh site — hero copy, nav CTA, VS Code card, doc audit

### DIFF
--- a/site/assets/css/components.css
+++ b/site/assets/css/components.css
@@ -74,6 +74,23 @@
   color: var(--color-primary);
 }
 
+.nav-link--lark {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35em;
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.nav-link--lark:hover {
+  color: var(--color-primary-hover);
+}
+
+.nav-lark-icon {
+  width: 1.1em;
+  height: 1.1em;
+}
+
 /* Theme toggle */
 .theme-toggle {
   background: none;

--- a/site/content/docs/_index.md
+++ b/site/content/docs/_index.md
@@ -4,7 +4,7 @@ summary: "Everything you need to get started with CalcMark."
 weight: 10
 ---
 
-CalcMark is a calculation language that blends seamlessly with markdown. Write your thinking in plain text, add calculations that reference each other, and watch results update as you type.
+CalcMark is a calculation language that blends seamlessly with Markdown. Write your thinking in plain text, add calculations that reference each other, and watch results update as you type.
 
 ## Where to Start
 

--- a/site/content/docs/agent-integration.md
+++ b/site/content/docs/agent-integration.md
@@ -278,7 +278,7 @@ When combined with `cm convert --to=html`, this produces readable reports with i
 
 ## JSON Response Structure
 
-The response is an array of **blocks**. Each block is either `"calculation"` or `"text"` (markdown):
+The response is an array of **blocks**. Each block is either `"calculation"` or `"text"` (Markdown):
 
 ```json
 {
@@ -357,7 +357,7 @@ Note: `value` is the display-formatted string (may auto-convert units for readab
 |------|----------|
 | `--format json` | Structured data for programs and agents |
 | `--format text` | Human-readable plain text |
-| `cm convert --to=html` | HTML document with rendered markdown and results |
+| `cm convert --to=html` | HTML document with rendered Markdown and results |
 | `cm convert --to=md` | Markdown with results inline |
 
 Convert to a file with `-o`:
@@ -378,7 +378,7 @@ echo "x = unknown + 1" | cm --format json
 
 **Errors go to stderr as plain text, not JSON.** Always check the exit code.
 
-**Silent misinterpretation:** If CalcMark doesn't recognize an expression, it treats it as markdown prose. The JSON will contain `"type": "text"` blocks instead of `"type": "calculation"`. Always verify your output contains calculation blocks when you expect them.
+**Silent misinterpretation:** If CalcMark doesn't recognize an expression, it treats it as Markdown prose. The JSON will contain `"type": "text"` blocks instead of `"type": "calculation"`. Always verify your output contains calculation blocks when you expect them.
 
 ## Common Pitfalls
 
@@ -399,7 +399,7 @@ adjusted_cost = base_cost + 15%
 ```
 ### Calculations Are Separate From Markdown
 
-Calculations live on their own lines, not interspersed with markdown. The only exception is `{{ interpolated_variables}}`.
+Calculations live on their own lines, not interspersed with Markdown. The only exception is `{{ interpolated_variables}}`.
 
 OK:
 
@@ -500,7 +500,7 @@ Create a CalcMark document and convert it for the user:
 
 1. Write the `.cm` file with frontmatter, headers, calculations, and `{{template}}` interpolation
 2. Convert: `cm convert report.cm --to=html -o report.html`
-3. Deliver the HTML (or markdown) to the user
+3. Deliver the HTML (or Markdown) to the user
 
 ### Iterative Analysis
 

--- a/site/content/docs/cli-reference.md
+++ b/site/content/docs/cli-reference.md
@@ -19,6 +19,8 @@ cm help functions    # List all CalcMark functions
 cm help constants    # List all unit constants
 cm help frontmatter  # List all frontmatter directives
 cm help --all        # Show everything at once
+cm watch <file.cm>   # Live HTML preview in browser
+cm lsp               # Start language server (stdio)
 cm version           # Print version info
 cm completion [shell] # Generate shell completions
 ```
@@ -169,7 +171,7 @@ The template receives a root object with two fields:
 | `.Type` | string | `"calculation"` or `"text"` |
 | `.SourceLines` | list | Calculation lines (only for `calculation` blocks) |
 | `.Error` | string | Error message (only for `calculation` blocks) |
-| `.HTML` | HTML | Rendered markdown (only for `text` blocks) |
+| `.HTML` | HTML | Rendered Markdown (only for `text` blocks) |
 
 **SourceLine fields** (each item in `.SourceLines`):
 
@@ -303,8 +305,58 @@ cm help functions        # Functions only
 cm help constants        # Unit constants only
 cm help frontmatter      # Frontmatter directives only
 cm help --functions      # Same as cm help functions
+cm help --constants      # Same as cm help constants
+cm help --frontmatter    # Same as cm help frontmatter
 cm help --all            # Everything at once
 cm help eval             # Help for a specific command
+```
+
+---
+
+## `cm watch <file.cm>` {#watch}
+
+Watch a CalcMark file for changes and serve a live HTML preview in the browser. The preview updates automatically on every save via WebSocket.
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--port int` | Port to listen on (default 3141) |
+
+### Security
+
+The watch server binds to `127.0.0.1` only (never exposed to the network), generates a random session token in the URL, and validates WebSocket origins.
+
+### Examples
+
+```bash
+cm watch budget.cm                  # Open http://127.0.0.1:3141/<token>
+cm watch budget.cm --port 8080      # Use a custom port
+```
+
+---
+
+## `cm lsp` {#lsp}
+
+Start the CalcMark language server over stdio. Editor extensions (such as the VS Code extension) spawn this command automatically to provide language intelligence for `.cm` files.
+
+This command is not typically invoked directly by users.
+
+### Capabilities
+
+- Diagnostics
+- Autocomplete
+- Hover
+- Go-to-definition
+- Document symbols
+- Semantic tokens
+- Code actions
+- Signature help
+
+### Example
+
+```bash
+cm lsp    # Start the language server (called by editor extensions)
 ```
 
 ---

--- a/site/content/docs/configuration.md
+++ b/site/content/docs/configuration.md
@@ -120,6 +120,9 @@ locale = "en-US"
 # Set to "light" if you use a light terminal background.
 color_mode = "dark"
 
+# Display fractions as Unicode characters (e.g., ½) instead of ASCII (1/2).
+unicode_fractions = true
+
 [tui.theme]
 # Color overrides (hex strings: #RGB or #RRGGBB).
 # Leave empty to use the built-in adaptive palette defaults.

--- a/site/content/docs/editor.md
+++ b/site/content/docs/editor.md
@@ -1,6 +1,6 @@
 ---
 title: "The CalcMark Editor"
-summary: "A terminal-based editor with live results, markdown preview, autocomplete, and keyboard-driven workflows."
+summary: "A terminal-based editor with live results, Markdown preview, autocomplete, and keyboard-driven workflows."
 weight: 22
 ---
 
@@ -26,9 +26,9 @@ The default mode. Shows calculation results aligned with their source lines. Mar
 
 ### Side-by-Side
 
-Shows rendered markdown alongside calculation results. Headings, lists, and prose are styled with terminal colors. This is useful when your document mixes explanatory text with calculations and you want to see both.
+Shows rendered Markdown alongside calculation results. Headings, lists, and prose are styled with terminal colors. This is useful when your document mixes explanatory text with calculations and you want to see both.
 
-<img src="/images/editor-sidebyside.png" alt="Side-by-Side mode — rendered markdown next to results" width="700">
+<img src="/images/editor-sidebyside.png" alt="Side-by-Side mode — rendered Markdown next to results" width="700">
 
 ### Reading Mode
 
@@ -111,7 +111,7 @@ The same picker appears for **Save As** and **Export**, with context-appropriate
 
 **Ctrl+T** opens the export dialog. Choose a format:
 
-- **Markdown** (`.md`) — Rendered markdown with results inline
+- **Markdown** (`.md`) — Rendered Markdown with results inline
 - **JSON** (`.json`) — Structured output with values, types, and units
 - **HTML** (`.html`) — Styled HTML document
 

--- a/site/content/docs/examples/_index.md
+++ b/site/content/docs/examples/_index.md
@@ -1,12 +1,23 @@
 ---
 title: "Examples"
-summary: "Worked examples showing CalcMark in action."
+summary: "Tutorials, worked examples, and feature references for CalcMark."
 weight: 900
 ---
 
-Explore complete CalcMark files that demonstrate real-world use cases. Each example page has a Larky icon you can click to copy the `cm remote` command — paste it into your terminal to open the file directly.
+Each example page has a Larky icon you can click to open the file directly in [Lark](https://lark.calcmark.org), or copy the `cm remote` command to your terminal.
 
-## Real-World Use Cases
+## Tutorials
+
+Step-by-step walkthroughs that teach CalcMark through a specific domain.
+
+- [System Sizing & Capacity Planning](/guides/system-sizing/) -- Server fleets, bandwidth, storage, and SLA budgets
+- [Business Planning & Financial Modeling](/guides/business-planning/) -- P&L statements, budgets, and projections
+- [Recipe Scaling & Cooking](/guides/recipe-scaling/) -- Fractions, measurement conventions, and the `scale` directive
+- [Unit Conversion & Measurement](/guides/unit-conversion/) -- Ambiguous units, inline qualifiers, and unit systems
+
+## Worked Examples
+
+Complete `.cm` files you can run, modify, and learn from.
 
 - [Markdown Showcase](markdown-showcase/) -- Headings, lists, quotes, links, tables, and live calculations
 - [Household Budget](household-budget/) -- Monthly budget with rates, conversions, and napkin math
@@ -21,7 +32,7 @@ Explore complete CalcMark files that demonstrate real-world use cases. Each exam
 
 ## Feature Reference
 
-These examples are drawn from the project's {{< repo-file path="testdata/eval/success/features" type="tree" text="golden test suite" >}} and demonstrate every language feature:
+Drawn from the project's {{< repo-file path="testdata/eval/success/features" type="tree" text="golden test suite" >}}, these pages demonstrate every language feature:
 
 - [Functions & Natural Language](functions-and-nl/) -- All function call styles
 - [Network & Storage](network-and-storage/) -- Latency, throughput, read/seek, compression

--- a/site/content/docs/examples/datacenter-cost/_index.md
+++ b/site/content/docs/examples/datacenter-cost/_index.md
@@ -104,7 +104,7 @@ For reference, 1000 kilowatts converts cleanly:
 
 CalcMark knows SI power units and can convert between them using the `in` keyword. The `$9.5M` syntax uses a multiplier suffix -- CalcMark supports `k` (thousand), `M` (million), and `B` (billion).
 
-**CalcMark features:** Quantities with units (`kilowatts`); `in` unit conversion; multiplier suffixes (`$9.5M`); markdown prose between calculations.
+**CalcMark features:** Quantities with units (`kilowatts`); `in` unit conversion; multiplier suffixes (`$9.5M`); Markdown prose between calculations.
 
 ---
 

--- a/site/content/docs/examples/home-renovation/_index.md
+++ b/site/content/docs/examples/home-renovation/_index.md
@@ -98,7 +98,7 @@ flooring = kitchen_sqft * tile_per_sqft
 
 CalcMark preserves currency types through arithmetic — multiplying a count by a currency produces a currency, not a plain number.
 
-**CalcMark features:** Currency literals (`$`); currency arithmetic; markdown prose between calculations.
+**CalcMark features:** Currency literals (`$`); currency arithmetic; Markdown prose between calculations.
 
 ---
 

--- a/site/content/docs/examples/household-budget/_index.md
+++ b/site/content/docs/examples/household-budget/_index.md
@@ -46,7 +46,7 @@ net_income = total_gross - total_taxes
 
 The combined rate is 0.3065 (about 30.7%), giving `total_taxes = $3,586.05` and `net_income = $8,113.95`.
 
-**CalcMark features:** Decimal arithmetic; currency multiplication and subtraction; markdown prose between calculations.
+**CalcMark features:** Decimal arithmetic; currency multiplication and subtraction; Markdown prose between calculations.
 
 ---
 

--- a/site/content/docs/examples/markdown-showcase/_index.md
+++ b/site/content/docs/examples/markdown-showcase/_index.md
@@ -1,12 +1,12 @@
 ---
 title: "Markdown Showcase"
-summary: "A complete markdown document with headings, lists, quotes, links, tables, and live calculations."
+summary: "A complete Markdown document with headings, lists, quotes, links, tables, and live calculations."
 weight: 5
 calcmark_build: progressive
 calcmark_source: testdata/examples/markdown-showcase.cm
 ---
 
-CalcMark documents are just markdown. This example shows how headings, bullet lists, blockquotes, links, tables, and inline formatting all coexist with live calculations. Nothing special is needed — write your thinking, add numbers, and results appear.
+CalcMark documents are just Markdown. This example shows how headings, bullet lists, blockquotes, links, tables, and inline formatting all coexist with live calculations. Nothing special is needed — write your thinking, add numbers, and results appear.
 
 The complete CalcMark file is available at {{< repo-file path="testdata/examples/markdown-showcase.cm" >}}.
 

--- a/site/content/docs/examples/project-workback/_index.md
+++ b/site/content/docs/examples/project-workback/_index.md
@@ -99,7 +99,7 @@ total_points = num_sprints * team_velocity
 
 Plain arithmetic works alongside dates and durations. `2 * 40 = 80` story points across two sprints.
 
-**CalcMark features:** Plain arithmetic; markdown prose between calculations.
+**CalcMark features:** Plain arithmetic; Markdown prose between calculations.
 
 ---
 

--- a/site/content/docs/go-package.md
+++ b/site/content/docs/go-package.md
@@ -81,7 +81,7 @@ Call `session.Reset()` to clear all variables and start fresh.
 
 ## Evaluate a Full Document
 
-For complete CalcMark documents — with markdown, frontmatter, and multiple calc blocks — use the document-level API:
+For complete CalcMark documents — with Markdown, frontmatter, and multiple calc blocks — use the document-level API:
 
 ```go
 import (

--- a/site/content/docs/ide-setup.md
+++ b/site/content/docs/ide-setup.md
@@ -326,6 +326,6 @@ cm watch --port 8080 budget.cm    # Custom port (default: 3141)
 | Hover | Variable values, function signatures, unit descriptions |
 | Go-to-definition | Jump to variable assignment |
 | Document symbols | Variables and headings in outline view |
-| Semantic tokens | Context-aware highlighting (calc vs markdown lines) |
+| Semantic tokens | Context-aware highlighting (calc vs Markdown lines) |
 | Code actions | Quick fixes for undefined variables ("did you mean?") |
 | Signature help | Parameter hints inside function calls |

--- a/site/content/docs/language-reference.md
+++ b/site/content/docs/language-reference.md
@@ -10,7 +10,7 @@ This is the complete and authoritative specification for the CalcMark language. 
 
 ## Overview
 
-CalcMark is a calculation language that blends seamlessly with markdown. It allows calculations to live naturally within prose documents.
+CalcMark is a calculation language that blends seamlessly with Markdown. It allows calculations to live naturally within prose documents.
 
 ### Design Goals
 
@@ -18,7 +18,7 @@ CalcMark is a calculation language that blends seamlessly with markdown. It allo
 - **Minimal**: Only essential features, no unnecessary complexity
 - **Unambiguous**: One way to do things, clear error messages
 - **Unicode-aware**: Full international character support
-- **Markdown-compatible**: Works within existing markdown documents
+- **Markdown-compatible**: Works within existing Markdown documents
 
 ### Key Characteristics
 
@@ -33,7 +33,7 @@ CalcMark is a calculation language that blends seamlessly with markdown. It allo
 
 ### Calculation by Exclusion
 
-CalcMark uses "calculation by exclusion" - if a line looks like markdown, it's markdown. Only unambiguous calculations are treated as calculations.
+CalcMark uses "calculation by exclusion" - if a line looks like Markdown, it's Markdown. Only unambiguous calculations are treated as calculations.
 
 ```calcmark
 # My Budget          -> MARKDOWN (header prefix)
@@ -288,7 +288,7 @@ See the [Recipe Scaling](/docs/examples/recipe-scaling/) example for a complete 
 
 ### Template Interpolation {#template-interpolation}
 
-Template variables embed calculated values into prose. After all calculations are evaluated, `{{variable_name}}` tags in text blocks are replaced with display-formatted results. Resolved values render **bold** in markdown and are wrapped in `<span class="cm-interpolated">` in HTML.
+Template variables embed calculated values into prose. After all calculations are evaluated, `{{variable_name}}` tags in text blocks are replaced with display-formatted results. Resolved values render **bold** in Markdown and are wrapped in `<span class="cm-interpolated">` in HTML.
 
 #### Forward References
 
@@ -313,7 +313,7 @@ The summary table renders with **$4.2M**, **28%**, and **14 people** — even th
 
 #### Inline Formatting
 
-Combine `{{var}}` with markdown formatting for emphasis, headings, and lists:
+Combine `{{var}}` with Markdown formatting for emphasis, headings, and lists:
 
 ```text
 The grand total is {{total_cost}}.
@@ -331,7 +331,7 @@ Backticks around tags are consumed — `` `{{var}}` `` renders as **value**, not
 
 #### Tables
 
-Interpolation works naturally in markdown tables. Use it for dashboard-style summaries:
+Interpolation works naturally in Markdown tables. Use it for dashboard-style summaries:
 
 ```text
 | Scenario | Revenue | Margin |
@@ -371,7 +371,7 @@ Lines are classified in this order:
 
 1. **BLANK** — Empty or only whitespace
 2. **INDENTED CODE** → MARKDOWN — Line starts with 4+ spaces or a tab
-3. **FENCED CODE BLOCK** → MARKDOWN — Lines between `` ``` `` or `~~~` fences (stateful; all content inside is markdown regardless of what it looks like)
+3. **FENCED CODE BLOCK** → MARKDOWN — Lines between `` ``` `` or `~~~` fences (stateful; all content inside is Markdown regardless of what it looks like)
 4. **MARKDOWN pattern** — Matches a known CommonMark construct:
    - Block-level: `#` (ATX heading), `>` (blockquote), `- ` / `* ` / `+ ` (unordered list), `digit.` (ordered list), `---` / `***` / `___` (horizontal rule), `===` / `---` (setext heading underline), `` ``` `` / `~~~` (fenced code fence)
    - Inline-level at start of line: `![` (image), `[text](url)` (inline link), `[id]: url` (link definition), `**text**` (bold formatting)
@@ -748,7 +748,7 @@ Case-insensitive: `AND`, `and`, `And` all work.
 | Operator | Name | Example | Result |
 |----------|------|---------|--------|
 | `in` | Unit conversion | `10 meters in feet` | `32.81 feet` |
-| `as` | Display modifier | `1234567 as napkin` | `~1.2M` |
+| `as` | Unit conversion or display modifier | `1 mile as km`, `1234567 as napkin` | `1.61 km`, `~1.2M` |
 | `per` | Rate denominator | `100 MB per day` | `100 MB/day` |
 | `over` | Accumulation | `100 MB/s over 1 day` | `~8.64 TB` |
 | `at...per` | Capacity | `10 TB at 2 TB per disk` | `5 disk` |

--- a/site/content/docs/user-guide/frontmatter.md
+++ b/site/content/docs/user-guide/frontmatter.md
@@ -74,7 +74,7 @@ The summary renders with **$1.8M** and **$150K** substituted in. If a variable i
 
 #### Inline Patterns
 
-Interpolated values render **bold** in markdown output and are wrapped in `<span class="cm-interpolated">` in HTML. You can combine them with other markdown formatting:
+Interpolated values render **bold** in Markdown output and are wrapped in `<span class="cm-interpolated">` in HTML. You can combine them with other Markdown formatting:
 
 ```text
 The grand total is {{total_cost}}.

--- a/site/content/docs/user-guide/functions.md
+++ b/site/content/docs/user-guide/functions.md
@@ -79,9 +79,9 @@ capacity(10000 req/s, 500 req/s, server) -> 20 servers
 #### `downtime` {#downtime-examples}
 
 ```calcmark
-downtime(0.999, year)              -> 8.76 hours
-downtime(0.999, month)             -> 43.2 minutes
-downtime(0.9999, month)            -> 4.32 minutes
+downtime(0.999, year)              -> 8.76 hour
+downtime(0.999, month)             -> 43.2 minute
+downtime(0.9999, month)            -> 4.32 minute
 ```
 
 #### `rtt` {#rtt-examples}
@@ -97,7 +97,7 @@ rtt(global)                        -> 150 ms
 
 ```calcmark
 throughput(gigabit)                 -> 125 MB/s
-throughput(ten_gig)                -> 1250 MB/s
+throughput(ten_gig)                -> 1.22 GB/s
 throughput(wifi)                   -> 12.5 MB/s
 throughput(five_g)                 -> 50 MB/s
 ```
@@ -140,7 +140,7 @@ db_query_hdd = seek(hdd) + read(5 MB, hdd)
 ```calcmark
 compress(1 GB, gzip)               -> ~333 MB
 compress(500 MB, lz4)              -> ~250 MB
-compress(2 GB, zstd)               -> ~571 MB
+compress(2 GB, zstd)               -> 585 MB
 compress 1 GB using gzip            -> (NL form)
 compress 500 MB using lz4
 
@@ -293,8 +293,8 @@ transfer 1 GB across regional gigabit       (NL form)
 #### Downtime from Availability
 
 ```calcmark
-downtime(99.9%, year)     -> ~8.76 hours
-downtime(99.99%, month)   -> ~4.32 minutes
+downtime(99.9%, year)     -> 8.76 hour
+downtime(99.99%, month)   -> 4.32 minute
 ```
 
 ### Storage Functions {#storage-functions}

--- a/site/content/larky.md
+++ b/site/content/larky.md
@@ -9,7 +9,7 @@ description: "Meet Larky, the CalcMark Lark."
 
 ## Larky is the CalcMark Lark
 
-Every good project needs a mascot. Ours is **Larky** — a chunky pixel lark, a cheeky sideways glance, a proud little crest, and a distinctive wing fold.
+Every good project needs a mascot. Ours is **Larky** — a chunky pixel lark with a cheeky sideways glance, a proud little crest, and a distinctive wing fold.
 
 ### Why a lark?
 

--- a/site/hugo.yaml
+++ b/site/hugo.yaml
@@ -12,7 +12,7 @@ disableKinds:
 enableGitInfo: true
 
 params:
-  description: "Calculations embedded in markdown documents."
+  description: "Calculations embedded in Markdown documents."
   githubURL: "https://github.com/CalcMark/go-calcmark"
   # Version is injected at build time via HUGO_PARAMS_version environment variable.
   # Falls back to "dev" for local builds.
@@ -37,9 +37,6 @@ menus:
     - name: Docs
       url: /docs/
       weight: 10
-    - name: Examples
-      url: /docs/examples/
-      weight: 20
     - name: Larky
       url: /larky/
       weight: 25
@@ -60,9 +57,6 @@ menus:
     - name: User Guide
       url: /docs/user-guide/
       weight: 20
-    - name: Domain Recipes
-      url: /guides/
-      weight: 25
     - name: Thinking in CalcMark
       url: /guides/thinking-in-calcmark/
       weight: 24
@@ -101,6 +95,3 @@ menus:
     - name: Configuration
       url: /docs/configuration/
       weight: 43
-    - name: Examples
-      url: /docs/examples/
-      weight: 50

--- a/site/layouts/_default/home.html
+++ b/site/layouts/_default/home.html
@@ -7,12 +7,12 @@
       <img src="{{ $larkColor.RelPermalink }}" alt="Larky the CalcMark Lark" class="hero-lark">
       <img src="{{ $logoColor.RelPermalink }}" alt="cm" class="hero-cm">
     </div>
-    <h1 class="hero-headline">Calculations embedded<br>in markdown documents.</h1>
-    <p class="hero-sub">Write your thinking in plain text. Add calculations that reference each other. Watch results update as you type.</p>
+    <h1 class="hero-headline">It&rsquo;s just Markdown.<br>Until it starts calculating.</h1>
+    <p class="hero-sub">Write your document in plain Markdown. CalcMark understands variables, converts units and currencies, then shows results &mdash; all while you type.</p>
     <div class="hero-install">
       <pre class="install-cmd"><code>brew install calcmark/tap/calcmark</code></pre>
       <div class="hero-actions">
-        <a href="https://lark.calcmark.org" class="btn btn-primary">Try it live!</a>
+        <a href="https://lark.calcmark.org" class="btn btn-primary btn-lark"><img src="{{ $larkColor.RelPermalink }}" alt="" class="btn-lark-icon" aria-hidden="true">Try it live!</a>
         <a href="{{ "docs/getting-started/" | relURL }}" class="btn btn-secondary">Get Started</a>
         <a href="https://github.com/CalcMark/agent-skill" class="btn btn-secondary">Install for Your AI Agent</a>
       </div>
@@ -119,6 +119,16 @@ total_cost = headcount * rate <span class="r">$1.8M</span></code></pre>
 <span class="c">$</span> cm eval budget.cm --format json
 <span class="c">$</span> cm convert report.cm --to html</code></pre>
       <a class="feature-link" href="/docs/agent-integration/">Agent &amp; API integration &rarr;</a>
+    </div>
+
+    <div class="feature-card">
+      <h3>VS Code extension</h3>
+      <p>Syntax highlighting, live preview, and export to HTML, Markdown, or JSON &mdash; all inside your editor.</p>
+      <pre class="feature-snippet"><code><span class="c">&gt;</span> CalcMark: Open Preview
+<span class="c">&gt;</span> CalcMark: Export to HTML
+<span class="c">&gt;</span> CalcMark: Export to Markdown
+<span class="c">&gt;</span> CalcMark: Export to JSON</code></pre>
+      <a class="feature-link" href="https://marketplace.visualstudio.com/items?itemName=calcmark.vscode-calcmark">Install from Marketplace &rarr;</a>
     </div>
 
   </div>

--- a/site/layouts/partials/nav.html
+++ b/site/layouts/partials/nav.html
@@ -1,12 +1,15 @@
 <header class="site-nav">
   <div class="container nav-inner">
     {{- $lark := resources.Get "images/lark.svg" | fingerprint -}}
+    {{- $larkColor := resources.Get "images/lark-color.svg" | fingerprint -}}
     <a href="{{ "/" | relURL }}" class="nav-logo"><img src="{{ $lark.RelPermalink }}" alt="" class="nav-logo-icon" aria-hidden="true">CalcMark</a>
     <nav class="nav-links" aria-label="Main navigation">
       {{ range .Site.Menus.main }}
       <a class="nav-link{{ if or ($.IsMenuCurrent "main" .) ($.HasMenuCurrent "main" .) }} nav-link--active{{ end }}"
          href="{{ .URL }}"{{ with .Params.external }} target="_blank" rel="noopener"{{ end }}>{{ .Name }}</a>
       {{ end }}
+      <a class="nav-link nav-link--lark"
+         href="https://lark.calcmark.org" target="_blank" rel="noopener"><img src="{{ $larkColor.RelPermalink }}" alt="" class="nav-lark-icon" aria-hidden="true">Try it live</a>
     </nav>
     {{ partial "theme-toggle.html" . }}
   </div>


### PR DESCRIPTION
## Summary

- **Hero**: New copy — "It's just Markdown. Until it starts calculating."
- **Nav**: "Try it live" link with lark icon, positioned last before theme toggle
- **Landing**: Lark icon on CTA button, new VS Code extension feature card
- **Navigation**: Merged Domain Recipes into Examples page (3 tiers: Tutorials, Worked Examples, Feature Reference)
- **Doc audit**: Fixed 6 inaccuracies, added 4 missing sections, capitalized Markdown across 13 files
- **CLI ref**: Added `cm watch`, `cm lsp`, help flag forms, `unicode_fractions` config

## Testing

- `task site:build` passes (docgen + doceval + hugo, 0 errors)
- `task test` — all 30 packages pass
- `task quality` — all checks pass

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: documentation-only changes with no runtime impact.

---

🤖 Generated with Claude Opus 4.6 (1M context) via [Claude Code](https://claude.com/claude-code)