### PR TITLE
fix: disambiguate identifier/time_unit rate vs division by whitespace

### DIFF
--- a/spec/parser/multiplicative.go
+++ b/spec/parser/multiplicative.go
@@ -23,7 +23,7 @@ func (p *RecursiveDescentParser) parseMultiplicative() (ast.Node, error) {
 		// Special case: Check if DIVIDE might be a rate (e.g., "100 MB/s")
 		// Use helper to try parsing as a rate first
 		if op.Type == lexer.DIVIDE {
-			if rate, ok := p.tryParseRateFromDivision(left); ok {
+			if rate, ok := p.tryParseRateFromDivision(left, op); ok {
 				left = rate
 				// Continue to allow further operations: (100 MB/s * 3600)
 				// This works because the rate is now 'left' and the loop continues
@@ -40,7 +40,7 @@ func (p *RecursiveDescentParser) parseMultiplicative() (ast.Node, error) {
 		// After parsing right operand for division, check if it should be a rate too
 		// This handles expressions like (10 req/s / 5 req/s)
 		if op.Type == lexer.DIVIDE {
-			if rate, ok := p.tryParseRateFromDivision(right); ok {
+			if rate, ok := p.tryParseRateFromDivision(right, op); ok {
 				right = rate
 			}
 		}

--- a/spec/parser/rate_helpers.go
+++ b/spec/parser/rate_helpers.go
@@ -82,17 +82,11 @@ func (p *RecursiveDescentParser) parseCapacityValue() (ast.Node, error) {
 // Returns (rateNode, true) if successful, (nil, false) otherwise.
 // This is a pure function that doesn't modify parser state except for advancing tokens if successful.
 //
-// When the left operand is a bare identifier (variable reference), the division
-// is NOT parsed as a rate. Variables like "total / days" should be arithmetic
-// division, not rate construction. Users should write "total per day" for rates
-// with variables.
-func (p *RecursiveDescentParser) tryParseRateFromDivision(left ast.Node) (*ast.RateLiteral, bool) {
-	// Don't create rates when the left side is a variable reference.
-	// "total / days" is division, not "$total per day".
-	if _, isIdent := left.(*ast.Identifier); isIdent {
-		return nil, false
-	}
-
+// When the left operand is a bare identifier (variable reference) AND the slash
+// is spaced ("total / days"), the expression is treated as division, not a rate.
+// Tight slash syntax ("weekly_posts/week") is still parsed as a rate even with
+// an identifier on the left — the lack of whitespace signals rate intent.
+func (p *RecursiveDescentParser) tryParseRateFromDivision(left ast.Node, divideOp lexer.Token) (*ast.RateLiteral, bool) {
 	// Check if next token is a time unit identifier (e.g., "s" in "100 MB/s")
 	if !p.check(lexer.IDENTIFIER) {
 		return nil, false
@@ -101,6 +95,15 @@ func (p *RecursiveDescentParser) tryParseRateFromDivision(left ast.Node) (*ast.R
 	timeUnit := string(p.peek().Value)
 	if !isTimeUnit(timeUnit) {
 		return nil, false
+	}
+
+	// When the left side is an identifier, use whitespace to disambiguate:
+	//   "weekly_posts/week"  → tight slash → rate (no space between / and time unit)
+	//   "total / days"       → spaced slash → division (variable reference)
+	if _, isIdent := left.(*ast.Identifier); isIdent {
+		if divideOp.EndPos != p.peek().StartPos {
+			return nil, false
+		}
 	}
 
 	// Success - consume the time unit and create rate

--- a/spec/parser/rate_test.go
+++ b/spec/parser/rate_test.go
@@ -119,56 +119,67 @@ func TestRateParsing(t *testing.T) {
 	}
 }
 
-// TestIdentifierDivisionNotRate verifies that identifier / time_unit is parsed
-// as a division (BinaryOp), not a rate literal. When a variable reference is on
-// the left side of /, the parser should not greedily consume the time-unit
-// denominator as a rate. Users should use "per" for rates with variables.
-func TestIdentifierDivisionNotRate(t *testing.T) {
-	tests := []struct {
+// TestIdentifierSlashDisambiguation verifies that whitespace around / controls
+// whether identifier/time_unit is parsed as a rate or division.
+//
+//	"weekly_posts/week"  → tight slash → RateLiteral (rate intent)
+//	"total / days"       → spaced slash → BinaryOp (division intent)
+func TestIdentifierSlashDisambiguation(t *testing.T) {
+	// Spaced slash: identifier / time_unit → division
+	divisionTests := []struct {
 		name  string
 		input string
 	}{
-		{
-			name:  "variable / days is division not rate",
-			input: "total / days\n",
-		},
-		{
-			name:  "variable / hours is division not rate",
-			input: "cost / hours\n",
-		},
-		{
-			name:  "variable / month is division not rate",
-			input: "revenue / month\n",
-		},
+		{name: "spaced: total / days", input: "total / days\n"},
+		{name: "spaced: cost / hours", input: "cost / hours\n"},
+		{name: "spaced: revenue / month", input: "revenue / month\n"},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range divisionTests {
 		t.Run(tt.name, func(t *testing.T) {
 			nodes, err := Parse(tt.input)
 			if err != nil {
 				t.Fatalf("Unexpected parse error: %v", err)
 			}
-
 			if len(nodes) != 1 {
 				t.Fatalf("Expected 1 node, got %d", len(nodes))
 			}
-
-			// Should be BinaryOp (division), NOT RateLiteral
 			binOp, ok := nodes[0].(*ast.BinaryOp)
 			if !ok {
-				t.Fatalf("Expected BinaryOp for variable division, got %T (parser incorrectly created rate literal)", nodes[0])
+				t.Fatalf("Expected BinaryOp for spaced division, got %T", nodes[0])
 			}
-
 			if binOp.Operator != "/" {
 				t.Errorf("Expected operator '/', got '%s'", binOp.Operator)
 			}
+		})
+	}
 
-			// Both sides should be identifiers
-			if _, ok := binOp.Left.(*ast.Identifier); !ok {
-				t.Errorf("Expected left side to be Identifier, got %T", binOp.Left)
+	// Tight slash: identifier/time_unit → rate
+	rateTests := []struct {
+		name    string
+		input   string
+		perUnit string
+	}{
+		{name: "tight: weekly_posts/week", input: "weekly_posts/week\n", perUnit: "week"},
+		{name: "tight: count/day", input: "count/day\n", perUnit: "day"},
+		{name: "tight: bandwidth/s", input: "bandwidth/s\n", perUnit: "s"},
+	}
+
+	for _, tt := range rateTests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, err := Parse(tt.input)
+			if err != nil {
+				t.Fatalf("Unexpected parse error: %v", err)
 			}
-			if _, ok := binOp.Right.(*ast.Identifier); !ok {
-				t.Errorf("Expected right side to be Identifier, got %T", binOp.Right)
+			if len(nodes) != 1 {
+				t.Fatalf("Expected 1 node, got %d", len(nodes))
+			}
+			rate, ok := nodes[0].(*ast.RateLiteral)
+			if !ok {
+				t.Fatalf("Expected RateLiteral for tight slash, got %T", nodes[0])
+			}
+			if rate.PerUnit != tt.perUnit {
+				t.Errorf("Expected per unit '%s', got '%s'", tt.perUnit, rate.PerUnit)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Fixes site deploy failure caused by `weekly_posts/week` in system-sizing being parsed as division instead of a rate
- Refines the parser heuristic: tight slash (`posts/week`) → rate, spaced slash (`total / days`) → division
- Only applies when left operand is an identifier; literals like `$100/day` are always rates

Hotfix for v1.9.10 site deploy regression.

## Test plan

- [x] `TestIdentifierSlashDisambiguation` — 6 cases covering tight (rate) and spaced (division)
- [x] `task test` — full suite passes
- [x] `task quality` — all checks pass
- [x] `weekly_posts/week over 1 day` evaluates correctly
- [x] `total / days` still produces `$363.46/day` rate via operator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-velocity:pr:106 -->
### Metrics

Opened by `@dvhthomas` (agent-assisted) on 2026-04-05 21:49 UTC. Merged 2026-04-05 21:50 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 20s  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
