### PR TITLE
fix: currency/duration division, date subtraction sign, and rate display

### DIFF
--- a/format/display/display_test.go
+++ b/format/display/display_test.go
@@ -110,6 +110,17 @@ func TestFormatRate(t *testing.T) {
 		{"1.5M bytes/s normalized", "1500000", "bytes", "second", "1.43 MB/s"}, // known unit: normalized
 		{"small rate", "100", "requests", "minute", "100 requests/min"},        // arbitrary unit
 		{"1000 meters/hour", "1000", "m", "hour", "1 km/h"},                    // meters → km
+		// Currency-symbol rates: prefix symbol, no space
+		{"dollar rate", "363.46", "$", "day", "$363.46/day"},
+		{"euro rate", "50", "€", "hour", "€50.00/h"},
+		{"pound rate", "1200", "£", "month", "£1,200.00/month"},
+		{"yen rate", "5000", "¥", "year", "¥5,000/year"},
+		// ISO code rates: postfix code with space
+		{"EUR code rate", "100", "EUR", "day", "100 EUR/day"},
+		// Large currency rate with suffix
+		{"large dollar rate", "50000", "$", "month", "$50K/month"},
+		// Negative currency rate
+		{"negative dollar rate", "-363.46", "$", "day", "-$363.46/day"},
 	}
 
 	for _, tt := range tests {

--- a/format/display/formatter.go
+++ b/format/display/formatter.go
@@ -194,13 +194,22 @@ func (f Formatter) formatExplicitQuantity(q *types.Quantity) string {
 }
 
 // FormatRate formats a rate (quantity per time) in human-readable form.
+// When the rate's amount unit is a currency symbol ($, €, £, ¥), the symbol
+// is rendered as a prefix (e.g., "$363.46/day") matching FormatCurrency style.
 func (f Formatter) FormatRate(r *types.Rate) string {
 	if r == nil || r.Amount == nil {
 		return "0/s"
 	}
 
-	normValue, normUnit := NormalizeForDisplay(r.Amount.Value, r.Amount.Unit)
 	timeAbbrev := abbreviateTimeUnit(r.PerUnit)
+
+	// Currency-symbol rates: format like "$363.46/day" not "363.46 $/day"
+	if _, isCurrencySymbol := types.SymbolToCode[r.Amount.Unit]; isCurrencySymbol {
+		cur := types.NewCurrency(r.Amount.Value, r.Amount.Unit)
+		return fmt.Sprintf("%s/%s", f.FormatCurrency(cur), timeAbbrev)
+	}
+
+	normValue, normUnit := NormalizeForDisplay(r.Amount.Value, r.Amount.Unit)
 
 	if normUnit != r.Amount.Unit {
 		numStr := f.formatNormalizedQuantity(normValue, normUnit)

--- a/impl/interpreter/date_test.go
+++ b/impl/interpreter/date_test.go
@@ -332,24 +332,22 @@ func TestDateLiteralArithmetic(t *testing.T) {
 }
 
 // TestDateDifference tests date - date expressions.
-// NOTE: Current implementation has inverted subtraction order.
-// Jan 2 - Jan 1 returns -1 day instead of +1 day.
-// This test documents current behavior; fix the implementation if this is wrong.
+// left - right should produce (left - right) days with correct sign.
 func TestDateDifference(t *testing.T) {
 	tests := []struct {
 		name     string
 		input    string
-		wantDays int64 // In days (may be negative due to subtraction order)
+		wantDays int64
 	}{
 		{
-			name:     "Jan 2 2025 - Jan 1 2025 (returns negative due to impl)",
+			name:     "Jan 2 2025 - Jan 1 2025 = 1 day",
 			input:    "d = Jan 2 2025 - Jan 1 2025\n",
-			wantDays: -1, // Implementation computes right - left
+			wantDays: 1, // Later date - earlier date = positive
 		},
 		{
-			name:     "Jan 1 2025 - Jan 8 2025 (returns positive)",
+			name:     "Jan 1 2025 - Jan 8 2025 = -7 days",
 			input:    "d = Jan 1 2025 - Jan 8 2025\n",
-			wantDays: 7, // Implementation computes right - left = Jan 8 - Jan 1
+			wantDays: -7, // Earlier date - later date = negative
 		},
 	}
 
@@ -381,6 +379,50 @@ func TestDateDifference(t *testing.T) {
 				t.Errorf("Got %d days, want %d days", gotDays, tt.wantDays)
 			}
 		})
+	}
+}
+
+// TestCurrencyDividedByDurationVariable tests that dividing a currency by a
+// duration variable produces a rate: $1453.84 / 4 days = $363.46/day.
+// Using number(days) gives plain currency division instead.
+func TestCurrencyDividedByDurationVariable(t *testing.T) {
+	input := `arrive = Apr 22
+depart = April 26
+days = depart - arrive
+total = $1,453.84
+daily = total / days
+`
+	interp := NewInterpreter()
+
+	nodes, err := parser.Parse(input)
+	if err != nil {
+		t.Fatalf("Parse error: %v", err)
+	}
+
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval error: %v", err)
+	}
+
+	// Find the "daily" result (last one)
+	daily := results[len(results)-1]
+
+	rate, ok := daily.(*types.Rate)
+	if !ok {
+		t.Fatalf("Expected daily to be *types.Rate, got %T (%v)", daily, daily)
+	}
+
+	// $1,453.84 / 4 days = $363.46/day
+	expected := "363.46"
+	got := rate.Amount.Value.StringFixed(2)
+	if got != expected {
+		t.Errorf("Expected rate amount = %s, got %s", expected, got)
+	}
+	if rate.Amount.Unit != "$" {
+		t.Errorf("Expected rate unit '$', got '%s'", rate.Amount.Unit)
+	}
+	if rate.PerUnit != "day" {
+		t.Errorf("Expected per unit 'day', got '%s'", rate.PerUnit)
 	}
 }
 

