### PR TITLE
fix(lsp): NL completion items carry wrong functionName + signature help missing for NL syntax

### DIFF
--- a/docs/plans/2026-04-12-001-fix-nl-completion-and-signature-help-plan.md
+++ b/docs/plans/2026-04-12-001-fix-nl-completion-and-signature-help-plan.md
@@ -1,0 +1,256 @@
+---
+title: "fix: NL completion items carry wrong functionName + signature help missing for NL syntax"
+type: fix
+status: active
+date: 2026-04-12
+origin: https://github.com/CalcMark/go-calcmark/issues/133
+---
+
+# fix: NL completion items carry wrong functionName + signature help missing for NL syntax
+
+## Overview
+
+Two LSP bugs prevent clients from providing placeholder suggestions and signature help for natural-language (NL) function syntax. Paren-form (`compound(1000, 5%, 10, monthly)`) works correctly, but NL-form (`compound $1000 by 5% monthly over 10 years`) is broken on both fronts. This fix adds a `FunctionName` field to the `Suggestion` struct and an NL-aware fallback to `extractArgumentContext`.
+
+## Problem Frame
+
+After #131 shipped structured parameter types in LSP completion and signatureHelp, `calcmark-web` deleted its client-side function registry in favor of reading `data.params` from the LSP. This works for paren-form but is broken for NL-form:
+
+1. **Bug 1:** NL completion items have `data.functionName` set to the alias display name (e.g., `"grow by over"`) instead of the canonical name (`"grow"`), and `data.params` is null because `GetFunctionSpec("grow by over")` returns nil.
+
+2. **Bug 2:** `textDocument/signatureHelp` returns null for NL-form syntax because `extractArgumentContext` only scans for parentheses, which NL syntax doesn't use.
+
+## Requirements Trace
+
+- **R1.** Every NL-example completion item carries `data.functionName` == canonical function name (e.g., `"grow"`, not `"grow by over"`)
+- **R2.** Every NL-example completion item carries `data.params` populated from the function spec
+- **R3.** Functions with synonyms (e.g., `avg`/`average`/`mean`) also carry correct `data.functionName` in signature-form items (latent bug: `s.Name` includes synonym suffix)
+- **R4.** `textDocument/signatureHelp` returns a valid `SignatureHelp` response when cursor is inside an NL function call
+- **R5.** `activeParameter` correctly tracks which NL argument the cursor is in
+- **R6.** Existing paren-form behavior is unchanged for both completion and signatureHelp
+
+## Scope Boundaries
+
+- NL signatureHelp uses a line-text heuristic approach matching against known NL function keywords — not full AST-based resolution
+- No changes to the NL parser or evaluator
+- No changes to hover behavior (hover already works via AST node ranges)
+- No changes to TUI autocomplete (it consumes `Suggestion.Name` for display, which remains correct)
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `spec/features/suggestions.go:7-14` — `Suggestion` struct, shared between TUI and LSP. `SortCategory` field is precedent for adding NL-specific fields
+- `spec/features/completion.go:89-107` — NL rows set `Name: nl.aliasName` and `InsertText: nl.example`; paren rows set `Name: displayName` and `InsertText: f.Name`
+- `lsp/completion.go:96-106` — `functionCompletionItems` uses `s.Name` as canonical, which is wrong for both NL rows and synonym-decorated paren rows
+- `lsp/argctx.go:31-95` — `extractArgumentContext` only tracks `(` `)` delimiters
+- `lsp/signature.go:60-82` — `signatureHelpHandle` returns nil when `ctx.funcName == ""`
+- `lsp/completion_test.go:243-286` — `TestFunctionCompletions_DataFunctionName` tests `"gro"` prefix (no synonyms), masking the bug for functions with synonyms
+- `spec/features/registry.go` — NL aliases carry `Parseable: true` and `Example` strings; `NLExample` field as fallback
+
+### Institutional Learnings
+
+- **NL/functional parity** (`docs/solutions/integration-issues/nl-functional-syntax-parity-and-doc-staleness.md`): Every fix is two fixes — NL and functional paths are separate code paths that must both be covered in tests
+- **Unified feature registry** (`docs/solutions/code-organization/unified-feature-registry-three-to-one.md`): All metadata must come from `spec/features.Feature`, never from `impl/interpreter`
+- **LSP debounce** (`docs/solutions/integration-issues/lsp-debounce-staleness-read-requests.md`): Use `ds.getSource()` for text operations, not debounced snapshot — already correct in current handlers
+
+## Key Technical Decisions
+
+- **Add `FunctionName` field to `Suggestion`** (Option 1 from issue): Safer than repurposing `Name` because `Name` is used for display/filtering in TUI. `InsertText` carries `f.Name` for paren rows but carries the full example for NL rows, so it can't be reused either. The new field is set to `f.Name` for all function suggestion rows.
+- **NL signatureHelp via line-text heuristic, not AST**: The signatureHelp handler already operates on line text (via `extractArgumentContext`). Adding a fallback that recognizes NL function keywords from the registry keeps the architecture consistent. AST-based resolution would be more robust but requires threading the evaluated document into the signature handler, which is a larger change.
+- **NL `activeParameter` by numeric literal index**: Count numeric literals (matching `(\$?)(\d+(?:\.\d+)?)`) on the line from left to right, and map cursor position to the index of the nearest literal. This mirrors the approach `nlExampleToSnippet` uses for tab stops.
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should `InsertText` be reused for canonical name?** No — NL rows use `InsertText` for the full example string (e.g., `"grow 100 by 20 over 5 months"`). A dedicated field is needed.
+- **Should we fix the paren-form synonym bug too?** Yes — `s.Name` for paren-form includes synonyms (e.g., `"avg (average, mean)"`), making `data.functionName` wrong. The new `FunctionName` field fixes both.
+
+### Deferred to Implementation
+
+- Exact regex pattern for NL numeric literal detection may need tuning for currency prefixes (`$`, `€`) and percentage suffixes (`%`)
+- Whether the NL keyword lookup should be cached or recomputed per request — profile if needed
+
+## Implementation Units
+
+- [x] **Unit 1: Add `FunctionName` field to `Suggestion` and populate it**
+
+**Goal:** Carry the canonical function name through the `Suggestion` struct so the LSP can resolve it without guessing.
+
+**Requirements:** R1, R2, R3
+
+**Dependencies:** None
+
+**Files:**
+- Modify: `spec/features/suggestions.go`
+- Modify: `spec/features/completion.go`
+- Test: `spec/features/completion_test.go`
+
+**Approach:**
+- Add `FunctionName string` to the `Suggestion` struct with a comment explaining it carries the canonical function name for LSP lookup
+- In `FunctionSuggestions`, set `FunctionName: f.Name` on both paren-form rows (line 89) and NL-example rows (line 100)
+- No changes needed to other `*Suggestions` functions (units, variables, directives, dates) — they don't carry function metadata
+
+**Patterns to follow:**
+- `SortCategory` field on `Suggestion` — precedent for an NL-specific field that only some rows populate
+
+**Test scenarios:**
+- Happy path: `FunctionSuggestions("gro", nil)` returns items where every item with `Category == "example"` has `FunctionName == "grow"`
+- Happy path: `FunctionSuggestions("av", nil)` returns items where the paren-form item has `FunctionName == "avg"` (not `"avg (average, mean)"`)
+- Happy path: `FunctionSuggestions("sum", nil)` returns items where NL-example item has `FunctionName == "sum"`
+- Edge case: `FunctionSuggestions("xyz", nil)` returns empty slice — no crash
+
+**Verification:**
+- All existing `spec/features/completion_test.go` tests pass
+- New tests confirm `FunctionName` is set correctly for both paren and NL rows
+
+- [x] **Unit 2: Use `FunctionName` in `functionCompletionItems`**
+
+**Goal:** Fix the LSP completion handler to resolve canonical name from the new field instead of `s.Name`.
+
+**Requirements:** R1, R2, R3, R6
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `lsp/completion.go`
+- Test: `lsp/completion_test.go`
+
+**Approach:**
+- In `functionCompletionItems` (line 98), replace `canonical := s.Name` with `canonical := s.FunctionName` when non-empty, falling back to `s.Name` for non-function suggestions
+- The rest of the function already uses `canonical` to call `GetFunctionSpec` and populate `data.FunctionName` and `data.Params` — no other changes needed
+
+**Patterns to follow:**
+- Existing `TestFunctionCompletions_DataFunctionName` test structure
+
+**Test scenarios:**
+- Happy path: `functionCompletionItems("gro")` — NL-example item for grow has `data.functionName == "grow"` and `data.params` with 3 entries
+- Happy path: `functionCompletionItems("av")` — paren-form item for avg has `data.functionName == "avg"` and `data.params` populated (variadic `values` param)
+- Happy path: NL-example item for avg has `data.functionName == "avg"` and same `data.params`
+- Integration: `functionCompletionItems("compou")` — NL items for compound carry `data.functionName == "compound"` and params with 4 entries (principal, rate, periods, period?)
+- Edge case: paren-form item for throughput still has `data.params[0].enumValues` populated (regression guard)
+
+**Verification:**
+- Existing `TestFunctionCompletions_DataFunctionName` still passes
+- New tests cover synonym-decorated functions (avg) and multi-alias NL functions (compound)
+
+- [x] **Unit 3: Add NL-aware fallback to `extractArgumentContext`**
+
+**Goal:** Detect NL function calls on a line when the paren scanner finds nothing, enabling signatureHelp for NL syntax.
+
+**Requirements:** R4, R5, R6
+
+**Dependencies:** None (parallel with Units 1-2)
+
+**Files:**
+- Modify: `lsp/argctx.go`
+- Test: `lsp/argctx_test.go`
+
+**Approach:**
+- Add a new function `extractNLArgumentContext(lineText string, col int) argumentContext` that:
+  1. Strips optional assignment prefix (`name = ` or `name=`)
+  2. Extracts the first identifier on the expression portion
+  3. Looks it up in `types.FunctionSpecs` — if found, it's a potential NL call
+  4. Counts numeric literals (regex: numbers with optional `$`/`€` prefix and optional `%` suffix) from left to right in the expression
+  5. Maps cursor position to the index of the enclosing or nearest-preceding literal
+  6. Returns `argumentContext{funcName: canonicalName, paramIdx: literalIndex}`
+- Modify `extractArgumentContext` to try the NL fallback when the paren stack is empty and returns `funcName == ""`
+- The NL fallback is conservative: if the first identifier isn't a known function name, return the empty context
+
+**Patterns to follow:**
+- `identifierEndingAt` helper in `argctx.go` — rune-aware identifier extraction
+- `extractArgumentContext` test table in `argctx_test.go`
+
+**Test scenarios:**
+- Happy path: `"grow 100 by 20 over 5 months"` with cursor on `100` → `{funcName: "grow", paramIdx: 0}`
+- Happy path: `"grow 100 by 20 over 5 months"` with cursor on `20` → `{funcName: "grow", paramIdx: 1}`
+- Happy path: `"grow 100 by 20 over 5 months"` with cursor on `5` → `{funcName: "grow", paramIdx: 2}`
+- Happy path: `"goal = compound $1000 by 5% monthly over 10 years"` with cursor on `1000` → `{funcName: "compound", paramIdx: 0}`
+- Happy path: `"goal = compound $1000 by 5% monthly over 10 years"` with cursor on `5` (the 5%) → `{funcName: "compound", paramIdx: 1}`
+- Happy path: `"goal = compound $1000 by 5% monthly over 10 years"` with cursor on `10` → `{funcName: "compound", paramIdx: 2}`
+- Happy path: `"average of 1, 2, 3"` with cursor on `2` → `{funcName: "avg", paramIdx: 1}` (alias lookup needed — `average` is a synonym of `avg`)
+- Edge case: `"x = 100 + 200"` — not an NL function call, returns empty context
+- Edge case: `"grow(100, 20, 5)"` — paren scanner handles this, NL fallback not invoked
+- Edge case: assignment prefix stripped: `"result = grow 100 by 20 over 5 months"` → `{funcName: "grow", paramIdx: 0}` when cursor on `100`
+- Error path: unknown identifier: `"foobar 100 by 200"` → empty context
+
+**Verification:**
+- All existing `extractArgumentContext` tests pass unchanged
+- New NL test cases pass for grow, compound, avg
+
+- [x] **Unit 4: Wire NL signatureHelp through the handler**
+
+**Goal:** Ensure `signatureHelpHandle` returns valid signature help for NL function calls.
+
+**Requirements:** R4, R5, R6
+
+**Dependencies:** Unit 3
+
+**Files:**
+- Modify: `lsp/signature.go` (likely no changes needed if Unit 3 is correct — `signatureHelpHandle` already delegates to `extractArgumentContext`)
+- Test: `lsp/signature_test.go`
+
+**Approach:**
+- If Unit 3 correctly extends `extractArgumentContext` with the NL fallback, `signatureHelpHandle` should work without modification — it already calls `extractArgumentContext` and passes the result to `signatureHelpForFunction`
+- This unit is focused on integration testing to confirm the full path works
+
+**Test scenarios:**
+- Happy path: `signatureHelpForFunction("grow", 0)` returns help with `activeParameter == 0` and label containing `"grow(amount, increment, periods)"` (already works, regression guard)
+- Integration: Mock a full signatureHelp request with NL line `"grow 100 by 20 over 5 months"` and cursor on `20` → response has `activeParameter == 1`
+- Integration: NL line `"goal = compound $1000 by 5% monthly over 10 years"` with cursor on `1000` → response has `activeParameter == 0` and label `"compound(principal, rate, periods, period?)"`
+- Edge case: NL line with cursor between numeric literals (on keyword `"by"`) → `activeParameter` should be the index of the preceding literal
+
+**Verification:**
+- `signatureHelpHandle` returns non-nil for NL function calls
+- `activeParameter` correctly tracks position within NL arguments
+
+- [x] **Unit 5: Acceptance tests for NL completion and signatureHelp**
+
+**Goal:** End-to-end tests confirming the full LSP handler chain works for NL syntax.
+
+**Requirements:** R1, R2, R4, R5
+
+**Dependencies:** Units 2, 4
+
+**Files:**
+- Test: `lsp/acceptance_test.go`
+
+**Approach:**
+- Add acceptance tests using `prepareServerDoc` + `completionAt` and signatureHelp request helpers
+- Test the scenarios from the issue's "Expected test scenario" sections
+
+**Patterns to follow:**
+- Existing acceptance tests in `lsp/acceptance_test.go`
+
+**Test scenarios:**
+- Happy path: Document with `grow 100 by 20 over 5 months`, completion at prefix `"gro"` — NL item has `data.functionName == "grow"` and `data.params` with 3 entries
+- Happy path: Document with `average of 1, 2, 3`, signatureHelp with cursor on `2` — returns signature with `activeParameter == 1`
+- Integration: Document with `goal = compound $1000 by 5% monthly over 10 years`, signatureHelp with cursor on `1000` — returns `compound` signature with `activeParameter == 0`
+
+**Verification:**
+- Acceptance tests pass, confirming full handler chain works for NL syntax
+
+## System-Wide Impact
+
+- **Interaction graph:** `Suggestion` struct is shared between TUI editor and LSP. Adding `FunctionName` is additive — TUI doesn't read it, LSP starts reading it. No breakage.
+- **Error propagation:** Both bugs produce nil/empty responses (graceful degradation). The fix adds data where nil existed — no new error paths.
+- **State lifecycle risks:** None — all changes are stateless request handlers.
+- **API surface parity:** Completion and signatureHelp are the two affected surfaces. Hover is not affected (uses AST nodes, not line-text heuristics).
+- **Unchanged invariants:** TUI autocomplete behavior is unchanged. Paren-form completion and signatureHelp behavior is unchanged (regression tested).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| NL numeric literal regex doesn't handle all currency/percentage patterns | Start with common patterns (`$`, `€`, `%`), expand if edge cases appear in testing |
+| NL function keyword lookup is O(n) per registry scan | Functions registry is small (~20 entries); cache if profiling shows need |
+| Synonym-to-canonical mapping not available in `extractNLArgumentContext` | Use `types.FunctionSpecs` for canonical lookup; use registry `Synonyms` for reverse mapping |
+
+## Sources & References
+
+- Related issue: #133
+- Related PR/issue: #131 (shipped `wireParamData` infrastructure)
+- Related plan: `docs/plans/2026-04-10-001-feat-lsp-structured-param-types-plan.md`
+- Institutional learning: `docs/solutions/integration-issues/nl-functional-syntax-parity-and-doc-staleness.md`
+- Institutional learning: `docs/solutions/code-organization/unified-feature-registry-three-to-one.md`

