### PR TITLE
fix: remove tag trigger from site deploy workflow

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -3,7 +3,6 @@ name: Deploy Site
 on:
   push:
     branches: [main]
-    tags: ["v*.*.*"]
 
 concurrency:
   group: "pages"


### PR DESCRIPTION
## Summary

- Tag-triggered site deploys always fail (github-pages environment only allows main branch)
- The concurrency group `cancel-in-progress: true` causes tag deploys to cancel in-progress main deploys
- This has been causing deploy failures since v1.9.9

Tags trigger the Release workflow for binaries. Site deploys only need the main branch trigger.

## Test plan

- [x] Merging this PR to main will trigger a site deploy that should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-velocity:pr:107 -->
### Metrics

Opened by `@dvhthomas` (agent-assisted) on 2026-04-06 00:28 UTC. Merged 2026-04-06 00:28 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 2s  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
