### PR TITLE
fix: `as napkin` missing ~ prefix on number and currency results

### DIFF
--- a/cmd/calcmark/cmd/embedded_test.go
+++ b/cmd/calcmark/cmd/embedded_test.go
@@ -450,15 +450,15 @@ func TestEmbedded_GoldmarkValidation(t *testing.T) {
 
 	// Verify key structural elements are present in the parsed AST.
 	checks := map[string]ast.NodeKind{
-		"Heading":        ast.KindHeading,
+		"Heading":         ast.KindHeading,
 		"FencedCodeBlock": ast.KindFencedCodeBlock,
-		"Blockquote":     ast.KindBlockquote,
-		"List":           ast.KindList,
-		"Link":           ast.KindLink,
-		"Image":          ast.KindImage,
-		"ThematicBreak":  ast.KindThematicBreak,
-		"HTMLBlock":      ast.KindHTMLBlock,
-		"Paragraph":      ast.KindParagraph,
+		"Blockquote":      ast.KindBlockquote,
+		"List":            ast.KindList,
+		"Link":            ast.KindLink,
+		"Image":           ast.KindImage,
+		"ThematicBreak":   ast.KindThematicBreak,
+		"HTMLBlock":       ast.KindHTMLBlock,
+		"Paragraph":       ast.KindParagraph,
 	}
 
 	for name, kind := range checks {

--- a/docs/plans/2026-03-19-001-fix-napkin-tilde-prefix-number-currency-plan.md
+++ b/docs/plans/2026-03-19-001-fix-napkin-tilde-prefix-number-currency-plan.md
@@ -1,0 +1,153 @@
+---
+title: "fix: `as napkin` missing ~ prefix on number and currency results"
+type: fix
+status: completed
+date: 2026-03-19
+---
+
+# fix: `as napkin` missing ~ prefix on number and currency results
+
+## Overview
+
+`as napkin` produces the `~` approximate prefix for quantities and fractions but not for plain numbers or currencies. The `~` signals approximation, which applies to all napkin results regardless of type.
+
+| Input | Current Output | Expected Output |
+|-------|---------------|-----------------|
+| `1234567 as napkin` | `1.2M` | `~1.2M` |
+| `$1234567 as napkin` | `$1.2M` | `~$1.2M` |
+| `1234567 GB as napkin` | `~1.14 PB` | `~1.14 PB` (correct) |
+
+Related: [#79](https://github.com/CalcMark/go-calcmark/issues/79)
+
+## Root Cause
+
+Only `types.Quantity` and `types.Fraction` have an `IsNapkin bool` field. `types.Number` and `types.Currency` lack it entirely. The interpreter sets `IsNapkin = true` for Quantity/Fraction in `evalNapkinConversion`, and the display formatter checks the flag — but Number and Currency have no flag to set or check.
+
+## Proposed Solution
+
+Follow the established `IsNapkin` bool pattern (per institutional learning from `display-formatter-overrides-explicit-unit-conversion.md`):
+
+1. Add `IsNapkin bool` to `types.Number` and `types.Currency`
+2. Set `IsNapkin = true` in `evalNapkinConversion` for both types
+3. Add `~` prefix in display formatter for both types
+4. Set `IsApproximate = true` in JSON formatter for both types
+
+## Acceptance Criteria
+
+- [ ] `1234567 as napkin` displays `~1.2M`
+- [ ] `$1234567 as napkin` displays `~$1.2M`
+- [ ] `-1234567 as napkin` displays `~-1.2M`
+- [ ] `-$1234567 as napkin` displays `~-$1.2M`
+- [ ] `47 as napkin` displays `~47` (small numbers still get prefix)
+- [ ] `$42.50 as napkin` displays `~$43`
+- [ ] JSON output: `is_approximate: true` for napkin numbers and currencies
+- [ ] Existing quantity/fraction napkin behavior unchanged
+- [ ] `task test` passes
+- [ ] `task quality` passes
+
+## MVP
+
+### Layer 1: Types — `spec/types/number.go` and `spec/types/currency.go`
+
+Add `IsNapkin bool` field to both structs. No constructor changes needed — the field defaults to `false` and is only set by the interpreter.
+
+```go
+// number.go
+type Number struct {
+	Value    decimal.Decimal
+	IsNapkin bool
+}
+
+// currency.go
+type Currency struct {
+	Value    decimal.Decimal
+	Symbol   string
+	Code     string
+	IsNapkin bool
+}
+```
+
+### Layer 2: Interpreter — `impl/interpreter/napkin_eval.go`
+
+Set `IsNapkin = true` on Number and Currency results:
+
+```go
+case *types.Number:
+	rounded := roundToNapkinPrecision(v.Value)
+	return &types.Number{Value: rounded, IsNapkin: true}, nil
+
+case *types.Currency:
+	rounded := roundToNapkinPrecision(v.Value)
+	return &types.Currency{Value: rounded, Symbol: v.Symbol, Code: v.Code, IsNapkin: true}, nil
+```
+
+### Layer 3: Display — `format/display/formatter.go`
+
+Add `~` prefix in the `Format()` dispatch for Number, and in `FormatCurrency` for Currency (since it already receives the struct):
+
+```go
+// In Format():
+case *types.Number:
+	s := f.FormatNumber(v.Value)
+	if v.IsNapkin {
+		return "~" + s
+	}
+	return s
+
+// In FormatCurrency():
+func (f Formatter) FormatCurrency(c *types.Currency) string {
+	// ... existing formatting logic ...
+	result := symbol + sep + numStr  // or "-" + symbol + sep + numStr
+	if c.IsNapkin {
+		return "~" + result
+	}
+	return result
+}
+```
+
+### Layer 4: JSON — `format/json_formatter.go`
+
+Add `IsApproximate` for Number and Currency in `populateResult`:
+
+```go
+case *types.Number:
+	jr.Type = "number"
+	f := v.Value.InexactFloat64()
+	jr.NumericValue = &f
+	if v.IsNapkin {
+		jr.IsApproximate = true
+	}
+case *types.Currency:
+	jr.Type = "currency"
+	f := v.Value.InexactFloat64()
+	jr.NumericValue = &f
+	jr.Unit = v.Code
+	if v.IsNapkin {
+		jr.IsApproximate = true
+	}
+```
+
+### Layer 5: Tests
+
+**`impl/interpreter/napkin_eval_test.go`** — Add/update tests:
+- Number napkin sets `IsNapkin = true`
+- Currency napkin sets `IsNapkin = true`
+- Display output includes `~` prefix for both
+
+**`format/display/display_test.go`** — Add tests:
+- `FormatNumber` via `Format(*types.Number{IsNapkin: true})` produces `~` prefix
+- `FormatCurrency` with `IsNapkin: true` produces `~` prefix
+
+**`format/json_formatter_test.go`** — Add tests:
+- Number napkin → `is_approximate: true`
+- Currency napkin → `is_approximate: true`
+
+**`testdata/eval/success/features/napkin.cm`** — Update golden file with `~` prefix on number/currency results.
+
+**TUI catwalk test** — If existing catwalk tests cover napkin numbers, update expected output.
+
+## Sources
+
+- GitHub issue: [#79](https://github.com/CalcMark/go-calcmark/issues/79)
+- Institutional learning: `docs/solutions/ui-bugs/display-formatter-overrides-explicit-unit-conversion.md` — documents the `IsNapkin` bool pattern
+- Institutional learning: `docs/solutions/ui-bugs/currency-code-output-spacing.md` — currency display spacing rules to preserve

--- a/format/display/formatter.go
+++ b/format/display/formatter.go
@@ -68,7 +68,11 @@ func (f Formatter) Format(t types.Type) string {
 
 	switch v := t.(type) {
 	case *types.Number:
-		return f.FormatNumber(v.Value)
+		s := f.FormatNumber(v.Value)
+		if v.IsNapkin {
+			return "~" + s
+		}
+		return s
 	case *types.Quantity:
 		return f.FormatQuantity(v)
 	case *types.Rate:
@@ -236,10 +240,16 @@ func (f Formatter) FormatCurrency(c *types.Currency) string {
 		numStr = f.localizeDecimal(c.Value.Abs().StringFixed(int32(decimals)))
 	}
 
+	var result string
 	if isNegative {
-		return "-" + symbol + sep + numStr
+		result = "-" + symbol + sep + numStr
+	} else {
+		result = symbol + sep + numStr
 	}
-	return symbol + sep + numStr
+	if c.IsNapkin {
+		return "~" + result
+	}
+	return result
 }
 
 // FormatDuration formats a duration in human-readable form.

--- a/format/json_formatter.go
+++ b/format/json_formatter.go
@@ -90,11 +90,17 @@ func populateResult(jr *JSONResult, result types.Type) {
 		jr.Type = "number"
 		f := v.Value.InexactFloat64()
 		jr.NumericValue = &f
+		if v.IsNapkin {
+			jr.IsApproximate = true
+		}
 	case *types.Currency:
 		jr.Type = "currency"
 		f := v.Value.InexactFloat64()
 		jr.NumericValue = &f
 		jr.Unit = v.Code
+		if v.IsNapkin {
+			jr.IsApproximate = true
+		}
 	case *types.Quantity:
 		jr.Type = "quantity"
 		f := v.Value.InexactFloat64()

--- a/format/json_formatter_test.go
+++ b/format/json_formatter_test.go
@@ -654,6 +654,56 @@ func TestJSONFormatterNapkinEstimate(t *testing.T) {
 	}
 }
 
+// TestJSONFormatterNapkinNumber verifies is_approximate for napkin numbers.
+func TestJSONFormatterNapkinNumber(t *testing.T) {
+	result := formatJSON(t, "estimate = 1234567 as napkin\n", Options{})
+
+	block := findCalcBlock(result)
+	if block == nil {
+		t.Fatal("Expected a calculation block")
+	}
+
+	if len(block.Results) < 1 {
+		t.Fatal("Expected at least one result")
+	}
+
+	r := block.Results[0]
+	if r.Type != "number" {
+		t.Errorf("Type = %q, want %q", r.Type, "number")
+	}
+	if !r.IsApproximate {
+		t.Error("IsApproximate should be true for napkin number")
+	}
+	if r.Value != "~1.2M" {
+		t.Errorf("Value = %q, want %q", r.Value, "~1.2M")
+	}
+}
+
+// TestJSONFormatterNapkinCurrency verifies is_approximate for napkin currencies.
+func TestJSONFormatterNapkinCurrency(t *testing.T) {
+	result := formatJSON(t, "estimate = $1234567 as napkin\n", Options{})
+
+	block := findCalcBlock(result)
+	if block == nil {
+		t.Fatal("Expected a calculation block")
+	}
+
+	if len(block.Results) < 1 {
+		t.Fatal("Expected at least one result")
+	}
+
+	r := block.Results[0]
+	if r.Type != "currency" {
+		t.Errorf("Type = %q, want %q", r.Type, "currency")
+	}
+	if !r.IsApproximate {
+		t.Error("IsApproximate should be true for napkin currency")
+	}
+	if r.Value != "~$1.2M" {
+		t.Errorf("Value = %q, want %q", r.Value, "~$1.2M")
+	}
+}
+
 // TestJSONFormatterFractionASCII verifies that JSON output uses ASCII fractions,
 // never Unicode Number Forms.
 func TestJSONFormatterFractionASCII(t *testing.T) {

--- a/impl/interpreter/napkin_eval.go
+++ b/impl/interpreter/napkin_eval.go
@@ -31,7 +31,7 @@ func (interp *Interpreter) evalNapkinConversion(n *ast.NapkinConversion) (types.
 	switch v := value.(type) {
 	case *types.Number:
 		rounded := roundToNapkinPrecision(v.Value)
-		return types.NewNumber(rounded), nil
+		return &types.Number{Value: rounded, IsNapkin: true}, nil
 
 	case *types.Quantity:
 		// Round the value, then normalize to human-friendly unit
@@ -47,7 +47,7 @@ func (interp *Interpreter) evalNapkinConversion(n *ast.NapkinConversion) (types.
 	case *types.Currency:
 		// Preserve symbol, round value
 		rounded := roundToNapkinPrecision(v.Value)
-		return types.NewCurrency(rounded, v.Symbol), nil
+		return &types.Currency{Value: rounded, Symbol: v.Symbol, Code: v.Code, IsNapkin: true}, nil
 
 	case *types.Duration:
 		// Preserve unit, round value (keep in original unit)

--- a/impl/interpreter/napkin_eval_test.go
+++ b/impl/interpreter/napkin_eval_test.go
@@ -222,6 +222,126 @@ func TestNapkinTypePreservation(t *testing.T) {
 	}
 }
 
+// TestNapkinNumberIsNapkinFlag verifies that napkin conversion sets IsNapkin=true
+// on Number results, enabling tilde prefix in display formatting.
+func TestNapkinNumberIsNapkinFlag(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantDisplay string
+	}{
+		{
+			name:        "large number shows tilde",
+			input:       "x = 1234567 as napkin\n",
+			wantDisplay: "~1.2M",
+		},
+		{
+			name:        "small number shows tilde",
+			input:       "x = 47 as napkin\n",
+			wantDisplay: "~47",
+		},
+		{
+			name:        "negative number shows tilde",
+			input:       "x = -1234567 as napkin\n",
+			wantDisplay: "~-1.2M",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, err := parser.Parse(tt.input)
+			if err != nil {
+				t.Fatalf("Parse error: %v", err)
+			}
+
+			interp := NewInterpreter()
+			results, err := interp.Eval(nodes)
+			if err != nil {
+				t.Fatalf("Eval error: %v", err)
+			}
+
+			if len(results) == 0 {
+				t.Fatal("No results returned")
+			}
+
+			result := results[0]
+			n, ok := result.(*types.Number)
+			if !ok {
+				t.Fatalf("Expected *types.Number, got %T", result)
+			}
+
+			if !n.IsNapkin {
+				t.Error("Expected IsNapkin=true, got false")
+			}
+
+			formatted := display.Format(result)
+			if formatted != tt.wantDisplay {
+				t.Errorf("Expected display %q, got %q", tt.wantDisplay, formatted)
+			}
+		})
+	}
+}
+
+// TestNapkinCurrencyIsNapkinFlag verifies that napkin conversion sets IsNapkin=true
+// on Currency results, enabling tilde prefix in display formatting.
+func TestNapkinCurrencyIsNapkinFlag(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantDisplay string
+	}{
+		{
+			name:        "large currency shows tilde",
+			input:       "x = $1234567 as napkin\n",
+			wantDisplay: "~$1.2M",
+		},
+		{
+			name:        "small currency shows tilde",
+			input:       "x = $42.50 as napkin\n",
+			wantDisplay: "~$43.00",
+		},
+		{
+			name:        "negative currency shows tilde",
+			input:       "x = -$1234567 as napkin\n",
+			wantDisplay: "~-$1.2M",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, err := parser.Parse(tt.input)
+			if err != nil {
+				t.Fatalf("Parse error: %v", err)
+			}
+
+			interp := NewInterpreter()
+			results, err := interp.Eval(nodes)
+			if err != nil {
+				t.Fatalf("Eval error: %v", err)
+			}
+
+			if len(results) == 0 {
+				t.Fatal("No results returned")
+			}
+
+			result := results[0]
+			c, ok := result.(*types.Currency)
+			if !ok {
+				t.Fatalf("Expected *types.Currency, got %T", result)
+			}
+
+			if !c.IsNapkin {
+				t.Error("Expected IsNapkin=true, got false")
+			}
+
+			formatted := display.Format(result)
+			if formatted != tt.wantDisplay {
+				t.Errorf("Expected display %q, got %q", tt.wantDisplay, formatted)
+			}
+		})
+	}
+}
+
 // TestNapkinQuantityIsNapkinFlag verifies that napkin conversion sets IsNapkin=true
 // on Quantity results, enabling tilde prefix in display formatting.
 func TestNapkinQuantityIsNapkinFlag(t *testing.T) {

--- a/spec/types/currency.go
+++ b/spec/types/currency.go
@@ -9,9 +9,10 @@ import (
 // Currency represents a monetary value with a currency symbol and ISO code.
 // It preserves both the display symbol (e.g., "$") and the normalized ISO code (e.g., "USD").
 type Currency struct {
-	Value  decimal.Decimal
-	Symbol string // Display symbol: "$", "€", "£", "¥", or ISO code like "USD"
-	Code   string // Normalized ISO 4217 code: "USD", "EUR", "GBP", "JPY"
+	Value    decimal.Decimal
+	Symbol   string // Display symbol: "$", "€", "£", "¥", or ISO code like "USD"
+	Code     string // Normalized ISO 4217 code: "USD", "EUR", "GBP", "JPY"
+	IsNapkin bool   // true when produced by `as napkin` conversion
 }
 
 // SymbolToCode maps currency symbols to their ISO 4217 codes.

--- a/spec/types/number.go
+++ b/spec/types/number.go
@@ -5,7 +5,8 @@ import "github.com/shopspring/decimal"
 // Number represents an arbitrary-precision decimal number.
 // It uses the shopspring/decimal package for accurate decimal arithmetic.
 type Number struct {
-	Value decimal.Decimal
+	Value    decimal.Decimal
+	IsNapkin bool // true when produced by `as napkin` conversion
 }
 
 // NewNumber creates a new Number from a decimal.Decimal value.


### PR DESCRIPTION
## Summary

- Add `IsNapkin bool` to `types.Number` and `types.Currency`, following the established pattern on `Quantity` and `Fraction`
- Set `IsNapkin = true` in `evalNapkinConversion` for both types
- Display formatter prepends `~` for napkin numbers and currencies
- JSON formatter sets `is_approximate: true` for both types

| Input | Before | After |
|-------|--------|-------|
| `1234567 as napkin` | `1.2M` | `~1.2M` |
| `$1234567 as napkin` | `$1.2M` | `~$1.2M` |
| `1234567 GB as napkin` | `~1.14 PB` | `~1.14 PB` (unchanged) |

Closes #79

## Test plan

- [x] `TestNapkinNumberIsNapkinFlag` — large, small, negative numbers get `~` prefix
- [x] `TestNapkinCurrencyIsNapkinFlag` — large, small, negative currencies get `~` prefix
- [x] `TestJSONFormatterNapkinNumber` — `is_approximate: true` in JSON output
- [x] `TestJSONFormatterNapkinCurrency` — `is_approximate: true` in JSON output
- [x] All existing napkin tests pass (quantity, fraction behavior unchanged)
- [x] `task test` — 31/31 packages pass
- [x] `task quality` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)