--- a/lsp/acceptance_test.go
+++ b/lsp/acceptance_test.go
@@ -175,9 +175,9 @@ func TestNLSignatureHelp_GrowAcceptance(t *testing.T) {
 		col       uint32
 		wantParam uint32
 	}{
-		{"cursor on 100", 6, 0},
-		{"cursor on 20", 13, 1},
-		{"cursor on 5", 21, 2},
+		{"cursor on 100", uint32(len([]rune("grow 1"))), 0},
+		{"cursor on 20", uint32(len([]rune("grow 100 by 2"))), 1},
+		{"cursor on 5", uint32(len([]rune("grow 100 by 20 over 5"))), 2},
 	}
 
 	for _, tc := range cases {
@@ -221,7 +221,7 @@ func TestNLSignatureHelp_CompoundWithAssignment(t *testing.T) {
 	params := &protocol.SignatureHelpParams{
 		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 			TextDocument: protocol.TextDocumentIdentifier{URI: uri},
-			Position:     protocol.Position{Line: 0, Character: 19}, // cursor on "1000"
+			Position:     protocol.Position{Line: 0, Character: uint32(len([]rune("goal = compound $10")))}, // cursor on "1000"
 		},
 	}
 	r, err := s.signatureHelpHandle(params)

--- a/lsp/acceptance_test.go
+++ b/lsp/acceptance_test.go
@@ -135,6 +135,118 @@ func TestR3_FunctionDataFunctionName(t *testing.T) {
 	}
 }
 