--- a/impl/interpreter/operators.go
+++ b/impl/interpreter/operators.go
@@ -231,6 +231,20 @@ func evalBinaryOperation(left, right types.Type, operator string) (types.Type, e
 				return types.NewCurrency(leftCur.Value.Div(rightNum.Value), leftCur.Symbol), nil
 			}
 		}
+		// Currency / Duration → Rate (divide value by duration magnitude)
+		// e.g., "$1000 / 4 days" = "$250/day"
+		if rightDur, ok := right.(*types.Duration); ok && operator == "/" {
+			if rightDur.Value.IsZero() {
+				return nil, fmt.Errorf("division by zero")
+			}
+			return &types.Rate{
+				Amount: &types.Quantity{
+					Value: leftCur.Value.Div(rightDur.Value),
+					Unit:  leftCur.Symbol,
+				},
+				PerUnit: types.NormalizeTimeUnit(rightDur.Unit),
+			}, nil
+		}
 		// Currency op Currency (same type)
 		if rightCur, ok := right.(*types.Currency); ok {
 			if !leftCur.IsSameCurrency(rightCur) { // #95: compare by Code so $ and USD match

--- a/site/content/docs/examples/project-workback/_index.md
+++ b/site/content/docs/examples/project-workback/_index.md
@@ -14,20 +14,20 @@ The complete CalcMark file is available at {{< repo-file path="testdata/examples
 
 ## Key Dates
 
-Start by pinning the two anchors of your schedule: the launch date and today. Subtracting one date from another gives you a duration.
+Start by pinning the two anchors of your schedule: the kickoff date and the launch date. Subtracting one date from another gives you a duration.
 
 ```calcmark
+kickoff = Jan 6 2025
 launch_date = Mar 15 2025
-kickoff = today
 
 Days until launch:
 
 days_to_launch = launch_date - kickoff
 ```
 
-`Mar 15 2025` is a date literal -- CalcMark parses it directly. The `today` keyword resolves to the current date at runtime. Subtracting two dates produces a duration in days.
+`Mar 15 2025` and `Jan 6 2025` are date literals -- CalcMark parses them directly. Subtracting two dates produces a duration in days.
 
-**CalcMark features:** Date literals (`Mar 15 2025`); `today` keyword; date subtraction producing a duration.
+**CalcMark features:** Date literals (`Mar 15 2025`); date subtraction producing a duration.
 
 ---
 
@@ -224,8 +224,8 @@ If `needed_time` exceeds `available_time`, you need to cut scope or extend the d
 
 This example showcases the following CalcMark features:
 
-- **Date literals** -- `Mar 15 2025`
-- **`today` keyword** -- resolves to the current date at runtime
+- **Date literals** -- `Jan 6 2025`, `Mar 15 2025`
+- **`today` keyword** -- resolves to the current date at runtime (used with `from`)
 - **Date arithmetic** -- subtracting dates, adding/subtracting durations from dates
 - **Duration literals** -- `weeks`, `days`, `month`
 - **Duration arithmetic** -- adding and subtracting mixed-unit durations

--- a/site/content/docs/language-reference.md
+++ b/site/content/docs/language-reference.md
@@ -484,6 +484,7 @@ Currency + Currency (different symbols) -> Number  (units dropped)
 Quantity + Quantity (same unit) -> Quantity
 Date + Duration -> Date
 Date - Date -> Duration
+Currency / Duration -> Rate  ($1000 / 4 days = $250/day)
 Rate * Duration -> Quantity  (via "over" keyword)
 Speed * Duration -> Quantity  (bridge: 60 mph * 2 hours = 120 mi)
 Number * Rate -> Rate        (scaling: 3 * 10 MB/s = 30 MB/s)

--- a/site/content/guides/thinking-in-calcmark/_index.md
+++ b/site/content/guides/thinking-in-calcmark/_index.md
@@ -175,7 +175,7 @@ monthly_commute = fare over 1 month
 {{< /tab >}}
 {{< tab name="Editor" >}}
 ```text
-fare = $5.50/day                     5.5 $/day
+fare = $5.50/day                     $5.50/day
 monthly_commute = fare over 1 ...    $165.00
 ```
 {{< /tab >}}
@@ -184,7 +184,7 @@ monthly_commute = fare over 1 ...    $165.00
 [
   {
     "source": "fare = $5.50/day",
-    "value": "5.5 $/day",
+    "value": "$5.50/day",
     "type": "rate",
     "numeric_value": 5.5,
     "unit": "$/day",

--- a/spec/parser/rate_helpers.go
+++ b/spec/parser/rate_helpers.go
@@ -81,7 +81,18 @@ func (p *RecursiveDescentParser) parseCapacityValue() (ast.Node, error) {
 // tryParseRateFromDivision attempts to parse a rate from a division operator followed by a time unit.
 // Returns (rateNode, true) if successful, (nil, false) otherwise.
 // This is a pure function that doesn't modify parser state except for advancing tokens if successful.
+//
+// When the left operand is a bare identifier (variable reference), the division
+// is NOT parsed as a rate. Variables like "total / days" should be arithmetic
+// division, not rate construction. Users should write "total per day" for rates
+// with variables.
 func (p *RecursiveDescentParser) tryParseRateFromDivision(left ast.Node) (*ast.RateLiteral, bool) {
+	// Don't create rates when the left side is a variable reference.
+	// "total / days" is division, not "$total per day".
+	if _, isIdent := left.(*ast.Identifier); isIdent {
+		return nil, false
+	}
+
 	// Check if next token is a time unit identifier (e.g., "s" in "100 MB/s")
 	if !p.check(lexer.IDENTIFIER) {
 		return nil, false

--- a/spec/parser/rate_test.go
+++ b/spec/parser/rate_test.go
@@ -119,6 +119,61 @@ func TestRateParsing(t *testing.T) {
 	}
 }
 
+// TestIdentifierDivisionNotRate verifies that identifier / time_unit is parsed
+// as a division (BinaryOp), not a rate literal. When a variable reference is on
+// the left side of /, the parser should not greedily consume the time-unit
+// denominator as a rate. Users should use "per" for rates with variables.
+func TestIdentifierDivisionNotRate(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "variable / days is division not rate",
+			input: "total / days\n",
+		},
+		{
+			name:  "variable / hours is division not rate",
+			input: "cost / hours\n",
+		},
+		{
+			name:  "variable / month is division not rate",
+			input: "revenue / month\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, err := Parse(tt.input)
+			if err != nil {
+				t.Fatalf("Unexpected parse error: %v", err)
+			}
+
+			if len(nodes) != 1 {
+				t.Fatalf("Expected 1 node, got %d", len(nodes))
+			}
+
+			// Should be BinaryOp (division), NOT RateLiteral
+			binOp, ok := nodes[0].(*ast.BinaryOp)
+			if !ok {
+				t.Fatalf("Expected BinaryOp for variable division, got %T (parser incorrectly created rate literal)", nodes[0])
+			}
+
+			if binOp.Operator != "/" {
+				t.Errorf("Expected operator '/', got '%s'", binOp.Operator)
+			}
+
+			// Both sides should be identifiers
+			if _, ok := binOp.Left.(*ast.Identifier); !ok {
+				t.Errorf("Expected left side to be Identifier, got %T", binOp.Left)
+			}
+			if _, ok := binOp.Right.(*ast.Identifier); !ok {
+				t.Errorf("Expected right side to be Identifier, got %T", binOp.Right)
+			}
+		})
+	}
+}
+
 // TestIdentifierPerDesugarsToConvertRate tests that "identifier per time_unit"
 // desugars to convert_rate(identifier, time_unit) at parse time (issue #87).
 func TestIdentifierPerDesugarsToConvertRate(t *testing.T) {

--- a/spec/types/date.go
+++ b/spec/types/date.go
@@ -59,8 +59,8 @@ func (d *Date) AddDays(days int) *Date {
 	return &Date{Time: newTime}
 }
 
-// DaysBetween returns the number of days between this date and another.
+// DaysBetween returns the number of days from other to this date (d - other).
 func (d *Date) DaysBetween(other *Date) int {
-	duration := other.Time.Sub(d.Time)
+	duration := d.Time.Sub(other.Time)
 	return int(duration.Hours() / 24)
 }

--- a/spec/types/types_test.go
+++ b/spec/types/types_test.go
@@ -134,11 +134,16 @@ func TestDateArithmetic(t *testing.T) {
 		t.Errorf("AddDays(5) from Dec 25 should be Dec 30, got day %d", d2.Time.Day())
 	}
 
-	// Test days between
+	// Test days between: d1.DaysBetween(d3) computes d1 - d3
 	d3, _ := NewDate(2024, 12, 31)
 	days := d1.DaysBetween(d3)
-	if days != 6 {
-		t.Errorf("Days between Dec 25 and Dec 31 should be 6, got %d", days)
+	if days != -6 {
+		t.Errorf("Dec 25 - Dec 31 should be -6, got %d", days)
+	}
+	// Reverse order: Dec 31 - Dec 25 = +6
+	daysReverse := d3.DaysBetween(d1)
+	if daysReverse != 6 {
+		t.Errorf("Dec 31 - Dec 25 should be 6, got %d", daysReverse)
 	}
 }
 

--- a/testdata/examples/project-workback.cm
+++ b/testdata/examples/project-workback.cm
@@ -5,8 +5,8 @@ Uses CalcMark's date arithmetic and compound durations.
 
 ## Key Dates
 
+kickoff = Jan 6 2025
 launch_date = Mar 15 2025
-kickoff = today
 
 Days until launch:
 


### PR DESCRIPTION
## Summary

- **Date subtraction sign fix** — `DaysBetween` computed `other - d` instead of `d - other`, inverting the sign on all date differences
- **Parser: identifier / time_unit** — `tryParseRateFromDivision` greedily consumed variable references as rate literals (`total / days` → rate instead of division), ignoring the variable binding
- **Currency / Duration → Rate** — new operator handler properly divides by magnitude and produces a rate (`$1453.84 / 4 days = $363.46/day`)
- **Rate display for currency symbols** — `FormatRate` now prefixes `$`/`€`/`£`/`¥` like `FormatCurrency` (`$363.46/day` not `363.46 $/day`)
- **project-workback example** — uses fixed dates instead of `today` so it always produces sensible positive durations

## Test plan

- [x] `TestIdentifierDivisionNotRate` — parser rejects rate when left is identifier (3 cases)
- [x] `TestCurrencyDividedByDurationVariable` — full integration: dates → duration → currency/duration → rate
- [x] `TestDateDifference` — correct sign for date subtraction
- [x] `TestDateArithmetic` — both directions verified
- [x] `TestFormatRate` — 7 new currency rate formatting cases ($, €, £, ¥, EUR code, large, negative)
- [x] `task test` — full suite passes
- [x] `task quality` — all quality checks pass
- [x] All example files audited for nonsensical output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-velocity:pr:105 -->
### Metrics

Opened by `@dvhthomas` (agent-assisted) on 2026-04-05 21:39 UTC. Merged 2026-04-05 21:39 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 8s  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
