### PR TITLE
fix: use --title flag for release velocity discussion titles

### DIFF
--- a/.github/workflows/velocity-release.yml
+++ b/.github/workflows/velocity-release.yml
@@ -41,4 +41,4 @@ jobs:
           else
             TAG="$RELEASE_TAG"
           fi
-          gh velocity quality release "$TAG" --post
+          gh velocity quality release "$TAG" --post --title "Release Velocity: $TAG"


### PR DESCRIPTION
## Summary

- Use the new gh-velocity v0.1.6 `--title` flag to set release discussion titles to "Release Velocity: <tag>"
- This prevents release posts from using the global weekly title template ("Weekly Velocity: ...")

## Context

Added `--title` flag upstream in dvhthomas/gh-velocity#160 (released in v0.1.6).

## Test plan

- [ ] Trigger `velocity-release.yml` via `workflow_dispatch` with a tag and verify the Discussion title is "Release Velocity: <tag>"

<!-- gh-velocity:pr:101 -->
### Metrics

Opened by @dvhthomas (agent-assisted) on 2026-03-21 19:32 UTC. Merged 2026-03-21 19:32 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 4s  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