+// TestR3b_NLCompletionDataFunctionName — NL-example completion items for
+// functions with synonyms carry the canonical name, not the alias display name.
+func TestR3b_NLCompletionDataFunctionName(t *testing.T) {
+	source := "x = av"
+	s, uri := prepareServerDoc(t, source)
+
+	items := completionAt(t, s, uri, 0, 6)
+	nlSeen := false
+	for _, it := range items {
+		d, ok := it.Data.(completionItemData)
+		if !ok {
+			continue
+		}
+		if it.Kind != nil && *it.Kind == protocol.CompletionItemKindSnippet && d.FunctionName == "avg" {
+			nlSeen = true
+			if len(d.Params) == 0 {
+				t.Errorf("NL avg item %q has empty data.params", it.Label)
+			}
+		}
+		// No item should carry the display name as functionName
+		if d.FunctionName == "avg (average, mean)" {
+			t.Errorf("item %q has display name as functionName: %q", it.Label, d.FunctionName)
+		}
+	}
+	if !nlSeen {
+		t.Error("expected NL-example item with data.functionName == avg")
+	}
+}
+
+// TestNLSignatureHelp_GrowAcceptance — end-to-end signatureHelp for NL-form
+// "grow 100 by 20 over 5 months" with cursor on each numeric literal.
+func TestNLSignatureHelp_GrowAcceptance(t *testing.T) {
+	source := "grow 100 by 20 over 5 months"
+	s, uri := prepareServerDoc(t, source)
+
+	cases := []struct {
+		name      string
+		col       uint32
+		wantParam uint32
+	}{
+		{"cursor on 100", 6, 0},
+		{"cursor on 20", 13, 1},
+		{"cursor on 5", 21, 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			params := &protocol.SignatureHelpParams{
+				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+					TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+					Position:     protocol.Position{Line: 0, Character: tc.col},
+				},
+			}
+			r, err := s.signatureHelpHandle(params)
+			if err != nil {
+				t.Fatalf("signatureHelp error: %v", err)
+			}
+			if r == nil {
+				t.Fatal("expected non-nil signatureHelp for NL grow")
+			}
+			help, ok := r.(*lspSignatureHelp)
+			if !ok {
+				t.Fatalf("result is not *lspSignatureHelp: %T", r)
+			}
+			if help.ActiveParameter == nil {
+				t.Fatal("expected activeParameter to be set")
+			}
+			if *help.ActiveParameter != protocol.UInteger(tc.wantParam) {
+				t.Errorf("activeParameter = %d, want %d", *help.ActiveParameter, tc.wantParam)
+			}
+			if !strings.Contains(help.Signatures[0].Label, "grow") {
+				t.Errorf("signature label = %q, want to contain grow", help.Signatures[0].Label)
+			}
+		})
+	}
+}
+
+// TestNLSignatureHelp_CompoundWithAssignment — end-to-end signatureHelp for
+// "goal = compound $1000 by 5% monthly over 10 years".
+func TestNLSignatureHelp_CompoundWithAssignment(t *testing.T) {
+	source := "goal = compound $1000 by 5% monthly over 10 years"
+	s, uri := prepareServerDoc(t, source)
+
+	params := &protocol.SignatureHelpParams{
+		TextDocumentPositionParams: protocol.TextDocumentPositionParams{
+			TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+			Position:     protocol.Position{Line: 0, Character: 19}, // cursor on "1000"
+		},
+	}
+	r, err := s.signatureHelpHandle(params)
+	if err != nil {
+		t.Fatalf("signatureHelp error: %v", err)
+	}
+	if r == nil {
+		t.Fatal("expected non-nil signatureHelp for NL compound")
+	}
+	help, ok := r.(*lspSignatureHelp)
+	if !ok {
+		t.Fatalf("result is not *lspSignatureHelp: %T", r)
+	}
+	if help.ActiveParameter == nil || *help.ActiveParameter != 0 {
+		var got any
+		if help.ActiveParameter != nil {
+			got = *help.ActiveParameter
+		}
+		t.Errorf("activeParameter = %v, want 0", got)
+	}
+	if !strings.Contains(help.Signatures[0].Label, "compound") {
+		t.Errorf("label = %q, want to contain compound", help.Signatures[0].Label)
+	}
+}
+
 // TestR4_SignatureHelpGrowSecondArg — signatureHelp at grow(100, |, 5)
 // returns activeParameter=1 and parameters[1].data.type is set.
 func TestR4_SignatureHelpGrowSecondArg(t *testing.T) {

--- a/lsp/argctx.go
+++ b/lsp/argctx.go
@@ -1,6 +1,12 @@
 package lsp
 
-import "unicode"
+import (
+	"strings"
+	"unicode"
+
+	"github.com/CalcMark/go-calcmark/spec/features"
+	"github.com/CalcMark/go-calcmark/spec/types"
+)
 
 // argumentContext describes where a cursor sits relative to an enclosing
 // function call. Returned by extractArgumentContext.
@@ -79,7 +85,7 @@ func extractArgumentContext(lineText string, col int) argumentContext {
 	}
 
 	if len(stack) == 0 {
-		return argumentContext{funcName: "", paramIdx: -1}
+		return extractNLArgumentContext(lineText, col)
 	}
 
 	top := stack[len(stack)-1]
@@ -114,4 +120,200 @@ func identifierEndingAt(runes []rune, end int) string {
 		return ""
 	}
 	return string(runes[start:end])
+}
+
+// extractNLArgumentContext detects natural-language function calls
+// (e.g., "grow 100 by 20 over 5 months") and returns the argument context.
+// It is called as a fallback when the paren-based scanner finds no call.
+func extractNLArgumentContext(lineText string, col int) argumentContext {
+	empty := argumentContext{funcName: "", paramIdx: -1}
+
+	runes := []rune(lineText)
+	if col > len(runes) {
+		col = len(runes)
+	}
+
+	// Strip optional assignment prefix: "identifier = expr" or "identifier= expr".
+	expr := lineText
+	exprColOffset := 0
+	if idx := strings.Index(lineText, "="); idx >= 0 {
+		// Only strip if the part before '=' looks like an identifier (no parens).
+		before := strings.TrimSpace(lineText[:idx])
+		if isSimpleIdentifier(before) {
+			exprColOffset = idx + 1
+			expr = lineText[idx+1:]
+		}
+	}
+
+	// Adjust col into the expression portion.
+	exprCol := col - exprColOffset
+	if exprCol < 0 {
+		return empty
+	}
+
+	// Extract the first identifier in the expression.
+	exprTrimmed := strings.TrimLeft(expr, " \t")
+	leadingSpaces := len(expr) - len(exprTrimmed)
+	funcName := extractLeadingIdentifier(exprTrimmed)
+	if funcName == "" {
+		return empty
+	}
+
+	// Look up the function name: first in FunctionSpecs, then synonyms.
+	canonicalName := resolveNLFunctionName(funcName)
+	if canonicalName == "" {
+		return empty
+	}
+
+	// Scan for numeric literals in the expression to determine paramIdx.
+	// A numeric literal is a sequence of digits with optional decimal point,
+	// optionally preceded by $ or € and optionally followed by %.
+	exprRunes := []rune(expr)
+	literals := findNumericLiterals(exprRunes, leadingSpaces+len([]rune(funcName)))
+
+	if len(literals) == 0 {
+		return argumentContext{funcName: canonicalName, paramIdx: 0}
+	}
+
+	// Find which literal the cursor is in or most recently past.
+	// exprCol is relative to expr start.
+	paramIdx := 0
+	for i, lit := range literals {
+		if exprCol >= lit.start {
+			paramIdx = i
+		}
+	}
+
+	return argumentContext{funcName: canonicalName, paramIdx: paramIdx}
+}
+
+// numericLiteral records the rune-index span of a numeric literal within a rune slice.
+type numericLiteral struct {
+	start int // inclusive, rune index
+	end   int // exclusive, rune index
+}
+
+// findNumericLiterals scans runes starting from startIdx for numeric literals.
+// A numeric literal is digits with optional decimal point, optionally preceded
+// by $ or € and optionally followed by %.
+func findNumericLiterals(runes []rune, startIdx int) []numericLiteral {
+	var lits []numericLiteral
+	i := startIdx
+	for i < len(runes) {
+		// Skip non-numeric runes.
+		r := runes[i]
+
+		// Check for currency prefix.
+		hasCurrencyPrefix := r == '$' || r == '€'
+		digitStart := i
+		if hasCurrencyPrefix {
+			if i+1 < len(runes) && (unicode.IsDigit(runes[i+1]) || runes[i+1] == '.') {
+				i++ // skip currency symbol, digit follows
+			} else {
+				i++
+				continue
+			}
+		}
+
+		if !unicode.IsDigit(runes[i]) && runes[i] != '.' {
+			i++
+			continue
+		}
+
+		// We're at the start of a potential number. Check that a '.' is followed by digit.
+		if runes[i] == '.' {
+			if i+1 >= len(runes) || !unicode.IsDigit(runes[i+1]) {
+				i++
+				continue
+			}
+		}
+
+		// Consume digits and optional decimal point.
+		hasDigit := false
+		for i < len(runes) && (unicode.IsDigit(runes[i]) || runes[i] == '.') {
+			if unicode.IsDigit(runes[i]) {
+				hasDigit = true
+			}
+			i++
+		}
+
+		if !hasDigit {
+			continue
+		}
+
+		// Optional trailing %.
+		end := i
+		if i < len(runes) && runes[i] == '%' {
+			end = i + 1
+			i++
+		}
+
+		lits = append(lits, numericLiteral{start: digitStart, end: end})
+		continue
+	}
+	return lits
+}
+
+// resolveNLFunctionName checks if name is a known function (in FunctionSpecs)
+// or a synonym mapping to a canonical function name.
+func resolveNLFunctionName(name string) string {
+	lower := strings.ToLower(name)
+
+	// Direct lookup in FunctionSpecs.
+	if types.GetFunctionSpec(lower) != nil {
+		return lower
+	}
+
+	// Check synonyms in the features registry.
+	registry := features.DefaultRegistry()
+	for _, f := range registry.ByCategory(features.CategoryFunction) {
+		for _, syn := range f.Synonyms {
+			if strings.EqualFold(syn, name) {
+				return f.Name
+			}
+		}
+	}
+
+	return ""
+}
+
+// isSimpleIdentifier checks if s is a valid simple identifier (letters, digits, underscores,
+// starting with a letter or underscore).
+func isSimpleIdentifier(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if i == 0 {
+			if !unicode.IsLetter(r) && r != '_' {
+				return false
+			}
+		} else {
+			if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// extractLeadingIdentifier returns the first identifier at the start of s.
+func extractLeadingIdentifier(s string) string {
+	runes := []rune(s)
+	if len(runes) == 0 {
+		return ""
+	}
+	if !unicode.IsLetter(runes[0]) && runes[0] != '_' {
+		return ""
+	}
+	end := 1
+	for end < len(runes) {
+		r := runes[end]
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '_' {
+			end++
+			continue
+		}
+		break
+	}
+	return string(runes[:end])
 }

--- a/lsp/argctx.go
+++ b/lsp/argctx.go
@@ -134,27 +134,35 @@ func extractNLArgumentContext(lineText string, col int) argumentContext {
 	}
 
 	// Strip optional assignment prefix: "identifier = expr" or "identifier= expr".
-	expr := lineText
-	exprColOffset := 0
-	if idx := strings.Index(lineText, "="); idx >= 0 {
-		// Only strip if the part before '=' looks like an identifier (no parens).
-		before := strings.TrimSpace(lineText[:idx])
-		if isSimpleIdentifier(before) {
-			exprColOffset = idx + 1
-			expr = lineText[idx+1:]
+	// Uses rune indexing throughout to handle multi-byte identifiers correctly.
+	// Skips comparison operators (==, !=, <=, >=) which also contain '='.
+	exprRunes := runes
+	exprCol := col
+	for i, r := range runes {
+		if r == '=' {
+			// Skip comparison operators: ==, !=, <=, >=
+			if i+1 < len(runes) && runes[i+1] == '=' {
+				continue // == at this position
+			}
+			if i > 0 && (runes[i-1] == '!' || runes[i-1] == '<' || runes[i-1] == '>') {
+				continue // !=, <=, >= at this position
+			}
+			before := strings.TrimSpace(string(runes[:i]))
+			if isIdentifier(before) {
+				exprRunes = runes[i+1:]
+				exprCol = col - (i + 1)
+				if exprCol < 0 {
+					return empty
+				}
+			}
+			break
 		}
 	}
 
-	// Adjust col into the expression portion.
-	exprCol := col - exprColOffset
-	if exprCol < 0 {
-		return empty
-	}
-
 	// Extract the first identifier in the expression.
-	exprTrimmed := strings.TrimLeft(expr, " \t")
-	leadingSpaces := len(expr) - len(exprTrimmed)
-	funcName := extractLeadingIdentifier(exprTrimmed)
+	exprTrimmed := []rune(strings.TrimLeft(string(exprRunes), " \t"))
+	leadingSpaces := len(exprRunes) - len(exprTrimmed)
+	funcName := extractLeadingIdentifier(string(exprTrimmed))
 	if funcName == "" {
 		return empty
 	}
@@ -168,7 +176,6 @@ func extractNLArgumentContext(lineText string, col int) argumentContext {
 	// Scan for numeric literals in the expression to determine paramIdx.
 	// A numeric literal is a sequence of digits with optional decimal point,
 	// optionally preceded by $ or € and optionally followed by %.
-	exprRunes := []rune(expr)
 	literals := findNumericLiterals(exprRunes, leadingSpaces+len([]rune(funcName)))
 
 	if len(literals) == 0 {
@@ -275,26 +282,6 @@ func resolveNLFunctionName(name string) string {
 	}
 
 	return ""
-}
-
-// isSimpleIdentifier checks if s is a valid simple identifier (letters, digits, underscores,
-// starting with a letter or underscore).
-func isSimpleIdentifier(s string) bool {
-	if s == "" {
-		return false
-	}
-	for i, r := range s {
-		if i == 0 {
-			if !unicode.IsLetter(r) && r != '_' {
-				return false
-			}
-		} else {
-			if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_' {
-				return false
-			}
-		}
-	}
-	return true
 }
 
 // extractLeadingIdentifier returns the first identifier at the start of s.

--- a/lsp/argctx_test.go
+++ b/lsp/argctx_test.go
@@ -268,6 +268,103 @@ func TestExtractArgumentContext_NLFallback(t *testing.T) {
 	}
 }
 
+// TestExtractArgumentContext_ComparisonOperators verifies that comparison
+// operators containing '=' do not trigger false assignment prefix stripping.
+func TestExtractArgumentContext_ComparisonOperators(t *testing.T) {
+	cases := []struct {
+		name      string
+		line      string
+		col       int
+		wantFunc  string
+		wantParam int
+	}{
+		{
+			name:      "!= does not strip",
+			line:      "x != grow 100",
+			col:       12,
+			wantFunc:  "",
+			wantParam: -1,
+		},
+		{
+			name:      "<= does not strip",
+			line:      "a <= grow 100 by 20",
+			col:       14,
+			wantFunc:  "",
+			wantParam: -1,
+		},
+		{
+			name:      ">= does not strip",
+			line:      "b >= grow 100",
+			col:       12,
+			wantFunc:  "",
+			wantParam: -1,
+		},
+		{
+			name:      "== does not strip",
+			line:      "x == grow 100",
+			col:       12,
+			wantFunc:  "",
+			wantParam: -1,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := extractArgumentContext(tc.line, tc.col)
+			if ctx.funcName != tc.wantFunc {
+				t.Errorf("funcName = %q, want %q", ctx.funcName, tc.wantFunc)
+			}
+			if ctx.paramIdx != tc.wantParam {
+				t.Errorf("paramIdx = %d, want %d", ctx.paramIdx, tc.wantParam)
+			}
+		})
+	}
+}
+
+// TestExtractArgumentContext_UnicodeAssignment verifies that multi-byte
+// Unicode identifiers before '=' are handled correctly with rune indexing.
+func TestExtractArgumentContext_UnicodeAssignment(t *testing.T) {
+	// "résultat" has a multi-byte é, so byte index != rune index for '='
+	line := "résultat = grow 100 by 20 over 5 months"
+	ctx := extractArgumentContext(line, len([]rune("résultat = grow 1")))
+	if ctx.funcName != "grow" {
+		t.Errorf("funcName = %q, want grow", ctx.funcName)
+	}
+	if ctx.paramIdx != 0 {
+		t.Errorf("paramIdx = %d, want 0", ctx.paramIdx)
+	}
+}
+
+// TestFindNumericLiterals tests the numeric literal scanner directly.
+func TestFindNumericLiterals(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		startIdx int
+		want     int // expected number of literals
+	}{
+		{"single integer", "grow 100", 5, 1},
+		{"decimal number", "grow 1.5", 5, 1},
+		{"dollar prefix", "compound $1000 by 5%", 9, 2},
+		{"euro prefix", "compound €1000 by 5%", 9, 2},
+		{"percent suffix", "rate 5%", 5, 1},
+		{"multiple numbers", "grow 100 by 20 over 5", 5, 3},
+		{"leading dot followed by digit", "x .5", 2, 1},
+		{"lone dot not a number", "x . y", 2, 0},
+		{"no numbers", "grow by over", 5, 0},
+		{"currency with no following digit", "$ by", 0, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runes := []rune(tc.input)
+			lits := findNumericLiterals(runes, tc.startIdx)
+			if len(lits) != tc.want {
+				t.Errorf("findNumericLiterals(%q, %d) found %d literals, want %d",
+					tc.input, tc.startIdx, len(lits), tc.want)
+			}
+		})
+	}
+}
+
 // FuzzExtractArgumentContext seeds the backward walker with edge-case inputs
 // and asserts that arbitrary byte sequences never panic. The plan commits to
 // a fuzz test as the mitigation for walker misclassification risk.
@@ -287,6 +384,16 @@ func FuzzExtractArgumentContext(f *testing.F) {
 		`outer(i1(1, 2), i2(3, 4), `,
 		string([]byte{0x00, '(', ')'}),
 		"δ(ε, ",
+		// NL-form seeds to exercise the NL fallback path
+		`grow 100 by 20 over 5 months`,
+		`goal = compound $1000 by 5% monthly over 10 years`,
+		`average of 1, 2, 3`,
+		`résultat = grow 100 by 20`,
+		`x != grow 100`,
+		`a <= grow 100 by 20`,
+		`grow`,
+		`$$$100`,
+		`compound €1000 by 5% over 10 years`,
 	}
 	for _, s := range seeds {
 		for i := 0; i <= len(s); i++ {

--- a/lsp/argctx_test.go
+++ b/lsp/argctx_test.go
@@ -166,6 +166,108 @@ func TestExtractArgumentContext_DeepNesting(t *testing.T) {
 	}
 }
 
+// TestExtractArgumentContext_NLFallback verifies that natural-language function
+// calls (without parens) are detected by the NL fallback path.
+func TestExtractArgumentContext_NLFallback(t *testing.T) {
+	cases := []struct {
+		name      string
+		line      string
+		col       int
+		wantFunc  string
+		wantParam int
+	}{
+		{
+			name:      "grow NL first param",
+			line:      "grow 100 by 20 over 5 months",
+			col:       5, // on the '1' of 100
+			wantFunc:  "grow",
+			wantParam: 0,
+		},
+		{
+			name:      "grow NL second param",
+			line:      "grow 100 by 20 over 5 months",
+			col:       13, // on the '2' of 20
+			wantFunc:  "grow",
+			wantParam: 1,
+		},
+		{
+			name:      "grow NL third param",
+			line:      "grow 100 by 20 over 5 months",
+			col:       21, // on the '5'
+			wantFunc:  "grow",
+			wantParam: 2,
+		},
+		{
+			name:      "compound with assignment and currency",
+			line:      "goal = compound $1000 by 5% monthly over 10 years",
+			col:       16, // on the '$' of $1000
+			wantFunc:  "compound",
+			wantParam: 0,
+		},
+		{
+			name:      "compound second param with percent",
+			line:      "goal = compound $1000 by 5% monthly over 10 years",
+			col:       25, // on the '5' of 5%
+			wantFunc:  "compound",
+			wantParam: 1,
+		},
+		{
+			name:      "compound third param",
+			line:      "goal = compound $1000 by 5% monthly over 10 years",
+			col:       41, // on the '1' of 10
+			wantFunc:  "compound",
+			wantParam: 2,
+		},
+		{
+			name:      "synonym average maps to avg",
+			line:      "average of 1, 2, 3",
+			col:       15, // on the '2'
+			wantFunc:  "avg",
+			wantParam: 1,
+		},
+		{
+			name:      "plain arithmetic not a function",
+			line:      "x = 100 + 200",
+			col:       5,
+			wantFunc:  "",
+			wantParam: -1,
+		},
+		{
+			name:      "paren form still handled by paren scanner",
+			line:      "grow(100, 20, 5)",
+			col:       5,
+			wantFunc:  "grow",
+			wantParam: 0,
+		},
+		{
+			name:      "assignment prefix stripped for grow",
+			line:      "result = grow 100 by 20 over 5 months",
+			col:       14, // on the '1' of 100
+			wantFunc:  "grow",
+			wantParam: 0,
+		},
+		{
+			name:      "unknown function returns empty",
+			line:      "foobar 100 by 200",
+			col:       7,
+			wantFunc:  "",
+			wantParam: -1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := extractArgumentContext(tc.line, tc.col)
+			if ctx.funcName != tc.wantFunc {
+				t.Errorf("funcName = %q, want %q", ctx.funcName, tc.wantFunc)
+			}
+			if ctx.paramIdx != tc.wantParam {
+				t.Errorf("paramIdx = %d, want %d", ctx.paramIdx, tc.wantParam)
+			}
+		})
+	}
+}
+
 // FuzzExtractArgumentContext seeds the backward walker with edge-case inputs
 // and asserts that arbitrary byte sequences never panic. The plan commits to
 // a fuzz test as the mitigation for walker misclassification risk.

--- a/lsp/completion.go
+++ b/lsp/completion.go
@@ -93,9 +93,12 @@ func functionCompletionItems(prefix string) []protocol.CompletionItem {
 	var items []protocol.CompletionItem
 
 	for _, s := range suggestions {
-		// For both signature-form and NL-example rows, the canonical name is
-		// s.Name — the features layer has already resolved label → canonical.
-		canonical := s.Name
+		// Use the canonical function name for spec lookup. FunctionName is set
+		// by FunctionSuggestions to f.Name for both paren-form and NL rows.
+		canonical := s.FunctionName
+		if canonical == "" {
+			canonical = s.Name
+		}
 		spec := types.GetFunctionSpec(canonical)
 		data := completionItemData{
 			Kind:         "function",

--- a/lsp/completion_test.go
+++ b/lsp/completion_test.go
@@ -312,6 +312,72 @@ func TestFunctionCompletions_ThroughputParamsEnumValues(t *testing.T) {
 	}
 }
 
+// TestFunctionCompletions_SynonymFunctionCanonicalName asserts that functions
+// with synonyms (like avg/average/mean) carry the canonical name in data, not
+// the display name with synonym suffix.
+func TestFunctionCompletions_SynonymFunctionCanonicalName(t *testing.T) {
+	items := functionCompletionItems("av")
+	if len(items) == 0 {
+		t.Fatal("expected avg completion items, got none")
+	}
+
+	avgSigSeen := false
+	avgNLSeen := false
+	for _, it := range items {
+		d, ok := it.Data.(completionItemData)
+		if !ok {
+			t.Errorf("item %q missing completionItemData", it.Label)
+			continue
+		}
+		if d.FunctionName != "avg" {
+			t.Errorf("item %q has data.functionName = %q, want avg", it.Label, d.FunctionName)
+		}
+		if len(d.Params) == 0 {
+			t.Errorf("avg item %q has empty params", it.Label)
+		}
+		if it.Kind != nil && *it.Kind == protocol.CompletionItemKindFunction {
+			avgSigSeen = true
+		}
+		if it.Kind != nil && *it.Kind == protocol.CompletionItemKindSnippet {
+			avgNLSeen = true
+		}
+	}
+	if !avgSigSeen {
+		t.Error("expected signature-form avg item")
+	}
+	if !avgNLSeen {
+		t.Error("expected NL-example avg item")
+	}
+}
+
+// TestFunctionCompletions_CompoundNLParamsPopulated asserts that compound's
+// NL-example items carry full params (principal, rate, periods, period?).
+func TestFunctionCompletions_CompoundNLParamsPopulated(t *testing.T) {
+	items := functionCompletionItems("compou")
+	nlSeen := false
+	for _, it := range items {
+		d, ok := it.Data.(completionItemData)
+		if !ok {
+			continue
+		}
+		if d.FunctionName != "compound" {
+			continue
+		}
+		if it.Kind != nil && *it.Kind == protocol.CompletionItemKindSnippet {
+			nlSeen = true
+			if len(d.Params) < 3 {
+				t.Errorf("compound NL item %q has %d params, want >= 3", it.Label, len(d.Params))
+			}
+			if len(d.Params) > 0 && d.Params[0].Name != "principal" {
+				t.Errorf("compound first param = %q, want principal", d.Params[0].Name)
+			}
+		}
+	}
+	if !nlSeen {
+		t.Error("expected at least one NL-example compound item")
+	}
+}
+
 // TestEnumValueCompletions_InsideStringSuppressed asserts that a cursor
 // inside a string literal suppresses enum completion — the LSP should not
 // offer unquoted bare identifiers inside a "..." literal because calcmark

--- a/lsp/signature_test.go
+++ b/lsp/signature_test.go
@@ -128,6 +128,81 @@ func TestSignatureHelp_EnumParamCarriesValues(t *testing.T) {
 	}
 }
 
+// TestSignatureHelp_NLFormGrow verifies the full signatureHelp path for
+// NL-form "grow 100 by 20 over 5 months" — extractArgumentContext returns
+// a valid context and signatureHelpForFunction produces the correct response.
+func TestSignatureHelp_NLFormGrow(t *testing.T) {
+	cases := []struct {
+		name      string
+		line      string
+		col       int
+		wantParam int
+	}{
+		{
+			name:      "cursor on first literal",
+			line:      "grow 100 by 20 over 5 months",
+			col:       len([]rune("grow 1")),
+			wantParam: 0,
+		},
+		{
+			name:      "cursor on second literal",
+			line:      "grow 100 by 20 over 5 months",
+			col:       len([]rune("grow 100 by 2")),
+			wantParam: 1,
+		},
+		{
+			name:      "cursor on third literal",
+			line:      "grow 100 by 20 over 5 months",
+			col:       len([]rune("grow 100 by 20 over 5")),
+			wantParam: 2,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := extractArgumentContext(tc.line, tc.col)
+			if ctx.funcName != "grow" {
+				t.Fatalf("funcName = %q, want grow", ctx.funcName)
+			}
+			help := signatureHelpForFunction(ctx.funcName, ctx.paramIdx)
+			if help == nil {
+				t.Fatal("expected non-nil signatureHelp")
+			}
+			if help.ActiveParameter == nil {
+				t.Fatal("expected activeParameter to be set")
+			}
+			if int(*help.ActiveParameter) != tc.wantParam {
+				t.Errorf("activeParameter = %d, want %d", *help.ActiveParameter, tc.wantParam)
+			}
+			if !strings.Contains(help.Signatures[0].Label, "grow") {
+				t.Errorf("signature label = %q, want to contain grow", help.Signatures[0].Label)
+			}
+		})
+	}
+}
+
+// TestSignatureHelp_NLFormCompoundWithAssignment verifies NL signatureHelp
+// for "goal = compound $1000 by 5% monthly over 10 years" with assignment prefix.
+func TestSignatureHelp_NLFormCompoundWithAssignment(t *testing.T) {
+	line := "goal = compound $1000 by 5% monthly over 10 years"
+
+	ctx := extractArgumentContext(line, len([]rune("goal = compound $10")))
+	if ctx.funcName != "compound" {
+		t.Fatalf("funcName = %q, want compound", ctx.funcName)
+	}
+	if ctx.paramIdx != 0 {
+		t.Errorf("paramIdx = %d, want 0", ctx.paramIdx)
+	}
+
+	help := signatureHelpForFunction(ctx.funcName, ctx.paramIdx)
+	if help == nil {
+		t.Fatal("expected non-nil signatureHelp for compound NL")
+	}
+	if !strings.Contains(help.Signatures[0].Label, "compound") {
+		t.Errorf("label = %q, want to contain compound", help.Signatures[0].Label)
+	}
+}
+
 // TestSignatureHelp_JSONShape asserts the wire format: marshaling the result
 // yields the expected top-level keys and nested structure.
 func TestSignatureHelp_JSONShape(t *testing.T) {

--- a/spec/features/completion.go
+++ b/spec/features/completion.go
@@ -87,11 +87,12 @@ func FunctionSuggestions(prefix string, implementedNames map[string]bool) []Sugg
 			}
 
 			suggestions = append(suggestions, Suggestion{
-				Name:        name,
-				Category:    f.Subcategory,
-				Description: f.Description,
-				Syntax:      f.Syntax,
-				InsertText:  f.Name,
+				Name:         name,
+				Category:     f.Subcategory,
+				Description:  f.Description,
+				Syntax:       f.Syntax,
+				InsertText:   f.Name,
+				FunctionName: f.Name,
 			})
 		}
 
@@ -102,6 +103,7 @@ func FunctionSuggestions(prefix string, implementedNames map[string]bool) []Sugg
 				Category:     "example",
 				Syntax:       nl.example,
 				InsertText:   nl.example,
+				FunctionName: f.Name,
 				SortCategory: f.Subcategory, // Sort alongside parent function
 			})
 		}

--- a/spec/features/completion_test.go
+++ b/spec/features/completion_test.go
@@ -117,6 +117,49 @@ func TestFunctionSuggestions(t *testing.T) {
 		}
 	})
 
+	t.Run("FunctionName is canonical for paren-form", func(t *testing.T) {
+		suggestions := FunctionSuggestions("av", implementedNames)
+		for _, s := range suggestions {
+			if s.InsertText == "avg" && s.Category != "example" {
+				if s.FunctionName != "avg" {
+					t.Errorf("paren-form FunctionName = %q, want %q", s.FunctionName, "avg")
+				}
+				return
+			}
+		}
+		t.Fatal("expected paren-form suggestion for avg")
+	})
+
+	t.Run("FunctionName is canonical for NL-example rows", func(t *testing.T) {
+		suggestions := FunctionSuggestions("av", implementedNames)
+		for _, s := range suggestions {
+			if s.Category == "example" && s.FunctionName == "avg" {
+				return // found it
+			}
+		}
+		t.Fatal("expected NL-example row with FunctionName='avg'")
+	})
+
+	t.Run("FunctionName is canonical for grow NL-example", func(t *testing.T) {
+		suggestions := FunctionSuggestions("gro", implementedNames)
+		for _, s := range suggestions {
+			if s.Category == "example" && s.FunctionName == "grow" {
+				return
+			}
+		}
+		t.Fatal("expected NL-example row with FunctionName='grow'")
+	})
+
+	t.Run("FunctionName is canonical for sum NL-example", func(t *testing.T) {
+		suggestions := FunctionSuggestions("sum", implementedNames)
+		for _, s := range suggestions {
+			if s.Category == "example" && s.FunctionName == "sum" {
+				return
+			}
+		}
+		t.Fatal("expected NL-example row with FunctionName='sum'")
+	})
+
 	t.Run("NLExample fallback for functions without parseable aliases", func(t *testing.T) {
 		suggestions := FunctionSuggestions("accum", implementedNames)
 		var nlRow *Suggestion

--- a/spec/features/suggestions.go
+++ b/spec/features/suggestions.go
@@ -10,6 +10,7 @@ type Suggestion struct {
 	Description  string // Brief description
 	Syntax       string // Syntax example
 	InsertText   string // Actual text to insert (without synonyms/formatting)
+	FunctionName string // Canonical function name for spec lookup (set only for function suggestions)
 	SortCategory string // Override category for sorting (e.g., NL rows use parent fn category)
 }
 


### PR DESCRIPTION
## Summary

- Fix NL completion items carrying alias display names instead of canonical function names in `data.functionName`, with `data.params` null
- Fix `textDocument/signatureHelp` returning null for NL-form syntax by adding NL-aware fallback to `extractArgumentContext`
- Add `FunctionName` field to `Suggestion` struct for reliable canonical name propagation

Fixes #133.

## Test plan

- [x] Unit tests for `FunctionName` field on Suggestion struct (paren + NL rows)
- [x] Unit tests for `functionCompletionItems` with synonym-decorated functions (avg) and compound NL
- [x] 11 NL fallback test cases for `extractArgumentContext`
- [x] Direct `findNumericLiterals` scanner tests
- [x] Comparison operator guard tests (`!=`, `<=`, `>=`, `==`)
- [x] Unicode assignment prefix test (rune indexing)
- [x] NL signatureHelp integration tests (grow, compound with assignment)
- [x] End-to-end acceptance tests for NL completion and signatureHelp
- [x] NL-form fuzz seeds added
- [x] `task test` passes, `task quality` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-velocity:pr:134 -->
### Metrics

Opened by `@dvhthomas` (agent-assisted) on 2026-04-12 15:48 UTC. Merged 2026-04-12 15:48 UTC. Closed issue: [#133](https://github.com/CalcMark/go-calcmark/issues/133).

| Metric | Value |
|--------|-------|
| Cycle Time | 6s  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
