### PR TITLE
feat: frontmatter as a first-class part of the language

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ You are an expert language designer and implementer for the go-calcmark language
   - The site/content directory contains all the documentation.
   - ./spec/units/canonical.go contains the canonical set of units that calcmark understands. Use that central knowledge.
   - ./spec/features/registry.go describe the main features of the language.
+  - ./spec/document/frontmatter_registry.go is the source of truth for CalcMark-specific frontmatter keys (`exchange`, `globals`, `scale`, `convert_to`, `measurement`, `fiscal_year_starts`). LSP hover/completion/documentSymbol and `semantic.CheckFrontmatter` all consult it; non-CalcMark keys pass through untouched in `Frontmatter.Extra`.
 - Use Go for everything
 - Clear separate between the calcmark language specification in the spec directory and the implementation of the language as an interpreter and REPL in the impl directory.
   - Dependencies go one way

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ cm testdata/examples/budget.cm
 - **Currencies** - `$100`, `50 EUR`, automatic formatting
 - **Percentages** - `savings_rate = 20%`, then `income * savings_rate`
 - **Functions** - `avg()`, `sqrt()`, `capacity()`, and more
-- **YAML front matter** - Define document-level constants
+- **YAML front matter** - Define document-level constants (`exchange`, `globals`, `scale`, `convert_to`, `measurement`, `fiscal_year_starts`; see [`spec/document/frontmatter_registry.go`](spec/document/frontmatter_registry.go) for the authoritative list)
 - **Export formats** - Convert to HTML, Markdown, JSON, or plain text
 
 ## Help Commands

--- a/docs/plans/2026-04-14-001-feat-frontmatter-first-class-plan.md
+++ b/docs/plans/2026-04-14-001-feat-frontmatter-first-class-plan.md
@@ -214,7 +214,7 @@ These two functions are the foundation for hover / completion / documentSymbol. 
 
 ## Implementation Units
 
-- [ ] **Unit 1: Registry — extract the allowlist into a typed `Registry` slice**
+- [x] **Unit 1: Registry — extract the allowlist into a typed `Registry` slice**
 
 **Goal:** A new file `spec/document/frontmatter_registry.go` defines `RegisteredKey`, `FrontmatterKeyType`, and a populated `Registry` covering the six existing keys with docstrings and (for `convert_to`) enum values. `ParseFrontmatter` continues working unchanged.
 
@@ -252,7 +252,7 @@ These two functions are the foundation for hover / completion / documentSymbol. 
 
 ---
 
-- [ ] **Unit 2: Refactor `ParseFrontmatter` to consult the registry**
+- [x] **Unit 2: Refactor `ParseFrontmatter` to consult the registry**
 
 **Goal:** Replace the hardcoded allowlist at `frontmatter.go:700-703` with a `Registry`-driven check. No behavioral change for any caller — known keys still populate typed `Frontmatter` struct fields; unknown keys still flow into `Extra`. The change is one of provenance: the source of truth for "which keys are CalcMark-known" moves from a hardcoded slice into the new registry.
 
@@ -284,7 +284,7 @@ These two functions are the foundation for hover / completion / documentSymbol. 
 
 ---
 
-- [ ] **Unit 3: Capture frontmatter source ranges (per-key positions)**
+- [x] **Unit 3: Capture frontmatter source ranges (per-key positions)**
 
 **Goal:** Extend `Frontmatter` (or sidecar data) with line/column ranges per parsed key, so semantic diagnostics and LSP hover/completion can anchor to source positions. Backward-compatible — additive, no field renames or removals.
 
@@ -320,7 +320,7 @@ These two functions are the foundation for hover / completion / documentSymbol. 
 
 ---
 
-- [ ] **Unit 4: `semantic.CheckFrontmatter` — diagnostics for malformed registered keys**
+- [x] **Unit 4: `semantic.CheckFrontmatter` — diagnostics for malformed registered keys**
 
 **Goal:** A new exported function `semantic.CheckFrontmatter(fm document.Frontmatter) []semantic.Diagnostic` that returns diagnostics for registered keys whose values don't match their registered type. Non-registered keys (`Extra`) produce no diagnostics. Existing semantic-check callers gain access via either calling the new function directly or via `Checker.Check` automatically forwarding when frontmatter has been set (D4 + Open Questions Deferred).
 
@@ -361,7 +361,7 @@ These two functions are the foundation for hover / completion / documentSymbol. 
 
 ---
 
-- [ ] **Unit 5: LSP frontmatter-region detection helper**
+- [x] **Unit 5: LSP frontmatter-region detection helper**
 
 **Goal:** Pure helpers `DetectRegion(source string) (FrontmatterRegion, bool)` and `ClassifyCursor(region, position) CursorContext` in `lsp/frontmatter_region.go`. These are the foundation for Units 6, 7, 8 (hover, completion, documentSymbol).
 
@@ -400,7 +400,7 @@ These two functions are the foundation for hover / completion / documentSymbol. 
 
 ---
 
-- [ ] **Unit 6: LSP hover for registered frontmatter keys**
+- [x] **Unit 6: LSP hover for registered frontmatter keys**
 
 **Goal:** `textDocument/hover` at a position inside the frontmatter region, on a registered key (or a registered enum value), returns the registry's docstring + expected type formatted as Markdown. Hover on a non-registered key returns nothing (passthrough — null hover response).
 
@@ -438,7 +438,7 @@ These two functions are the foundation for hover / completion / documentSymbol. 
 
 ---
 
-- [ ] **Unit 7: LSP completion for registered keys + enum values**
+- [x] **Unit 7: LSP completion for registered keys + enum values**
 
 **Goal:** `textDocument/completion` inside the frontmatter region surfaces:
 - At a `key` position: all registered keys with their docstrings as completion items
@@ -480,7 +480,7 @@ Outside the region, existing completion logic runs unchanged.
 
 ---
 
-- [ ] **Unit 8: LSP documentSymbol for registered frontmatter keys**
+- [x] **Unit 8: LSP documentSymbol for registered frontmatter keys**
 
 **Goal:** `textDocument/documentSymbol` includes one symbol per registered frontmatter key present in the document, with `SymbolKind.Property`. The symbols sit at the top of the symbol list (before calc-block variables), so editor outlines show frontmatter at the top.
 
@@ -514,7 +514,7 @@ Outside the region, existing completion logic runs unchanged.
 
 ---
 
-- [ ] **Unit 9: Acceptance tests + close the loop**
+- [x] **Unit 9: Acceptance tests + close the loop**
 
 **Goal:** End-to-end acceptance tests in `lsp/acceptance_test.go` verifying all six R-numbered behaviors from a real LSP client perspective. Update relevant docs.
 
@@ -585,6 +585,24 @@ Outside the region, existing completion logic runs unchanged.
 - If Unit 3 (per-key ranges) reveals that the YAML library doesn't expose positions, the implementer scopes the work to manual instrumentation in the parsing pass — don't switch YAML libraries for this.
 - If `CheckFrontmatter` (Unit 4) finds that most of its target diagnostics are already produced by the parser, scope it to the residual cases and update the plan's R2 inline rather than producing duplicate diagnostics.
 - If any unit fails its verification, stop and commit what works as a documentation-only escalation; do not push through a broken state.
+
+## Resolution
+
+Shipped: CalcMark frontmatter is now a first-class language concept with a typed `Registry`, per-key source ranges, standalone semantic validation (`semantic.CheckFrontmatter`), and LSP hover, completion, and documentSymbol coverage for registered keys — while non-CalcMark (Extra) keys continue to pass through untouched. Downstream consumers (`calcmark-web`, TUI, any LSP client) now have a single source of truth for CalcMark-specific frontmatter semantics.
+
+| Unit | Commit |
+|---|---|
+| 1 — Registry | `b412a9b` |
+| 2 — ParseFrontmatter consults Registry | `76473cf` |
+| 3 — KeyRanges capture | `f646cad` |
+| 4 — semantic.CheckFrontmatter | `d96fae6` |
+| 5 — LSP region detection helpers | `9ad815a` |
+| 6 — LSP hover | `34f604b` |
+| 7 — LSP completion | `a67f7dd` |
+| 8 — LSP documentSymbol | `a4859f7` |
+| 9 — Consolidated acceptance + close the loop | (this commit) |
+
+Follow-up handoff: calcmark-web plan `2026-04-14-003`'s Deferred entry "First-class frontmatter handling in go-calcmark" is now unblocked. A new calcmark-web plan for frontend frontmatter rendering can be written against the next go-calcmark release tag.
 
 ## Sources & References
 

--- a/docs/plans/2026-04-14-001-feat-frontmatter-first-class-plan.md
+++ b/docs/plans/2026-04-14-001-feat-frontmatter-first-class-plan.md
@@ -1,0 +1,596 @@
+---
+title: "feat: Frontmatter as a first-class part of the language (registry, semantic check, LSP surface)"
+type: feat
+status: active
+date: 2026-04-14
+---
+
+# feat: Frontmatter as a first-class part of the language
+
+## Overview
+
+CalcMark documents already accept a YAML frontmatter block delimited by `---` lines (standard Markdown convention). The parser at `spec/document/frontmatter.go:563` (`ParseFrontmatter`) recognizes a hardcoded set of CalcMark-specific keys (`exchange`, `globals`, `scale`, `convert_to`, `measurement`, `fiscal_year_starts`) and silently captures everything else into a preserved `Extra` slice. This is the right behavior for users — non-CalcMark keys (Jekyll-style `title`, `date`, `tags`, etc.) flow through unchanged — but it means CalcMark's *own* frontmatter is parsed in detail without being treated as a first-class part of the language by the rest of the toolchain. The semantic checker only knows about `globals` and `scale` (via the minimal `FrontmatterInfo` interface at `spec/semantic/checker.go:105`); the LSP exposes nothing for frontmatter at all (no hover, completion, document symbol, or diagnostics for any frontmatter key).
+
+This plan finishes the lift: extract the existing hardcoded allowlist into a structured registry; extend the semantic checker so registered keys with malformed values produce useful diagnostics; surface registered keys via the LSP (hover with docstring + expected type, completion at key and value positions, document symbols). Non-CalcMark keys remain ignored — they pass through to `Extra` as today, no warnings, no LSP surface, no validation. The Markdown frontmatter convention is unchanged.
+
+This is upstream work: a separate plan in calcmark-web (or other clients) will then consume the new LSP surface to render and edit frontmatter cleanly. Until that lands, all current callers of `ParseFrontmatter` and `Checker.SetFrontmatter` continue to work unchanged — additions are additive and the existing struct shapes are preserved.
+
+## Problem Frame
+
+CalcMark's frontmatter is a load-bearing piece of the language:
+
+- `globals` declares document-scoped variable bindings used throughout calc blocks.
+- `convert_to` selects an output unit system (SI / Imperial) that affects every quantity rendering.
+- `exchange` overrides currency rates used by every cross-currency calculation.
+- `scale` multiplies every quantity in the document by a configured factor.
+- `measurement` resolves ambiguous units (volume / mass / ton) for the entire document.
+- `fiscal_year_starts` anchors fiscal-period date arithmetic.
+
+Each of these affects the meaning of expressions throughout the document. Yet the toolchain treats them as opaque configuration:
+
+- The semantic checker has no way to surface "you wrote `convert_to: xyz_not_a_currency`" or "your `exchange.USD_EUR` value isn't a number" — those errors land at runtime or silently mis-evaluate.
+- Authors editing in any LSP-aware client (`go-calcmark` LSP serves VS Code, Helix, Neovim today) get no completion when typing `conv` in a frontmatter key position, no hover docs for `globals.foo`, no document outline showing the configured directives.
+- `web/server.go` (calcmark-web) and the TUI both consume `ParseFrontmatter`'s output but cannot easily know "what would have been a valid value here" — there's no introspection.
+
+The fix is the registry-of-truth pattern: name what's known, expose the metadata, let downstream consumers (semantic checker, LSP, future renderers) reflect over it. Non-CalcMark keys keep their current escape hatch (silent capture in `Extra`).
+
+## Requirements Trace
+
+These align with the six testable expectations captured in calcmark-web's plan `2026-04-14-003`'s "Deferred to Separate Tasks" entry, plus a registry-shape requirement.
+
+- **R1 — Registry of CalcMark frontmatter keys.** A `spec/frontmatter` package (or `spec/document/frontmatter_registry.go`, whichever fits the repo's existing layout) exposes a typed registry: each known key has a name, an expected value type/shape, a docstring, and (where applicable) a value-domain enumerator (e.g., `convert_to` values are `si` or `imperial`). The registry is the single source of truth for "what is a CalcMark frontmatter key" — `ParseFrontmatter`, `semantic.CheckFrontmatter`, and the LSP all consult it.
+- **R2 — Semantic check for registered keys.** A new `semantic.CheckFrontmatter(fm Frontmatter) []Diagnostic` validates registered keys with wrong-type values (e.g., `convert_to: xyz`, `exchange: not-a-map`, `globals: 42`). Non-registered keys produce no diagnostics. Existing semantic-checker invocations gain access to these diagnostics by calling the new function (or having it folded into `Checker.Check` if cleaner).
+- **R3 — LSP hover.** `textDocument/hover` at a position inside the frontmatter region on a registered key (or a registered key's value, where the value has a known schema like `convert_to`) returns the registry's docstring + expected type. Hover on a non-registered key returns nothing (passthrough).
+- **R4 — LSP completion.** `textDocument/completion` inside the frontmatter region: typing at a key position surfaces all registered keys with their docstrings; typing at a value position for a known-type key surfaces the enum values (e.g., `si` and `imperial` for `convert_to`).
+- **R5 — LSP document symbol.** `textDocument/documentSymbol` includes one symbol per registered frontmatter key present in the document, so editors' outline views show the configured directives.
+- **R6 — Test coverage.** Unit tests on the registry (registry shape, lookup), unit tests on `CheckFrontmatter` (each known key's failure modes), and integration tests in `lsp/acceptance_test.go` covering all three LSP surfaces (hover, completion, document symbol) for registered keys, plus negative tests confirming non-CalcMark keys produce no LSP responses.
+- **R7 — Backward compatibility.** No existing `ParseFrontmatter` caller breaks. The `Frontmatter` struct shape is unchanged. The `FrontmatterInfo` interface (`spec/semantic/checker.go:105`) may grow methods but doesn't lose any. Calcmark-web's `web/server.go:309` and the TUI continue working unmodified.
+
+## Scope Boundaries
+
+### In scope
+
+- New `spec/frontmatter` package OR new `spec/document/frontmatter_registry.go` with a typed registry of CalcMark-specific keys + metadata
+- Refactor `ParseFrontmatter` to consult the registry instead of the hardcoded allowlist at `frontmatter.go:700-703` (no behavioral change for callers)
+- New `semantic.CheckFrontmatter(fm Frontmatter) []Diagnostic` covering registered keys with malformed values
+- LSP hover / completion / documentSymbol for registered keys, dispatched by detecting the cursor is inside the frontmatter region of the document
+- Tests at three layers: registry unit tests, semantic-checker unit tests, LSP integration tests
+
+### Out of scope
+
+- Adding new CalcMark frontmatter keys beyond the existing six (this is a structural / introspection change, not a feature expansion)
+- Validating non-CalcMark keys (`Extra` keys stay silently captured; this is by design — Markdown frontmatter convention preserved)
+- Any frontend / editor consumer changes (calcmark-web, TUI, VS Code extension, etc.) — those are downstream plans
+- Changing the YAML frontmatter delimiter convention (`---` fences stay)
+- Renaming any existing `Frontmatter` struct fields (R7 backward compat)
+- Editing frontmatter via LSP code actions (read-only LSP surface for now; editing happens in the editor's normal text edit path)
+- The `measurement` config's user-facing integration (parsed today but not yet wired downstream — surveyed and noted; not opened here)
+- Cross-document frontmatter inheritance / includes
+
+### Deferred to Separate Tasks
+
+- **Calcmark-web frontmatter rendering migration**: tracked in calcmark-web's plan `2026-04-14-003` Deferred entry. Becomes its own follow-up plan once this one ships and a go-calcmark release is cut.
+- **TUI frontmatter editing surface**: separate plan if/when the TUI grows interactive frontmatter editing.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `spec/document/frontmatter.go` — `ParseFrontmatter` (line 563), `Frontmatter` struct (lines 80-123), hardcoded allowlist (lines 700-703), `Extra` capture (lines 699-712). The registry replaces / wraps the allowlist; the struct stays.
+- `spec/document/frontmatter.go:700-712` — the existing "silently capture unknowns into `Extra`" branch is the model for the "non-CalcMark passthrough" behavior. R7 preserves it exactly.
+- `spec/semantic/checker.go:105-110` — current `FrontmatterInfo` interface (HasScale, HasGlobals, HasGlobal, GlobalKeys). May grow methods if the new `CheckFrontmatter` needs more handles, but cannot lose any.
+- `spec/semantic/checker.go:147` — `SetFrontmatter(fm FrontmatterInfo)` and `Check(nodes)` (line 153). New `CheckFrontmatter` is either a separate exported function or a method on `Checker` — pick whichever reads cleaner without breaking existing callers.
+- `lsp/server.go:80-124` — main server; standard LSP method dispatch lives here. Hover, completion, documentSymbol handlers are at lines 109, 111, 113.
+- `lsp/handler_wrap.go` — `interceptingHandler` is where method-level intercepts already exist (used by `signatureHelp` and `hover` per the surveyed extensions). Frontmatter-region detection can hook in similarly.
+- `lsp/diagnostics.go:54,103,140,148` — existing `calcmark/documentRendered` notification pattern. Custom CalcMark notifications already work; if new ones are needed for frontmatter (none expected in this plan), the pattern is established.
+- `lsp/acceptance_test.go` — full notification/request integration tests. Frontmatter LSP coverage lands here.
+
+### Institutional Learnings
+
+- `docs/plans/2026-04-10-001-feat-lsp-structured-param-types-plan.md` — most recent LSP extension plan; structural template for LSP-touching plans in this repo.
+- `docs/plans/2026-02-24-frontmatter-stability-preview-alignment-plan.md` — earlier frontmatter work; useful context on how frontmatter parsing interacts with the preview pipeline.
+
+### External References
+
+- CommonMark spec for frontmatter — there is no formal spec; the de-facto convention is Jekyll's YAML between `---` fences at the start of the document. CalcMark already implements this; nothing to change.
+- LSP spec for `textDocument/hover`, `textDocument/completion`, `textDocument/documentSymbol` — standard. The implementations dispatch on cursor position; the only novelty here is detecting "cursor is inside the frontmatter region."
+
+## Key Technical Decisions
+
+- **D1. Registry shape: typed Go values, not stringly-typed map.** The registry exposes `[]RegisteredKey` where each entry has fields like `Name string`, `Type FrontmatterKeyType` (enum: `String`, `MapStringDecimal`, `MapStringString`, `EnumString`, `Struct`), `Doc string`, `EnumValues []string` (for `EnumString` / `Struct` keys with constrained value sets). Compile-time-safe, easy to iterate, easy to add new keys. *Rejected alternative: `map[string]reflect.Type` — looser, easier to write but harder to attach docstrings, harder to evolve the type taxonomy when new shapes are needed.*
+
+- **D2. Registry lives in `spec/document/frontmatter_registry.go`, not a new package.** The registry is intimately tied to the `Frontmatter` struct's existing fields. Putting it in a new `spec/frontmatter` package would add an import cycle risk (the registry needs to know the struct shape; the parser needs to know the registry) and split related code across packages for no semantic gain. *Rejected alternative: `spec/frontmatter/registry.go` — cleaner naming but worse cohesion; defer if this grows enough to justify a new package.*
+
+- **D3. `ParseFrontmatter` consults the registry but its public contract is unchanged.** The hardcoded allowlist at lines 700-703 becomes a `for _, k := range Registry { ... }` loop. Behavior is identical: known keys flow into typed struct fields, unknown keys flow into `Extra`. *Rejected alternative: have `ParseFrontmatter` return a `[]Diagnostic` for malformed registered values too — would expand the function's return signature and break R7. Diagnostics are the semantic checker's job (R2), not the parser's.*
+
+- **D4. `semantic.CheckFrontmatter` is a separate exported function, not a method on `Checker`.** The semantic checker today operates on `[]ast.Node` (calc-line statements). Frontmatter validation is structural ("is this map a `map[string]decimal`?") and doesn't need the Checker's accumulated state. Keeping it separate also lets calcmark-web call it during `/api/eval` without dragging in the full Checker setup. The Checker can call it internally if the user has called `SetFrontmatter`. *Rejected alternative: add a `Checker.CheckFrontmatter()` method — couples frontmatter validation to the Checker's lifecycle for no benefit; harder to test in isolation.*
+
+- **D5. LSP frontmatter-region detection is a pure helper.** A new `lsp/frontmatter_region.go` exports `IsInFrontmatter(source string, position protocol.Position) (region FrontmatterRegion, ok bool)` returning the parsed range plus the cursor's position within it (key vs value, which key, etc.). Hover / completion / documentSymbol all consult this helper. *Rejected alternative: inline region detection in each handler — three copies of the same parsing logic; bug-fixes have to land three times.*
+
+- **D6. LSP completion dispatches based on cursor sub-position within the frontmatter region.** The helper from D5 returns enough info to know whether the cursor is at a key-position (start of line, before `:`) or a value-position (after `:`, on the same line or a continuation). Completion only triggers in the frontmatter region; outside the region it falls through to existing completion logic. *Rejected alternative: register a separate completion provider for the frontmatter region — LSP doesn't really support that cleanly; the same handler dispatches based on cursor context.*
+
+- **D7. Document symbol output uses `SymbolKind.Property` for registered frontmatter keys.** Closest match in the LSP `SymbolKind` enum. Editors render it with a property icon in their outline; semantically accurate ("this is a configured property of the document"). *Rejected alternative: `SymbolKind.Variable` — would conflate frontmatter keys with calc-block variable definitions, which already use Variable.*
+
+- **D8. No new custom `calcmark/*` LSP method.** Standard LSP methods (hover, completion, documentSymbol) cover every R1-R5 requirement. Custom methods are reserved for things outside the standard LSP vocabulary (rendering protocol, document model push). Frontmatter hover IS hover; don't invent a separate channel. *Rejected alternative: a `calcmark/frontmatterValidate` request — pointless; semantic diagnostics ride on the standard `textDocument/publishDiagnostics` notification that the existing checker already uses.*
+
+- **D9. Registry docstrings live in code, not in a separate doc file.** Each `RegisteredKey.Doc` is a Go string literal alongside the key entry. Easier to keep in sync with the type; one place to look. If documentation grows substantial (>2-3 lines per key), revisit and consider an embedded markdown file. *Rejected alternative: load docstrings from `docs/frontmatter/*.md` files at startup — adds I/O complexity and breaks the "compile-time-safe registry" property.*
+
+- **D10. Mind time complexity (carry-forward from calcmark-web plan 003 D9).** Every new code path in this plan is linear or constant in input size. The registry is iterated once per parse (O(|registry|) ≈ 6 today). `CheckFrontmatter` is O(|registered keys present|). Frontmatter region detection is a single pass over the source up to the closing `---` fence (O(|frontmatter source|)). Hover / completion lookups are O(1) given the cursor position. No quadratic anywhere. *Rejected alternative: lazy / cached registry that builds an index on first access — premature; a 6-entry registry doesn't need indexing, and adding caching adds invalidation complexity.*
+
+## Open Questions
+
+### Resolved During Planning
+
+- **Should the registry expose `Frontmatter` struct field paths so consumers can populate the typed struct from the registry?** No. The struct already exists; the registry is metadata about keys, not a code generator. `ParseFrontmatter` keeps its switch-style assignment to typed struct fields; the registry just provides the key names + types for validation and LSP introspection.
+- **Should `Extra` keys ever produce diagnostics?** No. The user explicitly wants non-CalcMark keys ignored. Capturing in `Extra` preserves them for round-trip; producing a warning would surprise users who use frontmatter for Jekyll-style metadata.
+- **Should this plan touch the `measurement` config's downstream wiring?** No. The survey flagged it as parsed-but-not-fully-wired, but that's a separate concern. This plan adds LSP/semantic surface for `measurement` like any other registered key; broader integration is a different plan.
+- **Should the LSP advertise frontmatter completion at document position 0 even before the user types `---`?** No. Completion only fires when the cursor is already inside an opened frontmatter region (between two `---` fences). The author has signaled intent by typing the opening fence.
+
+### Deferred to Implementation
+
+- **Exact `FrontmatterKeyType` enum values.** D1 names a starting set (`String`, `MapStringDecimal`, `MapStringString`, `EnumString`, `Struct`); the implementer audits the existing six keys and lands on the precise set. Likely additions: `MapStringStruct` for `measurement` (which has nested axis fields). Document choices in code.
+- **How to dispatch completion at a value position when the value type is `Struct`.** For `scale: { factor: 1000 }`, value-position completion at the `factor:` key needs the registry to expose nested field metadata. May require a small recursive registry shape; defer to implementation. Acceptable POC fallback: no completion inside struct values; just at the top-level key + simple-type value positions.
+- **Whether `CheckFrontmatter` is invoked automatically by `Checker.Check` when frontmatter has been set.** Convenience vs separation: probably yes, via a one-liner inside `Check` that prepends frontmatter diagnostics. Implementer decides based on whether existing `Checker` consumers expect frontmatter diagnostics in the same return value or separately.
+
+## High-Level Technical Design
+
+> *This illustrates the intended approach and is directional guidance for review, not implementation specification. The implementing agent should treat it as context, not code to reproduce.*
+
+### Registry shape (directional)
+
+```
+// Lives at spec/document/frontmatter_registry.go
+
+type FrontmatterKeyType int
+const (
+    KeyTypeString FrontmatterKeyType = iota
+    KeyTypeMapStringDecimal      // exchange
+    KeyTypeMapStringString       // globals
+    KeyTypeEnumString            // convert_to (enum: si | imperial)
+    KeyTypeStruct                // scale, measurement, fiscal_year_starts
+)
+
+type RegisteredKey struct {
+    Name       string             // YAML key as authored
+    Type       FrontmatterKeyType
+    Doc        string             // shown in LSP hover
+    EnumValues []string           // populated when Type == KeyTypeEnumString
+    // Future: nested-field metadata for KeyTypeStruct entries
+}
+
+var Registry = []RegisteredKey{
+    { Name: "exchange", Type: KeyTypeMapStringDecimal, Doc: "..." },
+    { Name: "globals", Type: KeyTypeMapStringString, Doc: "..." },
+    { Name: "scale", Type: KeyTypeStruct, Doc: "..." },
+    { Name: "convert_to", Type: KeyTypeEnumString, Doc: "...", EnumValues: []string{"si","imperial"} },
+    { Name: "measurement", Type: KeyTypeStruct, Doc: "..." },
+    { Name: "fiscal_year_starts", Type: KeyTypeStruct, Doc: "..." },
+}
+
+func IsRegisteredKey(name string) bool { ... }   // O(|Registry|), trivially small
+func LookupKey(name string) (RegisteredKey, bool) { ... }
+```
+
+### Semantic check (directional)
+
+```
+// Lives at spec/semantic/frontmatter_check.go
+
+func CheckFrontmatter(fm document.Frontmatter) []Diagnostic {
+    // For each populated typed-struct field on fm, validate it matches
+    // the registered key's type.
+    // For each Extra key: skip (passthrough).
+    // For each registered key with malformed shape (e.g., the parser
+    // captured raw YAML for an enum key but the value isn't in EnumValues):
+    // emit a Diagnostic with severity=Error and a useful Range pointing at
+    // the offending source line if available.
+}
+```
+
+Note: `ParseFrontmatter` may need to surface line/column ranges per key in the `Frontmatter` struct (or via a parallel ranges-by-key map) so diagnostics can have anchors. Detail deferred to implementation; the parser today doesn't keep these but the YAML library it uses likely does.
+
+### LSP frontmatter-region detection (directional)
+
+```
+// Lives at lsp/frontmatter_region.go
+
+type FrontmatterRegion struct {
+    StartLine int           // first '---' fence line
+    EndLine   int           // closing '---' fence line
+    KeyLines  map[int]string // line index -> key name (registered or not)
+}
+
+type CursorContext struct {
+    InRegion bool
+    Position string         // "key" | "value" | "fence" | "outside"
+    Key      string         // empty if Position == "key" and user hasn't typed yet
+}
+
+func DetectRegion(source string) (FrontmatterRegion, bool) { ... }
+func ClassifyCursor(region FrontmatterRegion, pos protocol.Position) CursorContext { ... }
+```
+
+These two functions are the foundation for hover / completion / documentSymbol. They're pure (source string in, structural data out) — easy to unit-test exhaustively.
+
+## Implementation Units
+
+- [ ] **Unit 1: Registry — extract the allowlist into a typed `Registry` slice**
+
+**Goal:** A new file `spec/document/frontmatter_registry.go` defines `RegisteredKey`, `FrontmatterKeyType`, and a populated `Registry` covering the six existing keys with docstrings and (for `convert_to`) enum values. `ParseFrontmatter` continues working unchanged.
+
+**Requirements:** R1, R7
+
+**Dependencies:** None
+
+**Files:**
+- Create: `spec/document/frontmatter_registry.go`
+- Create: `spec/document/frontmatter_registry_test.go`
+
+**Approach:**
+- Define types per D1.
+- Populate `Registry` for the six existing keys. Docstrings: write 1-2 sentences each, using existing `frontmatter.go` parse-block comments as source material.
+- Helpers: `IsRegisteredKey(name string) bool`, `LookupKey(name string) (RegisteredKey, bool)`. Both linear over `Registry` (≤6 entries today; D10 keeps it that way).
+- `ParseFrontmatter` is NOT modified in this unit — that's Unit 2. This unit is purely additive; existing tests stay green.
+
+**Execution note:** Test-first. Cover registry shape (each entry has non-empty Name/Doc, EnumValues populated iff Type==EnumString), lookups (existing keys found, unknown keys not found, case-sensitivity behavior — pick and document).
+
+**Patterns to follow:**
+- Existing `spec/document/frontmatter.go` for naming conventions.
+- `spec/types/` for enum-with-stringer pattern if applicable.
+
+**Test scenarios:**
+- Happy: each of the 6 registered keys returns from `LookupKey` with its expected `Type`
+- Happy: `convert_to` has `EnumValues == []string{"si","imperial"}` (or whatever the parser actually accepts — verify against `frontmatter.go:330` and adjacent code)
+- Happy: every entry has a non-empty `Doc`
+- Edge: `IsRegisteredKey("Exchange")` (capitalized) returns false (case-sensitive, matches YAML behavior; document)
+- Edge: `LookupKey("nonexistent_key")` returns `_, false`
+- Regression: existing `frontmatter_test.go` continues passing (no behavioral change)
+
+**Verification:**
+- `go test ./spec/document/... -run Registry` green
+- Existing `go test ./...` unchanged
+
+---
+
+- [ ] **Unit 2: Refactor `ParseFrontmatter` to consult the registry**
+
+**Goal:** Replace the hardcoded allowlist at `frontmatter.go:700-703` with a `Registry`-driven check. No behavioral change for any caller — known keys still populate typed `Frontmatter` struct fields; unknown keys still flow into `Extra`. The change is one of provenance: the source of truth for "which keys are CalcMark-known" moves from a hardcoded slice into the new registry.
+
+**Requirements:** R1, R3, R7
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `spec/document/frontmatter.go` (around lines 700-712)
+- Modify: `spec/document/frontmatter_test.go` if any test asserts on the old allowlist's exact shape (likely none; behavior is identical)
+
+**Approach:**
+- Replace the inline allowlist literal with `IsRegisteredKey(yamlKey)` calls.
+- Verify existing tests still pass — this is a refactor.
+- Preserve the existing parsing branch for each typed key (`exchange`, `globals`, etc.) — those switch arms stay; only the "is this a known CalcMark key vs goes into Extra" decision changes its source.
+
+**Execution note:** This is a refactor; no test-first ceremony beyond ensuring the existing test suite still passes. If any new test scenarios become natural to add (e.g., "adding a key to the Registry makes it parsed by `ParseFrontmatter` without further code changes"), add them.
+
+**Patterns to follow:**
+- Existing `ParseFrontmatter` structure.
+
+**Test scenarios:**
+- Regression: every existing `frontmatter_test.go` scenario stays green
+- Integration: if a new key were added to `Registry` (in a hypothetical future change), `ParseFrontmatter` would route it through the typed-struct path. This is an architectural property; document it in a code comment.
+
+**Verification:**
+- `go test ./spec/document/...` green
+- `git diff` for `frontmatter.go` is small and isolated to the allowlist site
+
+---
+
+- [ ] **Unit 3: Capture frontmatter source ranges (per-key positions)**
+
+**Goal:** Extend `Frontmatter` (or sidecar data) with line/column ranges per parsed key, so semantic diagnostics and LSP hover/completion can anchor to source positions. Backward-compatible — additive, no field renames or removals.
+
+**Requirements:** R2, R3, R5, R7
+
+**Dependencies:** None (orthogonal to Units 1-2; can run in parallel)
+
+**Files:**
+- Modify: `spec/document/frontmatter.go`
+- Modify: `spec/document/frontmatter_test.go`
+
+**Approach:**
+- Likely shape: a new `KeyRanges map[string]ast.Range` field on `Frontmatter` (or a separate `Ranges` struct returned alongside; pick whatever interferes least with R7's backward-compat). The map carries one entry per registered key found in the source.
+- The YAML library go-calcmark uses likely exposes node positions; if not, instrument the parsing pass to record start/end lines as it walks the YAML tree.
+- For the `Extra` slice, also capture ranges so future tooling can locate non-CalcMark keys (cheap addition; no extra parser passes).
+- 0-based or 1-based: match the existing `ast.Range` convention in this repo (verify; calcmark-web's plan 003 D2 is 0-based for new protocol but go-calcmark may differ — document the chosen convention in a code comment).
+
+**Execution note:** Test-first. Fixture: a multi-key frontmatter with known line numbers; assert each key's range matches.
+
+**Patterns to follow:**
+- `ast.Range` shape and existing `_test.go` fixtures using it.
+
+**Test scenarios:**
+- Happy: a frontmatter with `convert_to: si` on line 2 surfaces a range with `Start.Line == 2` (or 1, per convention)
+- Happy: a multi-line value (`globals:\n  foo: ...\n  bar: ...`) on lines 3-5 surfaces a range covering the full block
+- Edge: missing closing `---` fence → behavior should be the existing parser's (likely returns no frontmatter); ranges absent
+- Edge: empty frontmatter (`---\n---\n`) → empty `KeyRanges` map, no error
+- Regression: all existing tests stay green; the new field is additive
+
+**Verification:**
+- `go test ./spec/document/...` green
+- New field documented in `Frontmatter` struct comment
+
+---
+
+- [ ] **Unit 4: `semantic.CheckFrontmatter` — diagnostics for malformed registered keys**
+
+**Goal:** A new exported function `semantic.CheckFrontmatter(fm document.Frontmatter) []semantic.Diagnostic` that returns diagnostics for registered keys whose values don't match their registered type. Non-registered keys (`Extra`) produce no diagnostics. Existing semantic-check callers gain access via either calling the new function directly or via `Checker.Check` automatically forwarding when frontmatter has been set (D4 + Open Questions Deferred).
+
+**Requirements:** R2, R6
+
+**Dependencies:** Unit 1, Unit 3
+
+**Files:**
+- Create: `spec/semantic/frontmatter_check.go`
+- Create: `spec/semantic/frontmatter_check_test.go`
+- Possibly modify: `spec/semantic/checker.go` if folding into `Checker.Check` ends up cleaner
+
+**Approach:**
+- For each registered key, check whether the corresponding `Frontmatter` field is populated AND whether the populated value matches the registry's `Type`. Most cases the parser already enforces — but for `EnumString` keys the parser may accept any string and the validation lives here.
+- For `convert_to: xyz_not_a_value`, emit `Diagnostic{Severity: Error, Message: "..."}` with a Range from Unit 3's `KeyRanges`.
+- For value-shape mismatches the parser couldn't catch (e.g., `globals: 42` — the parser fails YAML-shape; if so the parser's own error is already returned; check whether semantic gets a chance) — confirm during implementation; add tests for both parser-caught and semantic-caught cases.
+- Diagnostic messages: short, actionable, including the offending value when safe.
+
+**Execution note:** Test-first. Each registered key gets at least one happy and one failure scenario. Use `KeyRanges` to verify Range anchors.
+
+**Patterns to follow:**
+- Existing `Diagnostic` shape in `spec/semantic/`.
+- Existing `Checker.Check` test fixtures.
+
+**Test scenarios:**
+- Happy: `Frontmatter{ ConvertTo: &ConvertToConfig{Value: "si"} }` → no diagnostics
+- Failure: `Frontmatter{ ConvertTo: &ConvertToConfig{Value: "xyz"} }` → one diagnostic, Severity=Error, Range from KeyRanges["convert_to"]
+- Failure: `Frontmatter{ Globals: map[string]string{} }` is fine (empty map is valid); but `Globals` with a key whose value is unparseable as a CalcMark expression — out of this plan's scope (calc-line semantic check covers it later)
+- Failure: `Exchange: map[string]decimal.Decimal{"USD_EUR": 0}` — emit warning if zero rates are nonsensical (decide; document)
+- Edge: empty `Frontmatter{}` → no diagnostics
+- Edge: `Frontmatter{ Extra: []ExtraField{{Key: "title", Value: "Hello"}} }` → no diagnostics (Extra is passthrough)
+- Edge: `Frontmatter{ ConvertTo: &ConvertToConfig{Value: "SI"} }` (case mismatch on enum value) → either accept (case-insensitive enums) or reject (exact match); pick and document
+- Regression: existing `Checker.Check` callers see no behavioral change unless they opt into frontmatter checking
+
+**Verification:**
+- `go test ./spec/semantic/... -run Frontmatter` green
+- Diagnostics carry usable Range anchors (verified via at least one assertion that Range != zero-value)
+
+---
+
+- [ ] **Unit 5: LSP frontmatter-region detection helper**
+
+**Goal:** Pure helpers `DetectRegion(source string) (FrontmatterRegion, bool)` and `ClassifyCursor(region, position) CursorContext` in `lsp/frontmatter_region.go`. These are the foundation for Units 6, 7, 8 (hover, completion, documentSymbol).
+
+**Requirements:** R3, R4, R5
+
+**Dependencies:** None (parsing is independent of registry; can run in parallel with Units 1-4)
+
+**Files:**
+- Create: `lsp/frontmatter_region.go`
+- Create: `lsp/frontmatter_region_test.go`
+
+**Approach:**
+- `DetectRegion`: scan the source for the opening `---` fence (must be at line 0 with optional whitespace) and the closing `---` fence. If both found, return the region with start/end line indexes and a `KeyLines` map (`line index → key name`). If frontmatter is malformed or absent, return `_, false`.
+- `ClassifyCursor`: given a region and a `protocol.Position`, classify the cursor's role: `outside` (not in region), `fence` (on a `---` line), `key` (start of a `key:` line, before the `:`), `value` (after the `:` on the same line, OR on a continuation indented block).
+- Pure functions, single-pass over the source. O(|frontmatter source|) per D10.
+
+**Execution note:** Test-first. The classifier has well-defined rules; cover each.
+
+**Patterns to follow:**
+- Existing pure helpers in `spec/document/` for source-walking style.
+
+**Test scenarios:**
+- Happy: well-formed frontmatter → DetectRegion returns the right line range; KeyLines contains every top-level key
+- Happy: ClassifyCursor at line 1 col 0 (just after the opening fence) → `key` position
+- Happy: ClassifyCursor at line 1 col 12 of `convert_to: si` → `value` position
+- Edge: missing closing fence → `_, false`
+- Edge: only opening fence → `_, false`
+- Edge: cursor outside the region → `outside`
+- Edge: cursor on the `---` line itself → `fence`
+- Edge: cursor on a continuation line (e.g., `globals:\n  foo: ...` with cursor on the `foo:` line) → `value` (or document otherwise)
+- Edge: fenced frontmatter with empty body (`---\n---\n`) → DetectRegion returns region with empty KeyLines; cursor on line 1 (between fences) → `key` (typing-position)
+
+**Verification:**
+- `go test ./lsp/... -run FrontmatterRegion` green
+- Helpers are pure; no LSP dependencies
+
+---
+
+- [ ] **Unit 6: LSP hover for registered frontmatter keys**
+
+**Goal:** `textDocument/hover` at a position inside the frontmatter region, on a registered key (or a registered enum value), returns the registry's docstring + expected type formatted as Markdown. Hover on a non-registered key returns nothing (passthrough — null hover response).
+
+**Requirements:** R3, R6
+
+**Dependencies:** Unit 1, Unit 5
+
+**Files:**
+- Modify: `lsp/server.go` (the existing hover handler at line 111)
+- Possibly modify: `lsp/handler_wrap.go` if the existing intercepting layer is the right injection point for frontmatter-aware hover
+- Modify: `lsp/server_test.go` and `lsp/acceptance_test.go`
+
+**Approach:**
+- In the hover handler, call `DetectRegion(source)` first. If outside the region, fall through to existing hover logic.
+- If inside the region, call `ClassifyCursor` to identify the key under the cursor (or the key whose value contains the cursor).
+- Look up via `LookupKey`. If found, format hover content as Markdown with key name, type, and docstring. If not found, return null hover.
+- Hover on an enum value (e.g., cursor on `si` in `convert_to: si`) returns the registry's docstring + a note that this is a valid value (or just the parent key's hover).
+
+**Execution note:** Integration-test in `acceptance_test.go` — open a doc, request hover at a frontmatter position, assert the response.
+
+**Patterns to follow:**
+- Existing hover handler (line 111 of `server.go`) and any existing acceptance tests for hover.
+
+**Test scenarios:**
+- Happy: hover on `convert_to` key returns docstring and `Type: enum (si | imperial)`
+- Happy: hover on `globals` key returns docstring
+- Happy: hover on `si` value of `convert_to: si` returns docstring (acceptable to delegate to the parent key's hover)
+- Edge: hover on an `Extra` key like `title: Hello` returns null (no hover response)
+- Edge: hover outside the frontmatter region falls through to existing hover (regression: existing hover tests stay green)
+- Edge: hover on the `---` fence returns null
+
+**Verification:**
+- `go test ./lsp/... -run Hover` green
+- `lsp/acceptance_test.go` includes the hover scenarios above
+
+---
+
+- [ ] **Unit 7: LSP completion for registered keys + enum values**
+
+**Goal:** `textDocument/completion` inside the frontmatter region surfaces:
+- At a `key` position: all registered keys with their docstrings as completion items
+- At a `value` position for a `EnumString`-typed key: the enum values
+
+Outside the region, existing completion logic runs unchanged.
+
+**Requirements:** R4, R6
+
+**Dependencies:** Unit 1, Unit 5
+
+**Files:**
+- Modify: `lsp/server.go` (the existing completion handler at line 109)
+- Modify: `lsp/server_test.go` and `lsp/acceptance_test.go`
+
+**Approach:**
+- In the completion handler, call `DetectRegion`. Outside region → fall through.
+- Inside region, `ClassifyCursor` to determine key vs value position.
+- Key position: build CompletionItems from `Registry`, each with kind `Property`, label = key name, documentation = docstring, sort-key alphabetic.
+- Value position for enum-typed key: build CompletionItems from `EnumValues`, each with kind `EnumMember`.
+- Value position for non-enum-typed key: no completions for this plan; punt to a future iteration.
+
+**Execution note:** Test-first.
+
+**Patterns to follow:**
+- Existing completion handler.
+
+**Test scenarios:**
+- Happy: typing `con` at a key position surfaces `convert_to` in completions
+- Happy: typing at a fresh key line (empty input) surfaces all 6 registered keys
+- Happy: typing at the value position of `convert_to: ` (cursor after the colon+space) surfaces `si` and `imperial`
+- Edge: completion at value position of `globals: ` returns no completions (non-enum type; not in scope)
+- Edge: completion outside the frontmatter region returns existing completions (regression)
+- Edge: completion on the `---` fence returns no completions
+
+**Verification:**
+- `go test ./lsp/... -run Completion` green
+- Acceptance tests cover the scenarios above
+
+---
+
+- [ ] **Unit 8: LSP documentSymbol for registered frontmatter keys**
+
+**Goal:** `textDocument/documentSymbol` includes one symbol per registered frontmatter key present in the document, with `SymbolKind.Property`. The symbols sit at the top of the symbol list (before calc-block variables), so editor outlines show frontmatter at the top.
+
+**Requirements:** R5, R6
+
+**Dependencies:** Unit 1, Unit 3, Unit 5
+
+**Files:**
+- Modify: `lsp/server.go` (existing documentSymbol handler at line 113)
+- Modify: `lsp/server_test.go` and `lsp/acceptance_test.go`
+
+**Approach:**
+- Detect the region; if absent, call existing logic.
+- For each `KeyLines` entry whose key is registered, emit a `DocumentSymbol{Name: key, Kind: Property, Range: KeyRanges[key], SelectionRange: ...}`.
+- Append existing calc-block symbols.
+
+**Execution note:** Test-first.
+
+**Patterns to follow:**
+- Existing documentSymbol handler.
+
+**Test scenarios:**
+- Happy: doc with `convert_to: si` produces one symbol with name `convert_to`, kind `Property`
+- Happy: doc with multiple registered keys produces multiple symbols in source order
+- Edge: doc with `Extra` keys produces no symbols for them
+- Edge: doc without frontmatter produces no frontmatter symbols (regression: calc-block symbols unaffected)
+
+**Verification:**
+- `go test ./lsp/... -run DocumentSymbol` green
+- Acceptance tests cover the scenarios above
+
+---
+
+- [ ] **Unit 9: Acceptance tests + close the loop**
+
+**Goal:** End-to-end acceptance tests in `lsp/acceptance_test.go` verifying all six R-numbered behaviors from a real LSP client perspective. Update relevant docs.
+
+**Requirements:** R6, plus durable knowledge capture
+
+**Dependencies:** Units 1-8
+
+**Files:**
+- Modify: `lsp/acceptance_test.go` — add a frontmatter-focused scenario block
+- Modify: `docs/plans/2026-04-14-001-feat-frontmatter-first-class-plan.md` — mark all unit checkboxes complete
+- Possibly create: a short solutions doc in `docs/solutions/` or equivalent if the repo uses one
+- Modify: any user-facing doc that lists supported frontmatter keys (e.g., README, language reference) to point at `Registry` as the source of truth
+
+**Approach:**
+- Acceptance scenario: open a doc with mixed registered + Extra frontmatter keys; verify hover, completion, documentSymbol, and diagnostics behave per R1-R6.
+- Negative scenarios: verify Extra keys produce no LSP responses (no hover, no completion, no symbol, no diagnostic).
+- Regression: existing acceptance tests for non-frontmatter LSP behavior continue passing.
+
+**Execution note:** Pure verification + docs.
+
+**Test scenarios:**
+- Integration: full LSP session opens a fixture doc; one pass verifies R1-R6 against the live LSP server
+- Integration: a fixture with only `Extra` keys (Jekyll-style) → LSP responses for frontmatter are empty across all four LSP methods
+- Regression: existing `acceptance_test.go` tests pass
+
+**Verification:**
+- `task test` (or `go test ./...`) green
+- Plan checkboxes all `[x]`
+
+## System-Wide Impact
+
+- **Interaction graph:** `ParseFrontmatter` consults `Registry` (Unit 2); `semantic.CheckFrontmatter` consults `Registry` and `KeyRanges` (Unit 4); LSP hover/completion/documentSymbol consult `Registry` + region helpers (Units 6/7/8). The registry is the new fan-in point — adding a new CalcMark key in the future means: (a) add to `Registry`, (b) extend the parser switch in `ParseFrontmatter`, (c) every LSP surface picks it up automatically.
+- **Error propagation:** Diagnostics from `CheckFrontmatter` flow into the standard `[]Diagnostic` return; consumers that already render diagnostics (calcmark-web, TUI, LSP `publishDiagnostics`) get them for free once they call the new function.
+- **State lifecycle risks:** None — `Registry` is a package-level constant slice, no mutable state. Region detection is per-call.
+- **API surface parity:** Public APIs grow additively (new exported types in `spec/document` and `spec/semantic`, new helpers in `lsp/`). No existing public function signature changes (R7).
+- **Integration coverage:** Three layers — registry unit tests (Unit 1), semantic-check unit tests (Unit 4), LSP acceptance tests (Units 6/7/8/9). Each layer catches a different class of regression.
+- **Unchanged invariants:**
+  - `Frontmatter` struct field names and types
+  - `ParseFrontmatter` signature and behavior for valid input
+  - Non-CalcMark keys flow into `Extra` and produce no diagnostics / no LSP responses (the user's "ignore everything except calcmark-specific" requirement)
+  - YAML frontmatter delimiter convention (`---` fences at document start)
+  - `FrontmatterInfo` interface keeps its existing methods (may grow new ones)
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| The YAML library go-calcmark uses doesn't expose per-key positions (Unit 3 blocker) | Implementer audits the library; if positions aren't exposed, instrument the parsing pass to record line numbers as it walks. The cost is small (one int per key) and the value (LSP anchoring) is high. |
+| `CheckFrontmatter` diagnostics mostly duplicate parser errors (e.g., the parser already rejects malformed `globals`) | Verify during Unit 4. If the overlap is significant, scope `CheckFrontmatter` to only the cases the parser CAN'T catch (enum value validation, cross-key consistency, etc.). Adjust R2 in the plan if so. |
+| Adding completion / hover changes the LSP behavior for users who currently get nothing for frontmatter — could surface as unexpected popups | All new LSP behavior is opt-in by cursor position; falls through silently outside the frontmatter region. Risk is low; surface in any release notes. |
+| `SymbolKind.Property` icon doesn't render meaningfully in some editor (VS Code, Helix, Neovim differ) | Acceptable cosmetic difference; SymbolKind.Property is the most semantically accurate. Document in Unit 8 if a specific editor breaks. |
+| The registry grows enough to need indexing (D10's "small enough" assumption fails) | The current 6 entries grow slowly; adding indexing is trivial when it matters. Defer until the registry has >20 entries or hot-path profiling shows the iteration cost. |
+| Backward compat regression — calcmark-web's `web/server.go` or the TUI breaks because of a subtle parser change | R7 is the gate. Run the full `go test ./...` after every unit; verify the calcmark-web test suite (separate repo, but `go-calcmark` is its dep) still works after each go-calcmark release tag. |
+| `convert_to` enum values not actually `si`/`imperial` (registry shape wrong from the start) | Unit 1's implementer confirms the actual accepted values by reading `frontmatter.go:330` and adjacent parsing code; updates the registry to match reality. |
+
+## Documentation / Operational Notes
+
+- New exported types: `RegisteredKey`, `FrontmatterKeyType`, `Registry`, `IsRegisteredKey`, `LookupKey`, `CheckFrontmatter`, `DetectRegion`, `ClassifyCursor`. Public API documentation comments are part of each unit's deliverable.
+- After Unit 9 lands and the next go-calcmark release is cut, calcmark-web's plan `2026-04-14-003`'s Deferred entry "First-class frontmatter handling in go-calcmark" can be marked unblocked, and a follow-up calcmark-web plan for frontend frontmatter rendering can be written.
+- No deploy-time changes; this is a library release.
+- Release notes (in the next go-calcmark version): "Frontmatter is now a first-class part of the language. Editors with LSP support get hover docs, completion, and document outline for CalcMark-specific frontmatter keys (`exchange`, `globals`, `scale`, `convert_to`, `measurement`, `fiscal_year_starts`). Non-CalcMark keys (Jekyll-style `title`, `date`, etc.) continue to pass through unmodified."
+
+## Autonomous Execution Guidance
+
+- Each unit is independently committable. Phases 1-2 (Units 1-4) can run sequentially or with Units 1+3 parallelized.
+- Test-first is the default execution posture. Each unit's first commit is a failing test for the new behavior.
+- Mind D10 (time complexity): every new code path is linear or constant in input size. The `Registry` is iterated linearly; that's fine at 6 entries. Region detection is single-pass. If the implementer reaches for a nested loop or repeated re-scan, stop and look for a one-pass alternative.
+- If Unit 3 (per-key ranges) reveals that the YAML library doesn't expose positions, the implementer scopes the work to manual instrumentation in the parsing pass — don't switch YAML libraries for this.
+- If `CheckFrontmatter` (Unit 4) finds that most of its target diagnostics are already produced by the parser, scope it to the residual cases and update the plan's R2 inline rather than producing duplicate diagnostics.
+- If any unit fails its verification, stop and commit what works as a documentation-only escalation; do not push through a broken state.
+
+## Sources & References
+
+- Survey of current state: `spec/document/frontmatter.go` (line refs above), `spec/semantic/checker.go`, `lsp/server.go`, `lsp/diagnostics.go`, `lsp/acceptance_test.go`
+- Calcmark-web plan that asks for this work: `../calcmark-web/.claude/worktrees/plan-interpreter-driven-editor/docs/plans/2026-04-14-003-feat-v2-text-frontmatter-retire-legacy-plan.md` (Deferred to Separate Tasks > "First-class frontmatter handling in go-calcmark")
+- Recent precedent for LSP extension: `docs/plans/2026-04-10-001-feat-lsp-structured-param-types-plan.md`
+- Frontmatter-related earlier work: `docs/plans/2026-02-24-frontmatter-stability-preview-alignment-plan.md`
+- Markdown frontmatter convention: de-facto Jekyll YAML between `---` fences (no formal spec)
+- LSP spec: `textDocument/hover`, `textDocument/completion`, `textDocument/documentSymbol`, `SymbolKind.Property`

--- a/docs/plans/2026-04-14-001-feat-frontmatter-first-class-plan.md
+++ b/docs/plans/2026-04-14-001-feat-frontmatter-first-class-plan.md
@@ -600,7 +600,7 @@ Shipped: CalcMark frontmatter is now a first-class language concept with a typed
 | 6 — LSP hover | `34f604b` |
 | 7 — LSP completion | `a67f7dd` |
 | 8 — LSP documentSymbol | `a4859f7` |
-| 9 — Consolidated acceptance + close the loop | (this commit) |
+| 9 — Consolidated acceptance + close the loop | `ce89021` |
 
 Follow-up handoff: calcmark-web plan `2026-04-14-003`'s Deferred entry "First-class frontmatter handling in go-calcmark" is now unblocked. A new calcmark-web plan for frontend frontmatter rendering can be written against the next go-calcmark release tag.
 

--- a/lsp/acceptance_test.go
+++ b/lsp/acceptance_test.go
@@ -417,3 +417,104 @@ func TestFrontmatterCompletion_Acceptance_CalcBlockStillWorks(t *testing.T) {
 		t.Errorf("expected grow function completion in calc line below frontmatter; labels = %v", itemLabels(items))
 	}
 }
+
+// documentSymbolsAt drives the documentSymbol handler end-to-end and returns
+// the resulting slice, failing the test on transport-level errors.
+func documentSymbolsAt(t *testing.T, s *Server, uri string) []protocol.DocumentSymbol {
+	t.Helper()
+	r, err := s.textDocumentDocumentSymbol(nil, &protocol.DocumentSymbolParams{
+		TextDocument: protocol.TextDocumentIdentifier{URI: uri},
+	})
+	if err != nil {
+		t.Fatalf("documentSymbol error: %v", err)
+	}
+	if r == nil {
+		return nil
+	}
+	syms, ok := r.([]protocol.DocumentSymbol)
+	if !ok {
+		t.Fatalf("documentSymbol result is not []DocumentSymbol: %T", r)
+	}
+	return syms
+}
+
+// TestFrontmatterDocumentSymbol_Acceptance_RegisteredKeysFirst — a doc with
+// frontmatter + calc-block assignments produces frontmatter Property symbols
+// ahead of the Variable/String symbols from the body.
+func TestFrontmatterDocumentSymbol_Acceptance_RegisteredKeysFirst(t *testing.T) {
+	source := "---\nconvert_to: si\nglobals:\n  rate: 10\n---\nprice = 100\n"
+	s, uri := prepareServerDoc(t, source)
+	syms := documentSymbolsAt(t, s, uri)
+
+	if len(syms) < 3 {
+		t.Fatalf("expected at least 3 symbols (2 frontmatter + 1 variable), got %d: %+v", len(syms), syms)
+	}
+	if syms[0].Name != "convert_to" || syms[0].Kind != protocol.SymbolKindProperty {
+		t.Errorf("first symbol should be Property convert_to, got %+v", syms[0])
+	}
+	if syms[1].Name != "globals" || syms[1].Kind != protocol.SymbolKindProperty {
+		t.Errorf("second symbol should be Property globals, got %+v", syms[1])
+	}
+	// The calc-block "price" Variable should appear after frontmatter symbols.
+	var sawPrice bool
+	for _, sym := range syms[2:] {
+		if sym.Name == "price" && sym.Kind == protocol.SymbolKindVariable {
+			sawPrice = true
+			break
+		}
+	}
+	if !sawPrice {
+		t.Errorf("expected Variable symbol 'price' after frontmatter symbols; got %+v", syms)
+	}
+}
+
+// TestFrontmatterDocumentSymbol_Acceptance_ExtraKeysProduceNoSymbols — Extra
+// (unregistered) frontmatter keys must not appear in the outline; calc-block
+// variables still do.
+func TestFrontmatterDocumentSymbol_Acceptance_ExtraKeysProduceNoSymbols(t *testing.T) {
+	source := "---\ntitle: Hello\nauthor: Alice\n---\nprice = 100\n"
+	s, uri := prepareServerDoc(t, source)
+	syms := documentSymbolsAt(t, s, uri)
+
+	for _, sym := range syms {
+		if sym.Name == "title" || sym.Name == "author" {
+			t.Errorf("Extra key %q leaked into documentSymbol output", sym.Name)
+		}
+	}
+	var sawPrice bool
+	for _, sym := range syms {
+		if sym.Name == "price" {
+			sawPrice = true
+			break
+		}
+	}
+	if !sawPrice {
+		t.Errorf("expected Variable symbol 'price' even with Extra-only frontmatter; got %+v", syms)
+	}
+}
+
+// TestFrontmatterDocumentSymbol_Acceptance_NoFrontmatter — documents without
+// any frontmatter produce only calc-block symbols (regression guard).
+func TestFrontmatterDocumentSymbol_Acceptance_NoFrontmatter(t *testing.T) {
+	source := "# Heading\nprice = 100\n"
+	s, uri := prepareServerDoc(t, source)
+	syms := documentSymbolsAt(t, s, uri)
+
+	for _, sym := range syms {
+		if sym.Kind == protocol.SymbolKindProperty {
+			t.Errorf("no Property symbols expected without frontmatter, got %+v", sym)
+		}
+	}
+	var sawHeading, sawPrice bool
+	for _, sym := range syms {
+		if sym.Name == "Heading" {
+			sawHeading = true
+		}
+		if sym.Name == "price" {
+			sawPrice = true
+		}
+	}
+	if !sawHeading || !sawPrice {
+		t.Errorf("expected existing heading+variable symbols intact; got %+v", syms)
+	}
+}

--- a/lsp/acceptance_test.go
+++ b/lsp/acceptance_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/spec/semantic"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 
@@ -516,5 +518,191 @@ func TestFrontmatterDocumentSymbol_Acceptance_NoFrontmatter(t *testing.T) {
 	}
 	if !sawHeading || !sawPrice {
 		t.Errorf("expected existing heading+variable symbols intact; got %+v", syms)
+	}
+}
+
+// TestFrontmatter_Unit9_ConsolidatedSession drives one realistic LSP session
+// covering all six R-numbered behaviors end-to-end against a single server
+// instance + document:
+//
+//   - R1: Registry exposes exactly the six CalcMark-grammar keys and
+//     IsRegisteredKey returns true for each
+//   - R2: semantic.CheckFrontmatter is callable standalone and surfaces
+//     diagnostics for malformed registered keys while ignoring Extra keys
+//   - R3: hover on a registered key returns a markdown body; hover on an
+//     Extra (passthrough) key returns nil
+//   - R4: completion at a key position returns all six registered keys;
+//     completion at an EnumString value position returns the enum values
+//   - R5: documentSymbol lists registered frontmatter keys first, then
+//     calc-block Variable symbols from the body
+//   - R6: the negative case — a document with ONLY Extra keys produces no
+//     frontmatter LSP output from hover, completion, or documentSymbol — is
+//     covered by TestFrontmatter_Unit9_ExtraOnlyNoLSPResponse below
+func TestFrontmatter_Unit9_ConsolidatedSession(t *testing.T) {
+	source := "---\n" +
+		"exchange:\n" + // line 1
+		"  USD_EUR: 0.92\n" + // line 2
+		"convert_to: si\n" + // line 3
+		"globals:\n" + // line 4
+		"  rate: 10\n" + // line 5
+		"title: Hello\n" + // line 6  (Extra)
+		"author: Alice\n" + // line 7  (Extra)
+		"\n" + // line 8  (blank key position)
+		"---\n" + // line 9
+		"price = 100\n" // line 10
+	s, uri := prepareServerDoc(t, source)
+
+	// R1 — Registry shape and membership.
+	if got := len(document.Registry); got != 6 {
+		t.Errorf("R1: Registry has %d entries, want 6", got)
+	}
+	for _, name := range []string{"exchange", "globals", "scale", "convert_to", "measurement", "fiscal_year_starts"} {
+		if !document.IsRegisteredKey(name) {
+			t.Errorf("R1: IsRegisteredKey(%q) = false, want true", name)
+		}
+	}
+	if document.IsRegisteredKey("title") {
+		t.Errorf("R1: IsRegisteredKey(\"title\") = true, want false (Extra passthrough)")
+	}
+
+	// R3 — hover on a registered key returns markdown; Extra key returns nil.
+	if content := hoverContent(t, source, 3, 2); content == "" {
+		t.Errorf("R3: expected non-empty hover on registered key 'convert_to'")
+	} else if !strings.Contains(content, "**convert_to**") {
+		t.Errorf("R3: hover on convert_to missing **convert_to**:\n%s", content)
+	}
+	if h := hoverResult(t, source, 6, 2); h != nil {
+		t.Errorf("R3: expected nil hover on Extra key 'title', got %+v", h)
+	}
+
+	// R4 — completion at a blank key-position line returns every registered key.
+	keyItems := completionAt(t, s, uri, 8, 0)
+	keyLabels := itemLabels(keyItems)
+	for _, want := range []string{"convert_to", "exchange", "fiscal_year_starts", "globals", "measurement", "scale"} {
+		if !slices.Contains(keyLabels, want) {
+			t.Errorf("R4: key-position completion missing %q: %v", want, keyLabels)
+		}
+	}
+	// R4 — completion at the value position of `convert_to: si` returns exactly
+	// the two EnumString values. col 12 = just past "convert_to: ".
+	valItems := completionAt(t, s, uri, 3, 12)
+	valLabels := itemLabels(valItems)
+	if len(valLabels) != 2 {
+		t.Errorf("R4: expected 2 enum labels at convert_to value position, got %d: %v", len(valLabels), valLabels)
+	}
+	for _, want := range []string{"si", "imperial"} {
+		if !slices.Contains(valLabels, want) {
+			t.Errorf("R4: enum-value completion missing %q: %v", want, valLabels)
+		}
+	}
+
+	// R5 — documentSymbol lists registered FM keys first, then calc variables.
+	syms := documentSymbolsAt(t, s, uri)
+	if len(syms) < 4 {
+		t.Fatalf("R5: expected >=4 symbols (3 frontmatter + 1 variable), got %d: %+v", len(syms), syms)
+	}
+	for i, want := range []string{"exchange", "convert_to", "globals"} {
+		if syms[i].Name != want || syms[i].Kind != protocol.SymbolKindProperty {
+			t.Errorf("R5: syms[%d] = %+v, want Property %q", i, syms[i], want)
+		}
+	}
+	for _, sym := range syms[:3] {
+		if sym.Name == "title" || sym.Name == "author" {
+			t.Errorf("R5: Extra key %q leaked into frontmatter symbols", sym.Name)
+		}
+	}
+	var sawPrice bool
+	for _, sym := range syms[3:] {
+		if sym.Name == "price" && sym.Kind == protocol.SymbolKindVariable {
+			sawPrice = true
+			break
+		}
+	}
+	if !sawPrice {
+		t.Errorf("R5: expected Variable 'price' after frontmatter symbols; got %+v", syms)
+	}
+
+	// R2 — semantic.CheckFrontmatter, invoked directly (not folded into LSP
+	// publishDiagnostics per Unit 9 constraint). The parsed document's
+	// frontmatter is clean, so we first assert zero diagnostics (Extra keys
+	// produce no noise), then mutate a registered value to an invalid state and
+	// assert CheckFrontmatter flags it. This exercises the standalone entry
+	// point tooling consumers rely on.
+	fm, _, err := document.ParseFrontmatter(source)
+	if err != nil {
+		t.Fatalf("R2: ParseFrontmatter error: %v", err)
+	}
+	if fm == nil {
+		t.Fatal("R2: ParseFrontmatter returned nil frontmatter")
+	}
+	if diags := semantic.CheckFrontmatter(*fm); len(diags) != 0 {
+		t.Errorf("R2: expected zero diagnostics for clean registered + Extra mix, got %+v", diags)
+	}
+	// Force an invalid convert_to system to confirm CheckFrontmatter catches it.
+	if fm.ConvertTo != nil {
+		fm.ConvertTo.System = "galactic"
+		diags := semantic.CheckFrontmatter(*fm)
+		var sawConvertTo bool
+		for _, d := range diags {
+			if strings.Contains(d.Message, "convert_to") || strings.Contains(d.Message, "galactic") {
+				sawConvertTo = true
+				break
+			}
+		}
+		if !sawConvertTo {
+			t.Errorf("R2: CheckFrontmatter missed malformed convert_to; diags=%+v", diags)
+		}
+	}
+}
+
+// TestFrontmatter_Unit9_ExtraOnlyNoLSPResponse — R6 negative path. A document
+// whose frontmatter contains only Extra (unregistered) keys produces no LSP
+// output from hover on any Extra key, no completion suggestions at a value
+// position of an Extra key, and no Property symbols in documentSymbol. Calc
+// variables below the region continue to work.
+func TestFrontmatter_Unit9_ExtraOnlyNoLSPResponse(t *testing.T) {
+	source := "---\n" +
+		"title: Hello\n" + // line 1
+		"author: Alice\n" + // line 2
+		"date: 2026-04-14\n" + // line 3
+		"---\n" + // line 4
+		"price = 100\n" // line 5
+	s, uri := prepareServerDoc(t, source)
+
+	// Hover — every Extra key returns nil.
+	for i, key := range []string{"title", "author", "date"} {
+		if h := hoverResult(t, source, uint32(i+1), 2); h != nil {
+			t.Errorf("hover on Extra key %q returned non-nil: %+v", key, h)
+		}
+	}
+
+	// Completion — at a value position for an unregistered key, there are no
+	// registry-driven enum values to surface, so the frontmatter completion
+	// path returns nil. col 7 = just past "title: ".
+	items := completionAt(t, s, uri, 1, 7)
+	for _, it := range items {
+		// The only items that could appear here from a cold server are the
+		// calc-block fallbacks, which should never carry FM registry labels.
+		if slices.Contains([]string{"si", "imperial"}, it.Label) {
+			t.Errorf("Extra-only frontmatter surfaced enum value %q in completion", it.Label)
+		}
+	}
+
+	// documentSymbol — no Property symbols, calc variable intact.
+	syms := documentSymbolsAt(t, s, uri)
+	for _, sym := range syms {
+		if sym.Kind == protocol.SymbolKindProperty {
+			t.Errorf("Extra-only frontmatter produced Property symbol: %+v", sym)
+		}
+	}
+	var sawPrice bool
+	for _, sym := range syms {
+		if sym.Name == "price" {
+			sawPrice = true
+			break
+		}
+	}
+	if !sawPrice {
+		t.Errorf("expected Variable 'price' even with Extra-only frontmatter; got %+v", syms)
 	}
 }

--- a/lsp/acceptance_test.go
+++ b/lsp/acceptance_test.go
@@ -361,3 +361,59 @@ func TestFrontmatterHover_Acceptance_VariableStillWorks(t *testing.T) {
 		t.Errorf("variable hover missing 'number'/'100':\n%s", content)
 	}
 }
+
+// TestFrontmatterCompletion_Acceptance_KeyPosition — end-to-end completion
+// at a key position in a frontmatter region returns every registered key.
+func TestFrontmatterCompletion_Acceptance_KeyPosition(t *testing.T) {
+	source := "---\n\n---\n"
+	s, uri := prepareServerDoc(t, source)
+	items := completionAt(t, s, uri, 1, 0)
+
+	labels := itemLabels(items)
+	for _, want := range []string{"convert_to", "exchange", "fiscal_year_starts", "globals", "measurement", "scale"} {
+		if !slices.Contains(labels, want) {
+			t.Errorf("missing registered key %q in completion labels: %v", want, labels)
+		}
+	}
+}
+
+// TestFrontmatterCompletion_Acceptance_EnumValuePosition — end-to-end
+// completion at the value position of `convert_to:` returns exactly the
+// EnumString values for that key.
+func TestFrontmatterCompletion_Acceptance_EnumValuePosition(t *testing.T) {
+	source := "---\nconvert_to: \n---\n"
+	s, uri := prepareServerDoc(t, source)
+	// col 12 = just after "convert_to: "
+	items := completionAt(t, s, uri, 1, 12)
+
+	labels := itemLabels(items)
+	if len(labels) != 2 {
+		t.Fatalf("expected 2 enum labels, got %d: %v", len(labels), labels)
+	}
+	for _, want := range []string{"si", "imperial"} {
+		if !slices.Contains(labels, want) {
+			t.Errorf("missing enum value %q in completion labels: %v", want, labels)
+		}
+	}
+}
+
+// TestFrontmatterCompletion_Acceptance_CalcBlockStillWorks — regression:
+// completion in a calc line below the frontmatter still surfaces functions.
+func TestFrontmatterCompletion_Acceptance_CalcBlockStillWorks(t *testing.T) {
+	source := "---\nconvert_to: si\n---\nx = gro"
+	s, uri := prepareServerDoc(t, source)
+	// Line 3 col 7 = end of "x = gro"
+	items := completionAt(t, s, uri, 3, 7)
+
+	var sawGrow bool
+	for _, it := range items {
+		d, ok := it.Data.(completionItemData)
+		if ok && d.FunctionName == "grow" {
+			sawGrow = true
+			break
+		}
+	}
+	if !sawGrow {
+		t.Errorf("expected grow function completion in calc line below frontmatter; labels = %v", itemLabels(items))
+	}
+}

--- a/lsp/acceptance_test.go
+++ b/lsp/acceptance_test.go
@@ -325,3 +325,39 @@ func TestR6_HoverOnPriceVariable(t *testing.T) {
 		t.Errorf("hover missing '100':\n%s", content)
 	}
 }
+
+// TestFrontmatterHover_Acceptance_RegisteredKey — end-to-end hover on a
+// registered frontmatter key returns non-empty markdown referencing the key.
+func TestFrontmatterHover_Acceptance_RegisteredKey(t *testing.T) {
+	source := "---\nglobals:\n  price: 100\n---\n"
+	content := hoverContent(t, source, 1, 2)
+	if content == "" {
+		t.Fatal("expected hover on globals key")
+	}
+	if !strings.Contains(content, "**globals**") {
+		t.Errorf("hover missing **globals**:\n%s", content)
+	}
+}
+
+// TestFrontmatterHover_Acceptance_ExtraKey — hover on an unregistered
+// frontmatter key (e.g., `title`) returns nil.
+func TestFrontmatterHover_Acceptance_ExtraKey(t *testing.T) {
+	source := "---\ntitle: Hello\n---\n"
+	h := hoverResult(t, source, 1, 2)
+	if h != nil {
+		t.Errorf("expected nil hover for extra key, got %+v", h)
+	}
+}
+
+// TestFrontmatterHover_Acceptance_VariableStillWorks — regression: calc-line
+// variable hover still works when a frontmatter region precedes the body.
+func TestFrontmatterHover_Acceptance_VariableStillWorks(t *testing.T) {
+	source := "---\nconvert_to: si\n---\nprice = 100\n"
+	content := hoverContent(t, source, 3, 2)
+	if content == "" {
+		t.Fatal("expected variable hover below frontmatter")
+	}
+	if !strings.Contains(content, "number") || !strings.Contains(content, "100") {
+		t.Errorf("variable hover missing 'number'/'100':\n%s", content)
+	}
+}

--- a/lsp/completion.go
+++ b/lsp/completion.go
@@ -23,6 +23,22 @@ func (s *Server) textDocumentCompletion(_ *glsp.Context, params *protocol.Comple
 	// Use latest source text (not snapshot -- snapshot may be stale during debounce)
 	source := ds.getSource()
 
+	// Frontmatter completion takes priority. When the cursor sits inside the
+	// frontmatter region we never fall through to calc-block completion:
+	// either we return registered-key / enum-value items, or we return an
+	// empty list (non-enum value positions, unregistered keys). Falling
+	// through would otherwise surface bogus function/variable completions
+	// against YAML text.
+	if region, ok := DetectRegion(source); ok {
+		ctx := ClassifyCursor(region, params.Position)
+		if ctx.InRegion {
+			if items := buildFrontmatterCompletions(source, params.Position); items != nil {
+				return items, nil
+			}
+			return []protocol.CompletionItem{}, nil
+		}
+	}
+
 	// Get the current line text for context-sensitive filtering
 	line := int(params.Position.Line)
 	col := int(params.Position.Character)

--- a/lsp/frontmatter_completion.go
+++ b/lsp/frontmatter_completion.go
@@ -1,0 +1,111 @@
+package lsp
+
+import (
+	"sort"
+
+	specDoc "github.com/CalcMark/go-calcmark/spec/document"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// buildFrontmatterCompletions returns completion items for CalcMark
+// frontmatter context. It returns:
+//
+//   - nil when the cursor is outside the frontmatter region, on a fence, or
+//     at a value position for a non-EnumString / unregistered key
+//   - all registered keys (sorted alphabetically by name) when the cursor is
+//     at a key position inside the region, including blank lines
+//   - the enum values of the key (sorted) when the cursor is at a value
+//     position for an EnumString-typed registered key
+//
+// Filtering decision: prefix filtering is intentionally NOT performed
+// server-side. LSP clients filter the returned list client-side as the user
+// types; returning the full registry keeps the server stateless and matches
+// how the existing calc-block completion surfaces all functions/units.
+//
+// Complexity per D10: O(|Registry|) ≈ 6 iterations for the key branch;
+// O(|EnumValues|) for the value branch.
+func buildFrontmatterCompletions(source string, position protocol.Position) []protocol.CompletionItem {
+	region, ok := DetectRegion(source)
+	if !ok {
+		return nil
+	}
+	ctx := ClassifyCursor(region, position)
+	if !ctx.InRegion {
+		return nil
+	}
+
+	switch ctx.Position {
+	case CursorFence, CursorOutside:
+		return nil
+	case CursorKey:
+		return registeredKeyCompletions()
+	case CursorValue:
+		if ctx.Key == "" {
+			return nil
+		}
+		key, found := specDoc.LookupKey(ctx.Key)
+		if !found {
+			return nil
+		}
+		if key.Type != specDoc.FrontmatterKeyEnumString {
+			// Struct / map value completion is deferred (Open Question).
+			return nil
+		}
+		return enumValueCompletions(key)
+	}
+	return nil
+}
+
+// registeredKeyCompletions returns one CompletionItem per entry in the
+// frontmatter Registry, sorted by label.
+func registeredKeyCompletions() []protocol.CompletionItem {
+	items := make([]protocol.CompletionItem, 0, len(specDoc.Registry))
+	kind := protocol.CompletionItemKindProperty
+	for _, key := range specDoc.Registry {
+		detail := frontmatterTypeLabel(key)
+		label := key.Name
+		insertText := key.Name
+		items = append(items, protocol.CompletionItem{
+			Label:      label,
+			Kind:       &kind,
+			Detail:     &detail,
+			InsertText: &insertText,
+			Documentation: protocol.MarkupContent{
+				Kind:  protocol.MarkupKindMarkdown,
+				Value: renderFrontmatterKeyHover(key),
+			},
+		})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Label < items[j].Label
+	})
+	return items
+}
+
+// enumValueCompletions returns one CompletionItem per enum value on an
+// EnumString-typed registered key, sorted by label.
+func enumValueCompletions(key specDoc.RegisteredKey) []protocol.CompletionItem {
+	if len(key.EnumValues) == 0 {
+		return nil
+	}
+	items := make([]protocol.CompletionItem, 0, len(key.EnumValues))
+	kind := protocol.CompletionItemKindEnumMember
+	for _, v := range key.EnumValues {
+		value := v
+		detail := "value of " + key.Name
+		items = append(items, protocol.CompletionItem{
+			Label:      value,
+			Kind:       &kind,
+			Detail:     &detail,
+			InsertText: &value,
+			Documentation: protocol.MarkupContent{
+				Kind:  protocol.MarkupKindMarkdown,
+				Value: key.Doc,
+			},
+		})
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Label < items[j].Label
+	})
+	return items
+}

--- a/lsp/frontmatter_completion_test.go
+++ b/lsp/frontmatter_completion_test.go
@@ -1,0 +1,184 @@
+package lsp
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// registryKeyNames returns the canonical set of registered CalcMark
+// frontmatter key names. Kept inline so the test fails loudly if Registry
+// changes unexpectedly.
+var registryKeyNames = []string{
+	"convert_to",
+	"exchange",
+	"fiscal_year_starts",
+	"globals",
+	"measurement",
+	"scale",
+}
+
+func itemLabelList(items []protocol.CompletionItem) []string {
+	out := make([]string, 0, len(items))
+	for _, it := range items {
+		out = append(out, it.Label)
+	}
+	return out
+}
+
+// TestFrontmatterCompletion_KeyPosition_EmptyRegion — cursor inside an
+// otherwise empty frontmatter returns all registered keys, alphabetically
+// sorted, with Property kind and a non-empty Markdown documentation.
+func TestFrontmatterCompletion_KeyPosition_EmptyRegion(t *testing.T) {
+	src := "---\n\n---\n"
+	items := buildFrontmatterCompletions(src, protocol.Position{Line: 1, Character: 0})
+	if len(items) != len(registryKeyNames) {
+		t.Fatalf("expected %d items, got %d: %v", len(registryKeyNames), len(items), itemLabelList(items))
+	}
+	labels := itemLabelList(items)
+	if !sort.StringsAreSorted(labels) {
+		t.Errorf("labels not alphabetically sorted: %v", labels)
+	}
+	for i, want := range registryKeyNames {
+		if labels[i] != want {
+			t.Errorf("labels[%d] = %q, want %q (full list %v)", i, labels[i], want, labels)
+		}
+	}
+	// Verify shape of one item
+	var cvt *protocol.CompletionItem
+	for i := range items {
+		if items[i].Label == "convert_to" {
+			cvt = &items[i]
+			break
+		}
+	}
+	if cvt == nil {
+		t.Fatal("convert_to item not found")
+	}
+	if cvt.Kind == nil || *cvt.Kind != protocol.CompletionItemKindProperty {
+		t.Errorf("convert_to kind = %v, want Property", cvt.Kind)
+	}
+	if cvt.Detail == nil || !strings.Contains(*cvt.Detail, "enum") {
+		t.Errorf("convert_to detail missing 'enum': %v", cvt.Detail)
+	}
+	mc, ok := cvt.Documentation.(protocol.MarkupContent)
+	if !ok {
+		t.Fatalf("convert_to documentation not MarkupContent: %T", cvt.Documentation)
+	}
+	if mc.Kind != protocol.MarkupKindMarkdown {
+		t.Errorf("convert_to doc kind = %q, want markdown", mc.Kind)
+	}
+	if !strings.Contains(strings.ToLower(mc.Value), "unit system") {
+		t.Errorf("convert_to doc missing expected text: %q", mc.Value)
+	}
+}
+
+// TestFrontmatterCompletion_KeyPosition_WithExistingKey — cursor on an
+// existing top-level key (before the colon) still returns the full registered
+// list. Client performs prefix filtering; server returns all candidates.
+func TestFrontmatterCompletion_KeyPosition_WithExistingKey(t *testing.T) {
+	src := "---\nconvert_to: si\n---\n"
+	items := buildFrontmatterCompletions(src, protocol.Position{Line: 1, Character: 3})
+	if len(items) != len(registryKeyNames) {
+		t.Fatalf("expected %d items (client-side filtering), got %d", len(registryKeyNames), len(items))
+	}
+}
+
+// TestFrontmatterCompletion_ValuePosition_EnumKey — cursor at value position
+// for an EnumString key returns exactly the enum values, alphabetically
+// sorted, as EnumMember items.
+func TestFrontmatterCompletion_ValuePosition_EnumKey(t *testing.T) {
+	src := "---\nconvert_to: \n---\n"
+	// col 12 = after "convert_to: "
+	items := buildFrontmatterCompletions(src, protocol.Position{Line: 1, Character: 12})
+	if len(items) != 2 {
+		t.Fatalf("expected 2 enum items, got %d: %v", len(items), itemLabelList(items))
+	}
+	labels := itemLabelList(items)
+	if !sort.StringsAreSorted(labels) {
+		t.Errorf("enum labels not sorted: %v", labels)
+	}
+	want := map[string]bool{"si": true, "imperial": true}
+	for _, l := range labels {
+		if !want[l] {
+			t.Errorf("unexpected enum label %q", l)
+		}
+	}
+	if items[0].Kind == nil || *items[0].Kind != protocol.CompletionItemKindEnumMember {
+		t.Errorf("kind = %v, want EnumMember", items[0].Kind)
+	}
+}
+
+// TestFrontmatterCompletion_ValuePosition_EnumKey_AlreadyTyped — even after
+// a value is already present, value-position completion still returns the
+// enum values. Client decides whether to show.
+func TestFrontmatterCompletion_ValuePosition_EnumKey_AlreadyTyped(t *testing.T) {
+	src := "---\nconvert_to: si\n---\n"
+	items := buildFrontmatterCompletions(src, protocol.Position{Line: 1, Character: 14})
+	if len(items) != 2 {
+		t.Fatalf("expected 2 enum items even when value typed, got %d", len(items))
+	}
+}
+
+// TestFrontmatterCompletion_ValuePosition_NonEnum — cursor at value position
+// for a non-EnumString key (e.g., globals → map) returns nil. Struct/map
+// completion is out of scope for this unit.
+func TestFrontmatterCompletion_ValuePosition_NonEnum(t *testing.T) {
+	src := "---\nglobals: \n---\n"
+	items := buildFrontmatterCompletions(src, protocol.Position{Line: 1, Character: 9})
+	if items != nil {
+		t.Errorf("expected nil for non-enum value position, got %v", itemLabelList(items))
+	}
+}
+
+// TestFrontmatterCompletion_ValuePosition_ExtraKey — cursor at value position
+// for an unregistered key returns nil.
+func TestFrontmatterCompletion_ValuePosition_ExtraKey(t *testing.T) {
+	src := "---\ntitle: \n---\n"
+	items := buildFrontmatterCompletions(src, protocol.Position{Line: 1, Character: 7})
+	if items != nil {
+		t.Errorf("expected nil for extra-key value, got %v", itemLabelList(items))
+	}
+}
+
+// TestFrontmatterCompletion_Fence — cursor on `---` fence returns nil.
+func TestFrontmatterCompletion_Fence(t *testing.T) {
+	src := "---\nconvert_to: si\n---\n"
+	if items := buildFrontmatterCompletions(src, protocol.Position{Line: 0, Character: 1}); items != nil {
+		t.Errorf("expected nil on opening fence, got %v", itemLabelList(items))
+	}
+	if items := buildFrontmatterCompletions(src, protocol.Position{Line: 2, Character: 1}); items != nil {
+		t.Errorf("expected nil on closing fence, got %v", itemLabelList(items))
+	}
+}
+
+// TestFrontmatterCompletion_BlankLine — blank line inside region → all
+// registered keys (author about to type a new key).
+func TestFrontmatterCompletion_BlankLine(t *testing.T) {
+	src := "---\nconvert_to: si\n\n---\n"
+	items := buildFrontmatterCompletions(src, protocol.Position{Line: 2, Character: 0})
+	if len(items) != len(registryKeyNames) {
+		t.Fatalf("expected %d items on blank line, got %d", len(registryKeyNames), len(items))
+	}
+}
+
+// TestFrontmatterCompletion_Outside — cursor outside region returns nil
+// (handler falls through to calc completion).
+func TestFrontmatterCompletion_Outside(t *testing.T) {
+	src := "---\nconvert_to: si\n---\nprice = 100\n"
+	items := buildFrontmatterCompletions(src, protocol.Position{Line: 3, Character: 2})
+	if items != nil {
+		t.Errorf("expected nil outside region, got %v", itemLabelList(items))
+	}
+}
+
+// TestFrontmatterCompletion_NoFrontmatter — source without a frontmatter
+// region returns nil.
+func TestFrontmatterCompletion_NoFrontmatter(t *testing.T) {
+	items := buildFrontmatterCompletions("price = 100\n", protocol.Position{Line: 0, Character: 0})
+	if items != nil {
+		t.Errorf("expected nil when no frontmatter, got %v", itemLabelList(items))
+	}
+}

--- a/lsp/frontmatter_hover.go
+++ b/lsp/frontmatter_hover.go
@@ -1,0 +1,79 @@
+package lsp
+
+import (
+	"fmt"
+	"strings"
+
+	specDoc "github.com/CalcMark/go-calcmark/spec/document"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// buildFrontmatterHover returns an *lspHover for registered CalcMark
+// frontmatter keys when the cursor sits on a key or its value. Returns nil
+// when the cursor is outside the frontmatter region, on a fence, on a blank
+// line, or on an unregistered (Extra) key — the caller should fall through to
+// regular hover dispatch in those cases.
+//
+// Content is Markdown formatted as:
+//
+//	**<name>** *(<type-label>)*
+//
+//	<docstring>
+//
+// For EnumString keys the type label includes the accepted values, e.g.
+// `enum: si | imperial`.
+//
+// Complexity: O(|frontmatter source|) for region detection, O(|Registry|) for
+// lookup — per D10.
+func buildFrontmatterHover(source string, position protocol.Position) *lspHover {
+	region, ok := DetectRegion(source)
+	if !ok {
+		return nil
+	}
+	ctx := ClassifyCursor(region, position)
+	if !ctx.InRegion {
+		return nil
+	}
+	switch ctx.Position {
+	case CursorFence, CursorOutside:
+		return nil
+	}
+	if ctx.Key == "" {
+		return nil
+	}
+	key, ok := specDoc.LookupKey(ctx.Key)
+	if !ok {
+		return nil
+	}
+	return &lspHover{
+		Contents: protocol.MarkupContent{
+			Kind:  protocol.MarkupKindMarkdown,
+			Value: renderFrontmatterKeyHover(key),
+		},
+	}
+}
+
+// renderFrontmatterKeyHover formats the Markdown body for a registered key.
+func renderFrontmatterKeyHover(key specDoc.RegisteredKey) string {
+	return fmt.Sprintf("**%s** *(%s)*\n\n%s", key.Name, frontmatterTypeLabel(key), key.Doc)
+}
+
+// frontmatterTypeLabel renders a human-readable type label for hover display.
+// EnumString keys inline the accepted values for at-a-glance learning.
+func frontmatterTypeLabel(key specDoc.RegisteredKey) string {
+	switch key.Type {
+	case specDoc.FrontmatterKeyEnumString:
+		if len(key.EnumValues) > 0 {
+			return "enum: " + strings.Join(key.EnumValues, " | ")
+		}
+		return "enum"
+	case specDoc.FrontmatterKeyMapStringDecimal:
+		return "map<string, decimal>"
+	case specDoc.FrontmatterKeyMapStringString:
+		return "map<string, expression>"
+	case specDoc.FrontmatterKeyStruct:
+		return "struct"
+	default:
+		return key.Type.String()
+	}
+}

--- a/lsp/frontmatter_hover_test.go
+++ b/lsp/frontmatter_hover_test.go
@@ -1,0 +1,101 @@
+package lsp
+
+import (
+	"strings"
+	"testing"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// TestFrontmatterHover_RegisteredKey — cursor on a registered key returns
+// hover content containing the key name, type label, and docstring text.
+func TestFrontmatterHover_RegisteredKey(t *testing.T) {
+	src := "---\nconvert_to: si\n---\nbody\n"
+	h := buildFrontmatterHover(src, protocol.Position{Line: 1, Character: 2})
+	if h == nil {
+		t.Fatal("expected hover for convert_to, got nil")
+	}
+	mc, ok := h.Contents.(protocol.MarkupContent)
+	if !ok {
+		t.Fatalf("contents not MarkupContent: %T", h.Contents)
+	}
+	for _, want := range []string{"**convert_to**", "enum", "si", "imperial"} {
+		if !strings.Contains(mc.Value, want) {
+			t.Errorf("missing %q in hover:\n%s", want, mc.Value)
+		}
+	}
+	if !strings.Contains(strings.ToLower(mc.Value), "unit system") {
+		t.Errorf("expected docstring content in hover:\n%s", mc.Value)
+	}
+}
+
+// TestFrontmatterHover_EnumValue — cursor on an enum value of a registered
+// key returns the same key hover (acceptable delegation).
+func TestFrontmatterHover_EnumValue(t *testing.T) {
+	src := "---\nconvert_to: si\n---\n"
+	h := buildFrontmatterHover(src, protocol.Position{Line: 1, Character: 13})
+	if h == nil {
+		t.Fatal("expected hover on enum value")
+	}
+	mc := h.Contents.(protocol.MarkupContent)
+	if !strings.Contains(mc.Value, "**convert_to**") {
+		t.Errorf("missing key in hover:\n%s", mc.Value)
+	}
+}
+
+// TestFrontmatterHover_ExtraKey — title is not registered, returns nil.
+func TestFrontmatterHover_ExtraKey(t *testing.T) {
+	src := "---\ntitle: Hello\n---\n"
+	if h := buildFrontmatterHover(src, protocol.Position{Line: 1, Character: 2}); h != nil {
+		t.Errorf("expected nil for extra key, got %+v", h)
+	}
+}
+
+// TestFrontmatterHover_Outside — cursor outside frontmatter returns nil
+// (handler must fall through to regular hover).
+func TestFrontmatterHover_Outside(t *testing.T) {
+	src := "---\nconvert_to: si\n---\nprice = 100\n"
+	if h := buildFrontmatterHover(src, protocol.Position{Line: 3, Character: 2}); h != nil {
+		t.Errorf("expected nil outside frontmatter, got %+v", h)
+	}
+}
+
+// TestFrontmatterHover_Fence — cursor on `---` fence returns nil.
+func TestFrontmatterHover_Fence(t *testing.T) {
+	src := "---\nconvert_to: si\n---\n"
+	if h := buildFrontmatterHover(src, protocol.Position{Line: 0, Character: 1}); h != nil {
+		t.Errorf("expected nil on fence, got %+v", h)
+	}
+	if h := buildFrontmatterHover(src, protocol.Position{Line: 2, Character: 1}); h != nil {
+		t.Errorf("expected nil on closing fence, got %+v", h)
+	}
+}
+
+// TestFrontmatterHover_Blank — blank line inside frontmatter returns nil.
+func TestFrontmatterHover_Blank(t *testing.T) {
+	src := "---\n\nconvert_to: si\n---\n"
+	if h := buildFrontmatterHover(src, protocol.Position{Line: 1, Character: 0}); h != nil {
+		t.Errorf("expected nil on blank line, got %+v", h)
+	}
+}
+
+// TestFrontmatterHover_IndentedContinuation — cursor on an indented
+// continuation line returns the parent key's hover.
+func TestFrontmatterHover_IndentedContinuation(t *testing.T) {
+	src := "---\nglobals:\n  price: 100\n---\n"
+	h := buildFrontmatterHover(src, protocol.Position{Line: 2, Character: 4})
+	if h == nil {
+		t.Fatal("expected hover on indented globals continuation")
+	}
+	mc := h.Contents.(protocol.MarkupContent)
+	if !strings.Contains(mc.Value, "**globals**") {
+		t.Errorf("missing parent key in hover:\n%s", mc.Value)
+	}
+}
+
+// TestFrontmatterHover_NoFrontmatter — source without `---` returns nil.
+func TestFrontmatterHover_NoFrontmatter(t *testing.T) {
+	if h := buildFrontmatterHover("price = 100", protocol.Position{Line: 0, Character: 0}); h != nil {
+		t.Errorf("expected nil when no frontmatter, got %+v", h)
+	}
+}

--- a/lsp/frontmatter_region.go
+++ b/lsp/frontmatter_region.go
@@ -1,0 +1,168 @@
+package lsp
+
+import (
+	"strings"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// CursorPosition classifies where in the frontmatter region a cursor sits.
+// String-typed for diagnostic readability per D1 (pragmatism).
+type CursorPosition string
+
+const (
+	CursorOutside CursorPosition = "outside"
+	CursorFence   CursorPosition = "fence"
+	CursorKey     CursorPosition = "key"
+	CursorValue   CursorPosition = "value"
+)
+
+// FrontmatterRegion describes the YAML frontmatter region delimited by `---`
+// fences at the top of a CalcMark source. Lines are 0-based to match LSP.
+type FrontmatterRegion struct {
+	StartLine int            // line of opening `---`
+	EndLine   int            // line of closing `---`
+	KeyLines  map[int]string // line index → top-level key name
+	// lines is the verbatim content of the region (StartLine..EndLine inclusive)
+	// indexed by absolute line number. Used by ClassifyCursor; unexported because
+	// callers should treat the region as opaque.
+	lines map[int]string
+}
+
+// CursorContext is the result of classifying a cursor against a region.
+type CursorContext struct {
+	InRegion bool
+	Position CursorPosition
+	Key      string // name of the key the cursor relates to ("" when unknown)
+}
+
+// DetectRegion finds the YAML frontmatter region in source. It is mid-edit
+// robust: it does NOT parse YAML — it only locates the fences and extracts
+// top-level key names from `key:` patterns. Returns ok=false when the source
+// does not begin with a `---\n` fence or when no closing fence is present.
+//
+// Complexity: O(n) over the bytes up to (and including) the closing fence.
+func DetectRegion(source string) (FrontmatterRegion, bool) {
+	if !strings.HasPrefix(source, "---\n") && source != "---\r\n" && !strings.HasPrefix(source, "---\r\n") {
+		return FrontmatterRegion{}, false
+	}
+
+	lines := strings.Split(source, "\n")
+	if len(lines) < 2 {
+		return FrontmatterRegion{}, false
+	}
+	// Confirm line 0 is exactly `---` (allow trailing CR).
+	if strings.TrimRight(lines[0], "\r") != "---" {
+		return FrontmatterRegion{}, false
+	}
+
+	endLine := -1
+	for i := 1; i < len(lines); i++ {
+		if strings.TrimRight(lines[i], "\r") == "---" {
+			endLine = i
+			break
+		}
+	}
+	if endLine == -1 {
+		return FrontmatterRegion{}, false
+	}
+
+	region := FrontmatterRegion{
+		StartLine: 0,
+		EndLine:   endLine,
+		KeyLines:  make(map[int]string),
+		lines:     make(map[int]string, endLine+1),
+	}
+	for i := 0; i <= endLine; i++ {
+		region.lines[i] = lines[i]
+	}
+	for i := 1; i < endLine; i++ {
+		if name, ok := topLevelKey(lines[i]); ok {
+			region.KeyLines[i] = name
+		}
+	}
+	return region, true
+}
+
+// topLevelKey extracts the key name from a `key: ...` line at zero indentation.
+// Returns ok=false for indented lines, comments, blank lines, or lines without
+// a `:` separator.
+func topLevelKey(line string) (string, bool) {
+	trimmedRight := strings.TrimRight(line, "\r")
+	if trimmedRight == "" {
+		return "", false
+	}
+	// Top-level keys have NO leading whitespace.
+	if trimmedRight[0] == ' ' || trimmedRight[0] == '\t' {
+		return "", false
+	}
+	if trimmedRight[0] == '#' {
+		return "", false
+	}
+	colon := strings.IndexByte(trimmedRight, ':')
+	if colon <= 0 {
+		return "", false
+	}
+	name := trimmedRight[:colon]
+	// Reject names with internal whitespace — not a valid YAML mapping key shape we recognize.
+	if strings.ContainsAny(name, " \t") {
+		return "", false
+	}
+	return name, true
+}
+
+// ClassifyCursor determines where the cursor at position sits relative to the
+// region: outside, on a fence, on a key, or in a value (including indented
+// continuations of the most recent top-level key).
+//
+// Edge case: if the cursor sits exactly on the `:` separator column, it is
+// classified as "key" — the user has not yet stepped into the value.
+//
+// Complexity: O(EndLine) worst case when scanning back for a parent key; for
+// well-formed frontmatter this is bounded by the region size.
+func ClassifyCursor(region FrontmatterRegion, position protocol.Position) CursorContext {
+	line := int(position.Line)
+	if line < region.StartLine || line > region.EndLine {
+		return CursorContext{InRegion: false, Position: CursorOutside}
+	}
+	if line == region.StartLine || line == region.EndLine {
+		return CursorContext{InRegion: true, Position: CursorFence}
+	}
+
+	col := int(position.Character)
+	text := region.lines[line]
+
+	// Top-level key line: cursor at-or-before colon → key; after colon → value.
+	if name, ok := region.KeyLines[line]; ok {
+		colon := strings.IndexByte(strings.TrimRight(text, "\r"), ':')
+		if colon < 0 || col <= colon {
+			return CursorContext{InRegion: true, Position: CursorKey, Key: name}
+		}
+		return CursorContext{InRegion: true, Position: CursorValue, Key: name}
+	}
+
+	// Blank line → key-position with no name (author about to type a key).
+	if strings.TrimSpace(text) == "" {
+		return CursorContext{InRegion: true, Position: CursorKey, Key: ""}
+	}
+
+	// Indented continuation → value of the most recent top-level key above.
+	if len(text) > 0 && (text[0] == ' ' || text[0] == '\t') {
+		return CursorContext{InRegion: true, Position: CursorValue, Key: parentKey(region, line)}
+	}
+
+	// Fallback: a non-blank, non-indented line we didn't classify as a top-level
+	// key (e.g., garbled mid-edit input). Treat as key-position with no name.
+	return CursorContext{InRegion: true, Position: CursorKey, Key: ""}
+}
+
+// parentKey scans backward from line-1 to find the nearest top-level key in
+// region.KeyLines. Returns "" if none found.
+func parentKey(region FrontmatterRegion, line int) string {
+	for i := line - 1; i > region.StartLine; i-- {
+		if name, ok := region.KeyLines[i]; ok {
+			return name
+		}
+	}
+	return ""
+}

--- a/lsp/frontmatter_region_test.go
+++ b/lsp/frontmatter_region_test.go
@@ -1,0 +1,193 @@
+package lsp
+
+import (
+	"reflect"
+	"testing"
+
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+func TestDetectRegion(t *testing.T) {
+	cases := []struct {
+		name       string
+		source     string
+		wantOK     bool
+		wantStart  int
+		wantEnd    int
+		wantKeys   map[int]string
+	}{
+		{
+			name:      "well-formed single key",
+			source:    "---\nconvert_to: si\n---\n# Body\n",
+			wantOK:    true,
+			wantStart: 0,
+			wantEnd:   2,
+			wantKeys:  map[int]string{1: "convert_to"},
+		},
+		{
+			name:      "multi-key with nested map",
+			source:    "---\nconvert_to: si\nglobals:\n  foo: 1\n---\n",
+			wantOK:    true,
+			wantStart: 0,
+			wantEnd:   4,
+			wantKeys:  map[int]string{1: "convert_to", 2: "globals"},
+		},
+		{
+			name:   "no frontmatter",
+			source: "# Just body\n",
+			wantOK: false,
+		},
+		{
+			name:   "missing closing fence",
+			source: "---\nconvert_to: si\n",
+			wantOK: false,
+		},
+		{
+			name:      "empty body between fences",
+			source:    "---\n---\n",
+			wantOK:    true,
+			wantStart: 0,
+			wantEnd:   1,
+			wantKeys:  map[int]string{},
+		},
+		{
+			name:   "leading whitespace before fence is rejected",
+			source: "  ---\nconvert_to: si\n---\n",
+			wantOK: false,
+		},
+		{
+			name:      "extra (non-registered) key included",
+			source:    "---\ntitle: Hello\n---\n",
+			wantOK:    true,
+			wantStart: 0,
+			wantEnd:   2,
+			wantKeys:  map[int]string{1: "title"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			region, ok := DetectRegion(tc.source)
+			if ok != tc.wantOK {
+				t.Fatalf("DetectRegion ok = %v, want %v", ok, tc.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if region.StartLine != tc.wantStart {
+				t.Errorf("StartLine = %d, want %d", region.StartLine, tc.wantStart)
+			}
+			if region.EndLine != tc.wantEnd {
+				t.Errorf("EndLine = %d, want %d", region.EndLine, tc.wantEnd)
+			}
+			if !reflect.DeepEqual(region.KeyLines, tc.wantKeys) {
+				t.Errorf("KeyLines = %v, want %v", region.KeyLines, tc.wantKeys)
+			}
+		})
+	}
+}
+
+func TestClassifyCursor(t *testing.T) {
+	// Region for "---\nconvert_to: si\n---\n# Body\n"
+	simple, ok := DetectRegion("---\nconvert_to: si\n---\n# Body\n")
+	if !ok {
+		t.Fatal("setup: expected DetectRegion ok for simple source")
+	}
+	// Region for "---\nconvert_to: si\nglobals:\n  foo: bar\n---\n"
+	nested, ok := DetectRegion("---\nconvert_to: si\nglobals:\n  foo: bar\n---\n")
+	if !ok {
+		t.Fatal("setup: expected DetectRegion ok for nested source")
+	}
+	// Region for "---\n\n---\n" — blank line between fences
+	blank, ok := DetectRegion("---\n\n---\n")
+	if !ok {
+		t.Fatal("setup: expected DetectRegion ok for blank-body source")
+	}
+
+	cases := []struct {
+		name     string
+		region   FrontmatterRegion
+		pos      protocol.Position
+		wantIn   bool
+		wantPos  CursorPosition
+		wantKey  string
+	}{
+		{
+			name:    "outside region (after end fence)",
+			region:  simple,
+			pos:     protocol.Position{Line: 3, Character: 0},
+			wantIn:  false,
+			wantPos: CursorOutside,
+			wantKey: "",
+		},
+		{
+			name:    "on opening fence",
+			region:  simple,
+			pos:     protocol.Position{Line: 0, Character: 0},
+			wantIn:  true,
+			wantPos: CursorFence,
+		},
+		{
+			name:    "on closing fence",
+			region:  simple,
+			pos:     protocol.Position{Line: 2, Character: 0},
+			wantIn:  true,
+			wantPos: CursorFence,
+		},
+		{
+			name:    "key position at column 0",
+			region:  simple,
+			pos:     protocol.Position{Line: 1, Character: 0},
+			wantIn:  true,
+			wantPos: CursorKey,
+			wantKey: "convert_to",
+		},
+		{
+			name:    "value position past colon",
+			region:  simple,
+			pos:     protocol.Position{Line: 1, Character: 12},
+			wantIn:  true,
+			wantPos: CursorValue,
+			wantKey: "convert_to",
+		},
+		{
+			name:    "exactly on the colon counts as key",
+			region:  simple,
+			pos:     protocol.Position{Line: 1, Character: 10},
+			wantIn:  true,
+			wantPos: CursorKey,
+			wantKey: "convert_to",
+		},
+		{
+			name:    "blank line between fences → key, no name",
+			region:  blank,
+			pos:     protocol.Position{Line: 1, Character: 0},
+			wantIn:  true,
+			wantPos: CursorKey,
+			wantKey: "",
+		},
+		{
+			name:    "indented continuation line → value, parent key",
+			region:  nested,
+			pos:     protocol.Position{Line: 3, Character: 4},
+			wantIn:  true,
+			wantPos: CursorValue,
+			wantKey: "globals",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := ClassifyCursor(tc.region, tc.pos)
+			if ctx.InRegion != tc.wantIn {
+				t.Errorf("InRegion = %v, want %v", ctx.InRegion, tc.wantIn)
+			}
+			if ctx.Position != tc.wantPos {
+				t.Errorf("Position = %q, want %q", ctx.Position, tc.wantPos)
+			}
+			if ctx.Key != tc.wantKey {
+				t.Errorf("Key = %q, want %q", ctx.Key, tc.wantKey)
+			}
+		})
+	}
+}

--- a/lsp/frontmatter_symbols.go
+++ b/lsp/frontmatter_symbols.go
@@ -1,0 +1,71 @@
+package lsp
+
+import (
+	"sort"
+
+	"github.com/CalcMark/go-calcmark/spec/ast"
+	specDoc "github.com/CalcMark/go-calcmark/spec/document"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// buildFrontmatterSymbols returns DocumentSymbol entries for every registered
+// CalcMark frontmatter key physically present in the source (as captured in
+// fm.KeyRanges). Emission order is source order — ascending Range.Start.Line —
+// so the outline reflects the document top-to-bottom.
+//
+// Extra (unregistered) keys produce no symbols per the Extra-passthrough
+// principle: they carry no CalcMark semantics and belong to generic Markdown
+// front matter, not our language surface.
+//
+// Complexity: O(|registered keys in source|) ≈ ≤6 (per D10). The sort is over
+// that same small slice.
+func buildFrontmatterSymbols(fm specDoc.Frontmatter) []protocol.DocumentSymbol {
+	if len(fm.KeyRanges) == 0 {
+		return nil
+	}
+
+	type entry struct {
+		name string
+		r    ast.Range
+	}
+	registered := make([]entry, 0, len(fm.KeyRanges))
+	for name, r := range fm.KeyRanges {
+		if !specDoc.IsRegisteredKey(name) {
+			continue
+		}
+		registered = append(registered, entry{name: name, r: r})
+	}
+	if len(registered) == 0 {
+		return nil
+	}
+	sort.Slice(registered, func(i, j int) bool {
+		return registered[i].r.Start.Line < registered[j].r.Start.Line
+	})
+
+	out := make([]protocol.DocumentSymbol, 0, len(registered))
+	for _, e := range registered {
+		r := e.r
+		full := ToLSPRange(&r)
+		// SelectionRange: identifier-only. Keys are YAML top-level identifiers,
+		// always on a single line, starting at the key's start column.
+		sel := protocol.Range{
+			Start: full.Start,
+			End: protocol.Position{
+				Line:      full.Start.Line,
+				Character: full.Start.Character + protocol.UInteger(len(e.name)),
+			},
+		}
+		sym := protocol.DocumentSymbol{
+			Name:           e.name,
+			Kind:           protocol.SymbolKindProperty,
+			Range:          full,
+			SelectionRange: sel,
+		}
+		if key, ok := specDoc.LookupKey(e.name); ok {
+			label := frontmatterTypeLabel(key)
+			sym.Detail = &label
+		}
+		out = append(out, sym)
+	}
+	return out
+}

--- a/lsp/frontmatter_symbols_test.go
+++ b/lsp/frontmatter_symbols_test.go
@@ -1,0 +1,134 @@
+package lsp
+
+import (
+	"testing"
+
+	"github.com/CalcMark/go-calcmark/spec/ast"
+	specDoc "github.com/CalcMark/go-calcmark/spec/document"
+	protocol "github.com/tliron/glsp/protocol_3_16"
+)
+
+// mkRange is a small local helper so tests read as specs, not arithmetic.
+func mkRange(startLine, startCol, endLine, endCol int) ast.Range {
+	return ast.Range{
+		Start: ast.Position{Line: startLine, Column: startCol},
+		End:   ast.Position{Line: endLine, Column: endCol},
+	}
+}
+
+func TestBuildFrontmatterSymbols_HappyRegisteredKeys(t *testing.T) {
+	fm := specDoc.Frontmatter{
+		KeyRanges: map[string]ast.Range{
+			"convert_to": mkRange(2, 1, 2, 12),
+			"globals":    mkRange(3, 1, 5, 20),
+		},
+	}
+	syms := buildFrontmatterSymbols(fm)
+	if len(syms) != 2 {
+		t.Fatalf("expected 2 symbols, got %d", len(syms))
+	}
+	// Source-order: convert_to on line 2 comes before globals on line 3.
+	if syms[0].Name != "convert_to" {
+		t.Errorf("expected first symbol convert_to, got %q", syms[0].Name)
+	}
+	if syms[1].Name != "globals" {
+		t.Errorf("expected second symbol globals, got %q", syms[1].Name)
+	}
+	if syms[0].Kind != protocol.SymbolKindProperty {
+		t.Errorf("expected Kind Property (7), got %v", syms[0].Kind)
+	}
+	// 0-indexed LSP conversion: line 2 -> 1.
+	if syms[0].Range.Start.Line != 1 {
+		t.Errorf("expected convert_to Range.Start.Line=1, got %d", syms[0].Range.Start.Line)
+	}
+}
+
+func TestBuildFrontmatterSymbols_ExtraOnly(t *testing.T) {
+	fm := specDoc.Frontmatter{
+		KeyRanges: map[string]ast.Range{
+			"title": mkRange(2, 1, 2, 12),
+		},
+	}
+	syms := buildFrontmatterSymbols(fm)
+	if len(syms) != 0 {
+		t.Errorf("expected no symbols for Extra-only frontmatter, got %d: %+v", len(syms), syms)
+	}
+}
+
+func TestBuildFrontmatterSymbols_SortedBySourceLine(t *testing.T) {
+	// Map iteration order is randomized; the helper must emit in line order.
+	fm := specDoc.Frontmatter{
+		KeyRanges: map[string]ast.Range{
+			"globals":    mkRange(5, 1, 7, 5),
+			"convert_to": mkRange(2, 1, 2, 12),
+			"exchange":   mkRange(3, 1, 4, 15),
+		},
+	}
+	syms := buildFrontmatterSymbols(fm)
+	if len(syms) != 3 {
+		t.Fatalf("expected 3 symbols, got %d", len(syms))
+	}
+	want := []string{"convert_to", "exchange", "globals"}
+	for i, name := range want {
+		if syms[i].Name != name {
+			t.Errorf("position %d: want %q, got %q", i, name, syms[i].Name)
+		}
+	}
+}
+
+func TestBuildFrontmatterSymbols_EmptyFrontmatter(t *testing.T) {
+	syms := buildFrontmatterSymbols(specDoc.Frontmatter{})
+	if len(syms) != 0 {
+		t.Errorf("expected empty slice for empty frontmatter, got %d symbols", len(syms))
+	}
+}
+
+func TestBuildFrontmatterSymbols_RegisteredKeyPresentEvenIfTypedFieldsAbsent(t *testing.T) {
+	// Only KeyRanges has "convert_to"; typed field ConvertTo is nil. The key
+	// physically appeared in the source, so we still emit a symbol for it.
+	fm := specDoc.Frontmatter{
+		KeyRanges: map[string]ast.Range{
+			"convert_to": mkRange(2, 1, 2, 12),
+		},
+	}
+	syms := buildFrontmatterSymbols(fm)
+	if len(syms) != 1 || syms[0].Name != "convert_to" {
+		t.Fatalf("expected one convert_to symbol, got %+v", syms)
+	}
+}
+
+func TestBuildFrontmatterSymbols_MixedRegisteredAndExtra(t *testing.T) {
+	fm := specDoc.Frontmatter{
+		KeyRanges: map[string]ast.Range{
+			"title":      mkRange(2, 1, 2, 12),
+			"convert_to": mkRange(3, 1, 3, 12),
+			"author":     mkRange(4, 1, 4, 12),
+		},
+	}
+	syms := buildFrontmatterSymbols(fm)
+	if len(syms) != 1 || syms[0].Name != "convert_to" {
+		t.Fatalf("expected only convert_to, got %+v", syms)
+	}
+}
+
+func TestBuildFrontmatterSymbols_SelectionRangeIsKeyOnly(t *testing.T) {
+	// For a key "convert_to" on line 2 col 1, SelectionRange should cover the
+	// identifier itself (same line, col 1 .. col 1+len("convert_to")).
+	fm := specDoc.Frontmatter{
+		KeyRanges: map[string]ast.Range{
+			"convert_to": mkRange(2, 1, 3, 5),
+		},
+	}
+	syms := buildFrontmatterSymbols(fm)
+	if len(syms) != 1 {
+		t.Fatalf("expected 1 symbol, got %d", len(syms))
+	}
+	sel := syms[0].SelectionRange
+	if sel.Start.Line != 1 || sel.End.Line != 1 {
+		t.Errorf("SelectionRange should stay on key line (line 1 in LSP 0-indexed), got %+v", sel)
+	}
+	// convert_to is 10 chars, start col 1 → LSP char 0; end char 10.
+	if sel.Start.Character != 0 || sel.End.Character != 10 {
+		t.Errorf("SelectionRange columns want 0..10, got %d..%d", sel.Start.Character, sel.End.Character)
+	}
+}

--- a/lsp/hover.go
+++ b/lsp/hover.go
@@ -7,6 +7,7 @@ import (
 	"text/template"
 	"unicode"
 
+	specDoc "github.com/CalcMark/go-calcmark/spec/document"
 	"github.com/CalcMark/go-calcmark/spec/features"
 	"github.com/CalcMark/go-calcmark/spec/types"
 	"github.com/CalcMark/go-calcmark/spec/units"
@@ -335,6 +336,14 @@ func (s *Server) textDocumentDocumentSymbol(_ *glsp.Context, params *protocol.Do
 	source := ds.getSource()
 
 	var symbols []protocol.DocumentSymbol
+
+	// Prepend frontmatter symbols for registered keys. A malformed YAML
+	// frontmatter must not kill the outline — if parsing fails we simply
+	// skip the frontmatter section and still emit calc-block symbols.
+	if fm, _, err := specDoc.ParseFrontmatter(source); err == nil && fm != nil {
+		symbols = append(symbols, buildFrontmatterSymbols(*fm)...)
+	}
+
 	lines := strings.Split(source, "\n")
 
 	for i, line := range lines {

--- a/lsp/hover.go
+++ b/lsp/hover.go
@@ -106,6 +106,23 @@ func (s *Server) hoverHandle(params *protocol.HoverParams) (any, error) {
 	}
 
 	source := ds.getSource()
+
+	// Frontmatter hover takes priority. When the cursor sits inside the
+	// frontmatter region we never fall through to calc-block hover: either
+	// we return a registered-key hover, or we return null (Extra keys,
+	// fences, blanks). This prevents the word-under-cursor code below from
+	// producing bogus variable/function matches against YAML text.
+	if region, ok := DetectRegion(source); ok {
+		ctx := ClassifyCursor(region, params.Position)
+		if ctx.InRegion {
+			h := buildFrontmatterHover(source, params.Position)
+			if h == nil {
+				return nil, nil
+			}
+			return h, nil
+		}
+	}
+
 	line := int(params.Position.Line)
 	col := int(params.Position.Character)
 	lineText := getLineText(source, line)

--- a/site/content/docs/user-guide/frontmatter.md
+++ b/site/content/docs/user-guide/frontmatter.md
@@ -5,6 +5,8 @@ weight: 3
 
 CalcMark uses YAML frontmatter to configure document-wide behavior: global variables, directive references, template interpolation, and scaling/conversion transforms.
 
+Editors with CalcMark LSP support (including the TUI and the CalcMark web editor) show hover documentation, completion, and document-outline entries for CalcMark-specific frontmatter keys. Keys outside the CalcMark set (e.g., Jekyll-style `title`, `date`, `author`) pass through untouched with no editor hints. The authoritative list of CalcMark-grammar keys lives in [`spec/document/frontmatter_registry.go`](https://github.com/CalcMark/go-calcmark/blob/main/spec/document/frontmatter_registry.go).
+
 ### Global Variables {#global-variables}
 
 Define reusable values in the frontmatter that can be referenced throughout your document:

--- a/spec/document/eval_flow_debug_test.go
+++ b/spec/document/eval_flow_debug_test.go
@@ -1,4 +1,10 @@
-package document
+package document_test
+
+// This test lives in package document_test (not document) to break what would
+// otherwise be a test-only import cycle: spec/semantic imports spec/document
+// (for document.Frontmatter in CheckFrontmatter), and a `package document` test
+// importing spec/semantic would close the cycle. The test exercises only
+// exported symbols, so the move is safe.
 
 import (
 	"testing"

--- a/spec/document/frontmatter.go
+++ b/spec/document/frontmatter.go
@@ -879,7 +879,15 @@ func nodeEndPosition(n *yaml.Node, lineOffset int) ast.Position {
 	default: // ScalarNode and DocumentNode (DocumentNode shouldn't appear here)
 		// Approximate the scalar's end by adding its rendered length to the
 		// start column. yaml.v3 does not expose folded/literal block scalar end
-		// positions; for those rare cases this gives a reasonable lower bound.
+		// positions; for `|` and `>` block scalars this leaves End.Line on the
+		// KEY line (the line of the `|` / `>` indicator), not the last physical
+		// line of the block content. Consumers (currently only the LSP) that
+		// anchor UI to the key location are unaffected; anything needing the
+		// full byte span of a block scalar would be wrong. See
+		// spec/document/frontmatter_yaml_shapes_test.go
+		// (TestParseFrontmatter_YAMLShape_LiteralBlockScalar) — the test
+		// asserts the observed (imperfect) value, so a future fix is a clean
+		// test-flip.
 		col := n.Column + len(n.Value)
 		if col < n.Column {
 			col = n.Column

--- a/spec/document/frontmatter.go
+++ b/spec/document/frontmatter.go
@@ -696,16 +696,14 @@ func ParseFrontmatter(source string) (*Frontmatter, string, error) {
 		fm.FiscalYearStarts = fc
 	}
 
-	// Capture non-CalcMark frontmatter keys in document order.
-	knownKeys := map[string]bool{
-		"exchange": true, "globals": true, "scale": true,
-		"convert_to": true, "measurement": true, "fiscal_year_starts": true,
-	}
+	// Capture non-CalcMark frontmatter keys in document order. The Registry
+	// (frontmatter_registry.go) is the source of truth for which keys carry
+	// CalcMark semantics; everything else is preserved verbatim in Extra.
 	extraOrder := extractYAMLTopLevelKeyOrder(yamlContent)
 	var rawMap map[string]any
 	_ = yaml.Unmarshal([]byte(yamlContent), &rawMap)
 	for _, key := range extraOrder {
-		if knownKeys[key] {
+		if IsRegisteredKey(key) {
 			continue
 		}
 		if val, ok := rawMap[key]; ok {

--- a/spec/document/frontmatter.go
+++ b/spec/document/frontmatter.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/CalcMark/go-calcmark/spec/ast"
 	"github.com/CalcMark/go-calcmark/spec/units"
 	"github.com/shopspring/decimal"
 	"gopkg.in/yaml.v3"
@@ -120,6 +121,20 @@ type Frontmatter struct {
 	// editing of frontmatter lines (Enter, whitespace, etc.) in the TUI editor.
 	// Cleared on programmatic modification (SetGlobal, SetExchangeRate).
 	rawSource string
+
+	// KeyRanges maps each top-level frontmatter key (registered or Extra) to
+	// the source range covering its key+value YAML block. Lines and columns are
+	// 1-based, matching ast.Position convention (see spec/ast/position.go).
+	// The range starts at the key identifier and ends at the last byte of its
+	// value (for mappings/sequences, the last byte of the deepest child).
+	//
+	// Absent keys are simply not present in the map. Use the
+	// `r, ok := fm.KeyRanges[key]` idiom; a returned zero-value ast.Range from a
+	// missing key is indistinguishable from one explicitly stored as zero.
+	//
+	// Lines are document-relative: line 1 is the opening "---" fence and the
+	// first key sits on line 2 in a typical frontmatter.
+	KeyRanges map[string]ast.Range
 }
 
 // ExtraField holds a non-CalcMark frontmatter key-value pair.
@@ -696,6 +711,11 @@ func ParseFrontmatter(source string) (*Frontmatter, string, error) {
 		fm.FiscalYearStarts = fc
 	}
 
+	// Capture per-key source ranges for every top-level key (registered + Extra).
+	// Lines are document-relative (1-based); the YAML body starts on line 2
+	// because line 1 is the opening "---" fence, hence yamlLineOffset = 1.
+	fm.KeyRanges = collectKeyRanges(yamlContent, 1)
+
 	// Capture non-CalcMark frontmatter keys in document order. The Registry
 	// (frontmatter_registry.go) is the source of truth for which keys carry
 	// CalcMark semantics; everything else is preserved verbatim in Extra.
@@ -803,6 +823,69 @@ func extractYAMLKeyOrder(yamlContent string, topKey string) []string {
 		}
 	}
 	return nil
+}
+
+// collectKeyRanges walks the top-level keys of a YAML mapping and returns each
+// key's source range covering the key identifier through the last byte of its
+// value. Line/column numbers are 1-based per ast.Position; lineOffset is added
+// to every yaml.Node line so callers can translate yaml-content-relative lines
+// into document-relative lines (typical caller passes 1 to skip the "---"
+// fence on document line 1).
+//
+// Returns an empty map (non-nil) when the YAML is empty or not a mapping, so
+// callers can use len() and ranged-for safely without nil-checks.
+//
+// Complexity: O(N) in total YAML node count — single pass over top-level keys
+// plus one descent per value to find its deepest end position. Lookup is O(1).
+func collectKeyRanges(yamlContent string, lineOffset int) map[string]ast.Range {
+	out := make(map[string]ast.Range)
+	mapping := parseYAMLMapping(yamlContent)
+	if mapping == nil {
+		return out
+	}
+	for i := 0; i < len(mapping.Content)-1; i += 2 {
+		keyNode := mapping.Content[i]
+		valueNode := mapping.Content[i+1]
+		start := ast.Position{
+			Line:   keyNode.Line + lineOffset,
+			Column: keyNode.Column,
+		}
+		end := nodeEndPosition(valueNode, lineOffset)
+		out[keyNode.Value] = ast.Range{Start: start, End: end}
+	}
+	return out
+}
+
+// nodeEndPosition returns a Position pointing to the last byte of the YAML
+// node's textual span. yaml.v3 only exposes a node's start; the end is derived
+// by walking to the deepest trailing child for mappings/sequences and by
+// adding the scalar's length for leaf scalars. lineOffset is added to convert
+// yaml-content lines into document-relative lines.
+func nodeEndPosition(n *yaml.Node, lineOffset int) ast.Position {
+	if n == nil {
+		return ast.Position{}
+	}
+	switch n.Kind {
+	case yaml.MappingNode, yaml.SequenceNode:
+		if len(n.Content) == 0 {
+			return ast.Position{Line: n.Line + lineOffset, Column: n.Column}
+		}
+		// For mappings, the trailing element is a value (odd-indexed); for
+		// sequences, it's the last item. In both cases the last Content entry
+		// is the deepest trailing node — recurse into it.
+		return nodeEndPosition(n.Content[len(n.Content)-1], lineOffset)
+	case yaml.AliasNode:
+		return ast.Position{Line: n.Line + lineOffset, Column: n.Column}
+	default: // ScalarNode and DocumentNode (DocumentNode shouldn't appear here)
+		// Approximate the scalar's end by adding its rendered length to the
+		// start column. yaml.v3 does not expose folded/literal block scalar end
+		// positions; for those rare cases this gives a reasonable lower bound.
+		col := n.Column + len(n.Value)
+		if col < n.Column {
+			col = n.Column
+		}
+		return ast.Position{Line: n.Line + lineOffset, Column: col}
+	}
 }
 
 // extractYAMLTopLevelKeyOrder returns all top-level YAML keys in document order.

--- a/spec/document/frontmatter_ranges_test.go
+++ b/spec/document/frontmatter_ranges_test.go
@@ -1,0 +1,136 @@
+package document
+
+import (
+	"testing"
+)
+
+// TestParseFrontmatter_KeyRanges_SingleScalar verifies a registered scalar key
+// surfaces a range whose Start.Line points at the key's source line (1-based).
+func TestParseFrontmatter_KeyRanges_SingleScalar(t *testing.T) {
+	source := "---\nconvert_to: si\n---\n"
+	fm, _, err := ParseFrontmatter(source)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if fm == nil {
+		t.Fatal("expected frontmatter, got nil")
+	}
+	r, ok := fm.KeyRanges["convert_to"]
+	if !ok {
+		t.Fatalf("KeyRanges missing 'convert_to'; got %v", fm.KeyRanges)
+	}
+	// Line 1 is "---", line 2 is "convert_to: si"; 1-based per ast.Position.
+	if r.Start.Line != 2 {
+		t.Errorf("Start.Line = %d, want 2", r.Start.Line)
+	}
+	if r.End.Line != 2 {
+		t.Errorf("End.Line = %d, want 2", r.End.Line)
+	}
+	if r.Start.Column != 1 {
+		t.Errorf("Start.Column = %d, want 1", r.Start.Column)
+	}
+}
+
+// TestParseFrontmatter_KeyRanges_MultiLineMapping verifies a mapping value
+// (globals: ...) yields a range that spans the whole block including children.
+func TestParseFrontmatter_KeyRanges_MultiLineMapping(t *testing.T) {
+	// Lines:
+	// 1: ---
+	// 2: convert_to: si
+	// 3: globals:
+	// 4:   foo: 1
+	// 5:   bar: 2
+	// 6: ---
+	source := "---\nconvert_to: si\nglobals:\n  foo: 1\n  bar: 2\n---\n"
+	fm, _, err := ParseFrontmatter(source)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	r, ok := fm.KeyRanges["globals"]
+	if !ok {
+		t.Fatalf("KeyRanges missing 'globals'; got %v", fm.KeyRanges)
+	}
+	if r.Start.Line != 3 {
+		t.Errorf("globals Start.Line = %d, want 3", r.Start.Line)
+	}
+	if r.End.Line != 5 {
+		t.Errorf("globals End.Line = %d, want 5 (last child line)", r.End.Line)
+	}
+}
+
+// TestParseFrontmatter_KeyRanges_ExtraKey verifies non-CalcMark keys (Extra)
+// also populate KeyRanges, so tooling can locate them too.
+func TestParseFrontmatter_KeyRanges_ExtraKey(t *testing.T) {
+	source := "---\ntitle: Hello\n---\n"
+	fm, _, err := ParseFrontmatter(source)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	r, ok := fm.KeyRanges["title"]
+	if !ok {
+		t.Fatalf("KeyRanges missing 'title' (Extra key); got %v", fm.KeyRanges)
+	}
+	if r.Start.Line != 2 {
+		t.Errorf("title Start.Line = %d, want 2", r.Start.Line)
+	}
+}
+
+// TestParseFrontmatter_KeyRanges_MultipleKeys verifies several keys at known
+// line numbers are populated correctly.
+func TestParseFrontmatter_KeyRanges_MultipleKeys(t *testing.T) {
+	// 1: ---
+	// 2: scale: 2
+	// 3: convert_to: si
+	// 4: title: Demo
+	// 5: ---
+	source := "---\nscale: 2\nconvert_to: si\ntitle: Demo\n---\n"
+	fm, _, err := ParseFrontmatter(source)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	cases := map[string]int{
+		"scale":      2,
+		"convert_to": 3,
+		"title":      4,
+	}
+	for key, wantLine := range cases {
+		r, ok := fm.KeyRanges[key]
+		if !ok {
+			t.Errorf("KeyRanges missing %q", key)
+			continue
+		}
+		if r.Start.Line != wantLine {
+			t.Errorf("%s Start.Line = %d, want %d", key, r.Start.Line, wantLine)
+		}
+	}
+}
+
+// TestParseFrontmatter_KeyRanges_EmptyBody verifies an empty frontmatter body
+// produces an empty (or nil) KeyRanges map.
+func TestParseFrontmatter_KeyRanges_EmptyBody(t *testing.T) {
+	source := "---\n---\n"
+	fm, _, err := ParseFrontmatter(source)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: %v", err)
+	}
+	if fm == nil {
+		t.Fatal("expected non-nil frontmatter for empty body")
+	}
+	if len(fm.KeyRanges) != 0 {
+		t.Errorf("KeyRanges should be empty for empty body, got %v", fm.KeyRanges)
+	}
+}
+
+// TestParseFrontmatter_KeyRanges_UnclosedFence verifies the existing parser
+// behavior on a missing closing fence is unchanged: error returned, no
+// frontmatter exposed (so KeyRanges is unobservable).
+func TestParseFrontmatter_KeyRanges_UnclosedFence(t *testing.T) {
+	source := "---\nconvert_to: si\n"
+	fm, _, err := ParseFrontmatter(source)
+	if err == nil {
+		t.Fatal("expected error for unclosed fence, got nil")
+	}
+	if fm != nil {
+		t.Errorf("expected nil frontmatter on parse error, got %+v", fm)
+	}
+}

--- a/spec/document/frontmatter_registry.go
+++ b/spec/document/frontmatter_registry.go
@@ -1,0 +1,127 @@
+package document
+
+// FrontmatterKeyType describes the value shape a registered CalcMark
+// frontmatter key accepts. It exists so tooling (LSP completion, hover,
+// semantic diagnostics) can describe and validate keys uniformly without
+// special-casing each one.
+type FrontmatterKeyType int
+
+const (
+	// FrontmatterKeyMapStringDecimal: map of string -> decimal.Decimal.
+	// Used by `exchange` (e.g., "USD_EUR" -> 0.92).
+	FrontmatterKeyMapStringDecimal FrontmatterKeyType = iota
+
+	// FrontmatterKeyMapStringString: map of string -> string.
+	// Used by `globals` (variable name -> CalcMark expression source).
+	FrontmatterKeyMapStringString
+
+	// FrontmatterKeyEnumString: a string drawn from a fixed set of values.
+	// EnumValues lists the accepted values in canonical order.
+	FrontmatterKeyEnumString
+
+	// FrontmatterKeyStruct: a structured value (typically a YAML map with
+	// known sub-keys). Sub-key shape is documented in the registered key's
+	// Doc string and enforced by the key's parser.
+	FrontmatterKeyStruct
+)
+
+// String returns a stable, human-readable label for the key type.
+// Useful for diagnostics and tooling output.
+func (t FrontmatterKeyType) String() string {
+	switch t {
+	case FrontmatterKeyMapStringDecimal:
+		return "MapStringDecimal"
+	case FrontmatterKeyMapStringString:
+		return "MapStringString"
+	case FrontmatterKeyEnumString:
+		return "EnumString"
+	case FrontmatterKeyStruct:
+		return "Struct"
+	default:
+		return "Unknown"
+	}
+}
+
+// RegisteredKey describes a single CalcMark-specific frontmatter key.
+// All CalcMark grammar keys (those that ParseFrontmatter recognizes and
+// validates beyond YAML decoding) are listed in the Registry.
+type RegisteredKey struct {
+	// Name is the YAML key as it appears in document frontmatter.
+	// Comparison is case-sensitive.
+	Name string
+
+	// Type describes the accepted value shape.
+	Type FrontmatterKeyType
+
+	// Doc is a 1-2 sentence description of what the key configures.
+	// It is the source of truth for hover text in tooling (LSP).
+	Doc string
+
+	// EnumValues lists accepted values when Type == FrontmatterKeyEnumString.
+	// Empty for all other types. Order is canonical (preferred form first).
+	EnumValues []string
+}
+
+// Registry lists every CalcMark-grammar frontmatter key recognized by
+// ParseFrontmatter. Non-registered top-level keys are preserved verbatim
+// in Frontmatter.Extra and carry no CalcMark semantics.
+//
+// Complexity note: lookup helpers walk this slice linearly. With ~6
+// entries this is faster than a map and keeps the data trivially
+// inspectable. If the registry grows past ~50 entries, consider an
+// auxiliary map index.
+var Registry = []RegisteredKey{
+	{
+		Name: "exchange",
+		Type: FrontmatterKeyMapStringDecimal,
+		Doc:  "Currency exchange rates as 'FROM_TO' -> rate (e.g., 'USD_EUR': 0.92 means 1 USD = 0.92 EUR). Used by currency conversion expressions in the document.",
+	},
+	{
+		Name: "globals",
+		Type: FrontmatterKeyMapStringString,
+		Doc:  "User-defined variables as name -> CalcMark expression string. Each value is parsed as a CalcMark expression and made available throughout the document.",
+	},
+	{
+		Name: "scale",
+		Type: FrontmatterKeyStruct,
+		Doc:  "Document-level scale transform. Either a positive number (factor only) or a map with 'factor' and optional 'unit_categories' to restrict which categories scale.",
+	},
+	{
+		Name:       "convert_to",
+		Type:       FrontmatterKeyEnumString,
+		Doc:        "Document-level unit system conversion. Either the string 'si' or 'imperial', or a map with 'system' and optional 'unit_categories' to restrict which categories convert.",
+		EnumValues: []string{"si", "imperial"},
+	},
+	{
+		Name: "measurement",
+		Type: FrontmatterKeyStruct,
+		Doc:  "Disambiguates ambiguous unit names. Map with axis keys 'volume' (us|imperial), 'mass' (standard|troy), 'ton' (short|long|metric), and optional 'strict' boolean controlling formatter annotation.",
+	},
+	{
+		Name: "fiscal_year_starts",
+		Type: FrontmatterKeyStruct,
+		Doc:  "Anchors fiscal-period expressions (FQ1, FY26, 'this fiscal quarter') to a calendar start. String value naming a month, optionally with a day (e.g., 'July', 'October 1').",
+	},
+}
+
+// IsRegisteredKey reports whether name is a CalcMark-grammar frontmatter key.
+// Comparison is case-sensitive. Runs in O(|Registry|).
+func IsRegisteredKey(name string) bool {
+	for i := range Registry {
+		if Registry[i].Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// LookupKey returns the RegisteredKey with the given name, if any.
+// Comparison is case-sensitive. Runs in O(|Registry|).
+func LookupKey(name string) (RegisteredKey, bool) {
+	for i := range Registry {
+		if Registry[i].Name == name {
+			return Registry[i], true
+		}
+	}
+	return RegisteredKey{}, false
+}

--- a/spec/document/frontmatter_registry_test.go
+++ b/spec/document/frontmatter_registry_test.go
@@ -1,0 +1,140 @@
+package document
+
+import "testing"
+
+func TestRegistry_LookupExchange(t *testing.T) {
+	rk, ok := LookupKey("exchange")
+	if !ok {
+		t.Fatal("expected to find 'exchange' in registry")
+	}
+	if rk.Type != FrontmatterKeyMapStringDecimal {
+		t.Errorf("expected exchange to be MapStringDecimal, got %v", rk.Type)
+	}
+}
+
+func TestRegistry_LookupGlobals(t *testing.T) {
+	rk, ok := LookupKey("globals")
+	if !ok {
+		t.Fatal("expected to find 'globals' in registry")
+	}
+	if rk.Type != FrontmatterKeyMapStringString {
+		t.Errorf("expected globals to be MapStringString, got %v", rk.Type)
+	}
+}
+
+func TestRegistry_LookupConvertToEnum(t *testing.T) {
+	rk, ok := LookupKey("convert_to")
+	if !ok {
+		t.Fatal("expected to find 'convert_to' in registry")
+	}
+	if rk.Type != FrontmatterKeyEnumString {
+		t.Errorf("expected convert_to to be EnumString, got %v", rk.Type)
+	}
+	want := []string{"si", "imperial"}
+	if len(rk.EnumValues) != len(want) {
+		t.Fatalf("expected %d enum values, got %v", len(want), rk.EnumValues)
+	}
+	for i, v := range want {
+		if rk.EnumValues[i] != v {
+			t.Errorf("EnumValues[%d]: want %q got %q", i, v, rk.EnumValues[i])
+		}
+	}
+}
+
+func TestRegistry_LookupScale(t *testing.T) {
+	rk, ok := LookupKey("scale")
+	if !ok {
+		t.Fatal("expected to find 'scale' in registry")
+	}
+	if rk.Type != FrontmatterKeyStruct {
+		t.Errorf("expected scale to be Struct, got %v", rk.Type)
+	}
+}
+
+func TestRegistry_LookupMeasurement(t *testing.T) {
+	rk, ok := LookupKey("measurement")
+	if !ok {
+		t.Fatal("expected to find 'measurement' in registry")
+	}
+	if rk.Type != FrontmatterKeyStruct {
+		t.Errorf("expected measurement to be Struct, got %v", rk.Type)
+	}
+}
+
+func TestRegistry_LookupFiscalYearStarts(t *testing.T) {
+	rk, ok := LookupKey("fiscal_year_starts")
+	if !ok {
+		t.Fatal("expected to find 'fiscal_year_starts' in registry")
+	}
+	if rk.Type != FrontmatterKeyStruct {
+		t.Errorf("expected fiscal_year_starts to be Struct, got %v", rk.Type)
+	}
+}
+
+func TestRegistry_AllEntriesHaveNameAndDoc(t *testing.T) {
+	for _, entry := range Registry {
+		if entry.Name == "" {
+			t.Errorf("registry entry has empty Name: %+v", entry)
+		}
+		if entry.Doc == "" {
+			t.Errorf("registry entry %q has empty Doc", entry.Name)
+		}
+	}
+}
+
+func TestRegistry_EnumStringEntriesHaveValues(t *testing.T) {
+	for _, entry := range Registry {
+		if entry.Type == FrontmatterKeyEnumString {
+			if len(entry.EnumValues) == 0 {
+				t.Errorf("EnumString entry %q has no EnumValues", entry.Name)
+			}
+		}
+	}
+}
+
+func TestRegistry_NonEnumEntriesHaveEmptyEnumValues(t *testing.T) {
+	for _, entry := range Registry {
+		if entry.Type != FrontmatterKeyEnumString {
+			if len(entry.EnumValues) != 0 {
+				t.Errorf("non-EnumString entry %q has unexpected EnumValues: %v",
+					entry.Name, entry.EnumValues)
+			}
+		}
+	}
+}
+
+func TestRegistry_LookupCaseSensitive(t *testing.T) {
+	if _, ok := LookupKey("Exchange"); ok {
+		t.Error("expected LookupKey to be case-sensitive; 'Exchange' should not match")
+	}
+}
+
+func TestRegistry_LookupNonexistent(t *testing.T) {
+	if _, ok := LookupKey("nonexistent_key"); ok {
+		t.Error("expected LookupKey to return false for unknown key")
+	}
+}
+
+func TestRegistry_IsRegisteredKey(t *testing.T) {
+	known := []string{"exchange", "globals", "scale", "convert_to", "measurement", "fiscal_year_starts"}
+	for _, k := range known {
+		if !IsRegisteredKey(k) {
+			t.Errorf("expected %q to be a registered key", k)
+		}
+	}
+	if IsRegisteredKey("title") {
+		t.Error("expected 'title' to NOT be a registered key")
+	}
+	if IsRegisteredKey("xyzzy") {
+		t.Error("expected 'xyzzy' to NOT be a registered key")
+	}
+	if IsRegisteredKey("Exchange") {
+		t.Error("expected 'Exchange' (capitalized) to NOT be a registered key")
+	}
+}
+
+func TestRegistry_HasAllSixKnownKeys(t *testing.T) {
+	if len(Registry) != 6 {
+		t.Errorf("expected 6 registered keys, got %d", len(Registry))
+	}
+}

--- a/spec/document/frontmatter_test.go
+++ b/spec/document/frontmatter_test.go
@@ -1659,3 +1659,45 @@ func TestFiscalYearStartsParsing(t *testing.T) {
 		})
 	}
 }
+
+// TestParseFrontmatter_RegistryDrivesKnownKeyRouting pins the architectural
+// property that the Registry — not an inline allowlist — decides which
+// frontmatter keys are CalcMark-known. Every Registry entry must be routed
+// through its typed parse arm (and therefore NOT appear in Extra), and a
+// non-Registry key must land in Extra.
+func TestParseFrontmatter_RegistryDrivesKnownKeyRouting(t *testing.T) {
+	// Sanity: registered keys never leak into Extra.
+	registered := "---\nexchange:\n  USD_EUR: 1.1\n---\n"
+	fm, _, err := ParseFrontmatter(registered)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter(registered) error: %v", err)
+	}
+	if len(fm.Exchange) == 0 {
+		t.Errorf("expected Exchange to be populated, got empty")
+	}
+	for _, e := range fm.Extra {
+		if IsRegisteredKey(e.Key) {
+			t.Errorf("registered key %q leaked into Extra", e.Key)
+		}
+	}
+
+	// Sanity: a non-registered key lands in Extra and does not pollute typed fields.
+	unregistered := "---\ntitle: Hello\n---\n"
+	fm2, _, err := ParseFrontmatter(unregistered)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter(unregistered) error: %v", err)
+	}
+	if len(fm2.Exchange) != 0 {
+		t.Errorf("expected Exchange empty for unregistered-key doc, got %v", fm2.Exchange)
+	}
+	found := false
+	for _, e := range fm2.Extra {
+		if e.Key == "title" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'title' in Extra, got %+v", fm2.Extra)
+	}
+}

--- a/spec/document/frontmatter_yaml_shapes_test.go
+++ b/spec/document/frontmatter_yaml_shapes_test.go
@@ -1,0 +1,313 @@
+package document
+
+// YAML-shape corner-case tests for ParseFrontmatter + KeyRanges.
+//
+// Each test probes a specific YAML syntactic construct (anchors, tagged
+// scalars, flow mappings, block scalars, etc.) and asserts the observed
+// behavior. The bar is "no panic, no silent data-loss, KeyRanges is either
+// sensibly populated or documented-imperfect for exotic shapes". KeyRanges
+// is currently consumed only by the LSP for anchoring diagnostics/hovers;
+// imperfect End.Line for multi-line block scalars is acceptable and
+// acknowledged in collectKeyRanges / nodeEndPosition in frontmatter.go.
+
+import (
+	"testing"
+)
+
+// helper: parse and assert no panic / no error / non-nil fm.
+func parseOrFatal(t *testing.T, source string) *Frontmatter {
+	t.Helper()
+	fm, _, err := ParseFrontmatter(source)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: unexpected error: %v", err)
+	}
+	if fm == nil {
+		t.Fatal("ParseFrontmatter: unexpected nil frontmatter")
+	}
+	return fm
+}
+
+// TestParseFrontmatter_YAMLShape_AnchorsAndAliases verifies YAML anchors (&x)
+// and aliases (*x) are resolved by yaml.v3 and both the anchor- and alias-
+// bearing keys appear in Extra + KeyRanges.
+func TestParseFrontmatter_YAMLShape_AnchorsAndAliases(t *testing.T) {
+	source := "---\ndefault: &d\n  precision: 2\noverrides: *d\n---\n"
+	fm := parseOrFatal(t, source)
+
+	if _, ok := fm.KeyRanges["default"]; !ok {
+		t.Error("KeyRanges missing 'default' (anchor key)")
+	}
+	if r, ok := fm.KeyRanges["overrides"]; !ok {
+		t.Error("KeyRanges missing 'overrides' (alias key)")
+	} else if r.Start.Line != 4 {
+		t.Errorf("overrides Start.Line = %d, want 4", r.Start.Line)
+	}
+
+	// Both should appear in Extra (neither is a registered CalcMark key).
+	haveDefault, haveOverrides := false, false
+	for _, e := range fm.Extra {
+		switch e.Key {
+		case "default":
+			haveDefault = true
+		case "overrides":
+			haveOverrides = true
+		}
+	}
+	if !haveDefault || !haveOverrides {
+		t.Errorf("Extra missing keys; haveDefault=%v haveOverrides=%v", haveDefault, haveOverrides)
+	}
+}
+
+// TestParseFrontmatter_YAMLShape_TaggedScalar verifies !!str and similar
+// explicit YAML tags parse without panic; the value surfaces as the tagged
+// Go type (string in this case, not time.Time).
+func TestParseFrontmatter_YAMLShape_TaggedScalar(t *testing.T) {
+	source := "---\ndate: !!str 2026-04-14\n---\n"
+	fm := parseOrFatal(t, source)
+
+	if _, ok := fm.KeyRanges["date"]; !ok {
+		t.Error("KeyRanges missing 'date'")
+	}
+	var got any
+	for _, e := range fm.Extra {
+		if e.Key == "date" {
+			got = e.Value
+		}
+	}
+	if s, ok := got.(string); !ok || s != "2026-04-14" {
+		t.Errorf("Extra[date] = %T %v, want string \"2026-04-14\" (!!str should force string)", got, got)
+	}
+}
+
+// TestParseFrontmatter_YAMLShape_FlowMapping verifies inline flow syntax
+// { k: v, k2: v2 } parses correctly for a registered key (exchange).
+func TestParseFrontmatter_YAMLShape_FlowMapping(t *testing.T) {
+	source := "---\nexchange: { USD_EUR: 1.1, USD_GBP: 0.8 }\n---\n"
+	fm := parseOrFatal(t, source)
+
+	if len(fm.Exchange) != 2 {
+		t.Errorf("Exchange len = %d, want 2; got %v", len(fm.Exchange), fm.Exchange)
+	}
+	if _, ok := fm.KeyRanges["exchange"]; !ok {
+		t.Error("KeyRanges missing 'exchange'")
+	}
+}
+
+// TestParseFrontmatter_YAMLShape_LiteralBlockScalar verifies `|` literal block
+// scalars don't panic and are captured as multi-line strings in Extra.
+//
+// KNOWN LIMITATION: KeyRanges.End.Line for block scalars points at the KEY
+// line, not the last physical line of the folded/literal content. See the
+// comment in nodeEndPosition() in frontmatter.go — yaml.v3 does not expose
+// block-scalar end positions. Fine for LSP's current use (it only needs the
+// key anchor), but flipped when yaml.v3 exposes end or we switch parsers.
+func TestParseFrontmatter_YAMLShape_LiteralBlockScalar(t *testing.T) {
+	source := "---\ndescription: |\n  Multi\n  line\n---\n"
+	fm := parseOrFatal(t, source)
+
+	r, ok := fm.KeyRanges["description"]
+	if !ok {
+		t.Fatal("KeyRanges missing 'description'")
+	}
+	if r.Start.Line != 2 {
+		t.Errorf("description Start.Line = %d, want 2", r.Start.Line)
+	}
+	// Imperfect-but-documented: End.Line == 2 (key line), not 4.
+	if r.End.Line != 2 {
+		t.Errorf("description End.Line = %d, want 2 (known limitation — yaml.v3 "+
+			"does not expose block-scalar end; flip this test when fixed)", r.End.Line)
+	}
+
+	var val any
+	for _, e := range fm.Extra {
+		if e.Key == "description" {
+			val = e.Value
+		}
+	}
+	if s, ok := val.(string); !ok || s != "Multi\nline" {
+		t.Errorf("Extra[description] = %T %q, want string \"Multi\\nline\"", val, val)
+	}
+}
+
+// TestParseFrontmatter_YAMLShape_FoldedBlockScalar verifies `>` folded block
+// scalars behave like literal: captured as a string, KeyRanges has an entry
+// (End.Line same limitation as literal block scalars).
+func TestParseFrontmatter_YAMLShape_FoldedBlockScalar(t *testing.T) {
+	source := "---\nsummary: >\n  Folded\n  into one line\n---\n"
+	fm := parseOrFatal(t, source)
+
+	r, ok := fm.KeyRanges["summary"]
+	if !ok {
+		t.Fatal("KeyRanges missing 'summary'")
+	}
+	if r.Start.Line != 2 {
+		t.Errorf("summary Start.Line = %d, want 2", r.Start.Line)
+	}
+
+	var val any
+	for _, e := range fm.Extra {
+		if e.Key == "summary" {
+			val = e.Value
+		}
+	}
+	if s, ok := val.(string); !ok || s != "Folded into one line" {
+		t.Errorf("Extra[summary] = %T %q, want folded one-line string", val, val)
+	}
+}
+
+// TestParseFrontmatter_YAMLShape_EmptyValue verifies `title:` with no value
+// yields a nil Extra value and a populated KeyRanges entry. No panic, no
+// silent data-loss (the key is preserved even with nil value).
+func TestParseFrontmatter_YAMLShape_EmptyValue(t *testing.T) {
+	source := "---\ntitle:\n---\n"
+	fm := parseOrFatal(t, source)
+
+	r, ok := fm.KeyRanges["title"]
+	if !ok {
+		t.Fatal("KeyRanges missing 'title'")
+	}
+	if r.Start.Line != 2 {
+		t.Errorf("title Start.Line = %d, want 2", r.Start.Line)
+	}
+
+	found := false
+	for _, e := range fm.Extra {
+		if e.Key == "title" {
+			found = true
+			if e.Value != nil {
+				t.Errorf("Extra[title].Value = %T %v, want nil", e.Value, e.Value)
+			}
+		}
+	}
+	if !found {
+		t.Error("Extra missing 'title' entry (empty-value key should be preserved)")
+	}
+}
+
+// TestParseFrontmatter_YAMLShape_ScalarTypes verifies bool, null, and int
+// scalars are captured with the correct Go types in Extra.
+func TestParseFrontmatter_YAMLShape_ScalarTypes(t *testing.T) {
+	source := "---\npublished: false\ndraft: null\npriority: 1\n---\n"
+	fm := parseOrFatal(t, source)
+
+	want := map[string]any{
+		"published": false,
+		"draft":     nil,
+		"priority":  1,
+	}
+	got := map[string]any{}
+	for _, e := range fm.Extra {
+		got[e.Key] = e.Value
+	}
+	for k, v := range want {
+		gv, ok := got[k]
+		if !ok {
+			t.Errorf("Extra missing %q", k)
+			continue
+		}
+		if gv != v {
+			t.Errorf("Extra[%q] = %T %v, want %T %v", k, gv, gv, v, v)
+		}
+		if _, rok := fm.KeyRanges[k]; !rok {
+			t.Errorf("KeyRanges missing %q", k)
+		}
+	}
+}
+
+// TestParseFrontmatter_YAMLShape_DateScalar verifies an unquoted ISO date
+// is parsed by yaml.v3 as time.Time. Worth documenting because it's a
+// common footgun — users expecting a string get a time.Time.
+func TestParseFrontmatter_YAMLShape_DateScalar(t *testing.T) {
+	source := "---\ndate: 2026-04-14\n---\n"
+	fm := parseOrFatal(t, source)
+
+	var got any
+	for _, e := range fm.Extra {
+		if e.Key == "date" {
+			got = e.Value
+		}
+	}
+	// yaml.v3 auto-parses ISO dates to time.Time. Document this so users can
+	// quote the value if they want a string.
+	if got == nil {
+		t.Fatal("Extra missing 'date'")
+	}
+	// We don't strictly assert time.Time here (the exact type is a yaml.v3
+	// implementation detail); we just assert it parsed and is not a string.
+	if _, isStr := got.(string); isStr {
+		t.Errorf("Extra[date] = string (unexpected); yaml.v3 auto-parses ISO dates to time.Time")
+	}
+	if _, ok := fm.KeyRanges["date"]; !ok {
+		t.Error("KeyRanges missing 'date'")
+	}
+}
+
+// TestParseFrontmatter_YAMLShape_QuotedSpecialChars verifies a quoted string
+// containing `:` and `!` parses without splitting on the colon.
+func TestParseFrontmatter_YAMLShape_QuotedSpecialChars(t *testing.T) {
+	source := "---\ntitle: \"Hello: World!\"\n---\n"
+	fm := parseOrFatal(t, source)
+
+	var got any
+	for _, e := range fm.Extra {
+		if e.Key == "title" {
+			got = e.Value
+		}
+	}
+	if s, ok := got.(string); !ok || s != "Hello: World!" {
+		t.Errorf("Extra[title] = %T %v, want string \"Hello: World!\"", got, got)
+	}
+	if _, ok := fm.KeyRanges["title"]; !ok {
+		t.Error("KeyRanges missing 'title'")
+	}
+}
+
+// TestParseFrontmatter_YAMLShape_MultiDocMarkerInBody verifies that a
+// `---` line inside the frontmatter body is treated as the closing fence
+// (first `---` wins). This is existing behavior: the fence scan stops at
+// the first match. We assert "no panic and predictable truncation", not
+// "error on embedded ---". If/when we want stricter validation, flip the
+// expectation here.
+func TestParseFrontmatter_YAMLShape_MultiDocMarkerInBody(t *testing.T) {
+	// Layout:
+	// 1: ---
+	// 2: title: a
+	// 3: ---      <- treated as closing fence
+	// 4: foo: b
+	// 5: ---
+	source := "---\ntitle: a\n---\nfoo: b\n---\n"
+	fm, rest, err := ParseFrontmatter(source)
+	if err != nil {
+		t.Fatalf("ParseFrontmatter: unexpected error: %v (expected graceful truncation at first ---)", err)
+	}
+	if fm == nil {
+		t.Fatal("expected non-nil frontmatter")
+	}
+	// Only 'title' should be captured; 'foo' lives in the body.
+	if _, ok := fm.KeyRanges["foo"]; ok {
+		t.Error("KeyRanges unexpectedly includes 'foo' — fence parse should stop at first ---")
+	}
+	if _, ok := fm.KeyRanges["title"]; !ok {
+		t.Error("KeyRanges missing 'title'")
+	}
+	if rest == "" {
+		t.Error("expected non-empty remaining body after truncated fence")
+	}
+}
+
+// TestParseFrontmatter_YAMLShape_InlineComment verifies `#` inline comments
+// are stripped by yaml.v3 and do not leak into the captured value.
+func TestParseFrontmatter_YAMLShape_InlineComment(t *testing.T) {
+	source := "---\ntitle: Hello  # a comment\n---\n"
+	fm := parseOrFatal(t, source)
+
+	var got any
+	for _, e := range fm.Extra {
+		if e.Key == "title" {
+			got = e.Value
+		}
+	}
+	if s, ok := got.(string); !ok || s != "Hello" {
+		t.Errorf("Extra[title] = %T %v, want string \"Hello\" (comment must be stripped)", got, got)
+	}
+}

--- a/spec/semantic/frontmatter_check.go
+++ b/spec/semantic/frontmatter_check.go
@@ -1,0 +1,150 @@
+package semantic
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/spec/document"
+)
+
+// CheckFrontmatter validates the populated CalcMark fields of a Frontmatter
+// and returns diagnostics for malformed values. It is a separate exported
+// function (not a method on Checker) because frontmatter validation is purely
+// structural — it has no dependency on accumulated Checker state and can be
+// called independently by tooling (LSP, calcmark-web) that wants to surface
+// frontmatter problems without setting up a full Checker.
+//
+// Scope: only registered keys (see document.Registry) are validated. Entries in
+// fm.Extra are passthrough by design — they carry no CalcMark semantics — and
+// produce zero diagnostics here.
+//
+// What this DOES NOT duplicate from the parser:
+//   - YAML shape errors (e.g., "globals: 42") — the parser already returns a
+//     fatal error and the resulting Frontmatter is never constructed.
+//   - convert_to/scale/measurement sub-key validation — the parser's
+//     validateConvertToConfig, validateScaleConfig, and parseMeasurementConfig
+//     already enforce those at parse time.
+//
+// What this DOES catch:
+//   - Programmatically constructed Frontmatter values that bypass the parser
+//     (e.g., a test or a future library caller that builds a Frontmatter by
+//     hand and sets ConvertTo.System = "xyz").
+//   - Cases the parser is too permissive about reaching the typed value, such
+//     as exchange rates that became zero or negative after construction.
+//
+// Diagnostic anchors come from fm.KeyRanges (Unit 3). When a registered key is
+// absent from KeyRanges (e.g., the Frontmatter was built programmatically
+// without source positions), the diagnostic still emits but with a zero-value
+// ast.Range as a fallback so callers can rely on Range != nil.
+//
+// Complexity: O(|registered keys present in fm|). Per D9/D10, the registry is
+// small and walked linearly; no auxiliary indices are built.
+func CheckFrontmatter(fm document.Frontmatter) []Diagnostic {
+	var diags []Diagnostic
+
+	// convert_to: System must be in the registry's EnumValues.
+	// Comparison is case-sensitive — the parser already lowercases input, so any
+	// non-canonical value reaching here came from programmatic construction and
+	// should be flagged exactly as written.
+	if fm.ConvertTo != nil {
+		if d, ok := checkConvertTo(fm.ConvertTo, rangeFor(fm, "convert_to")); ok {
+			diags = append(diags, d)
+		}
+	}
+
+	// exchange: every rate must be positive (zero and negative rates would
+	// silently yield zero or sign-flipped conversions). Walk in deterministic
+	// (sorted-key) order so the diagnostic stream is stable across runs.
+	if len(fm.Exchange) > 0 {
+		exchangeRange := rangeFor(fm, "exchange")
+		keys := make([]string, 0, len(fm.Exchange))
+		for k := range fm.Exchange {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			rate := fm.Exchange[k]
+			if !rate.IsPositive() {
+				diags = append(diags, Diagnostic{
+					Severity: Error,
+					Code:     DiagFrontmatterValidation,
+					Message: fmt.Sprintf(
+						"exchange rate %q must be positive, got %s",
+						k, rate.String(),
+					),
+					Range: exchangeRange,
+				})
+			}
+		}
+	}
+
+	// scale: Factor must be positive. The parser's validateScaleConfig enforces
+	// this for parsed input, but a programmatic caller can bypass it.
+	if fm.Scale != nil {
+		if !fm.Scale.Factor.IsPositive() {
+			diags = append(diags, Diagnostic{
+				Severity: Error,
+				Code:     DiagFrontmatterValidation,
+				Message: fmt.Sprintf(
+					"scale factor must be positive, got %s",
+					fm.Scale.Factor.String(),
+				),
+				Range: rangeFor(fm, "scale"),
+			})
+		}
+	}
+
+	// Sort by Range.Start.Line ascending so multi-key diagnostics arrive in
+	// source order. A zero-value Range (line 0) sorts to the front, which is
+	// fine — those are the no-source-position fallback cases.
+	sort.SliceStable(diags, func(i, j int) bool {
+		li, lj := 0, 0
+		if diags[i].Range != nil {
+			li = diags[i].Range.Start.Line
+		}
+		if diags[j].Range != nil {
+			lj = diags[j].Range.Start.Line
+		}
+		return li < lj
+	})
+
+	return diags
+}
+
+// checkConvertTo validates the System field against the registered enum values.
+// Returns (Diagnostic{}, false) when valid.
+func checkConvertTo(cfg *document.ConvertToConfig, r *ast.Range) (Diagnostic, bool) {
+	key, ok := document.LookupKey("convert_to")
+	if !ok {
+		// Defensive: the registry should always contain convert_to. If not,
+		// we have nothing to validate against.
+		return Diagnostic{}, false
+	}
+	for _, v := range key.EnumValues {
+		if cfg.System == v {
+			return Diagnostic{}, false
+		}
+	}
+	return Diagnostic{
+		Severity: Error,
+		Code:     DiagFrontmatterValidation,
+		Message: fmt.Sprintf(
+			"convert_to value %q is not valid; expected one of: %s",
+			cfg.System, strings.Join(key.EnumValues, ", "),
+		),
+		Range: r,
+	}, true
+}
+
+// rangeFor returns a non-nil *ast.Range for the named key. When KeyRanges
+// lacks an entry (e.g., programmatic construction with no source positions),
+// it returns a pointer to a zero-value Range so callers can always rely on
+// Diagnostic.Range != nil.
+func rangeFor(fm document.Frontmatter, key string) *ast.Range {
+	if r, ok := fm.KeyRanges[key]; ok {
+		return &r
+	}
+	return &ast.Range{}
+}

--- a/spec/semantic/frontmatter_check_test.go
+++ b/spec/semantic/frontmatter_check_test.go
@@ -1,0 +1,264 @@
+package semantic
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/shopspring/decimal"
+)
+
+// TestCheckFrontmatter_Empty: an empty Frontmatter produces no diagnostics.
+func TestCheckFrontmatter_Empty(t *testing.T) {
+	fm := document.Frontmatter{}
+	diags := CheckFrontmatter(fm)
+	if len(diags) != 0 {
+		t.Errorf("expected no diagnostics for empty frontmatter, got %d: %+v", len(diags), diags)
+	}
+}
+
+// TestCheckFrontmatter_ValidConvertToSI: convert_to: si is accepted.
+func TestCheckFrontmatter_ValidConvertToSI(t *testing.T) {
+	fm := document.Frontmatter{
+		ConvertTo: &document.ConvertToConfig{System: "si"},
+	}
+	diags := CheckFrontmatter(fm)
+	if len(diags) != 0 {
+		t.Errorf("expected no diagnostics, got %d: %+v", len(diags), diags)
+	}
+}
+
+// TestCheckFrontmatter_ValidConvertToImperial: convert_to: imperial is accepted.
+func TestCheckFrontmatter_ValidConvertToImperial(t *testing.T) {
+	fm := document.Frontmatter{
+		ConvertTo: &document.ConvertToConfig{System: "imperial"},
+	}
+	diags := CheckFrontmatter(fm)
+	if len(diags) != 0 {
+		t.Errorf("expected no diagnostics, got %d: %+v", len(diags), diags)
+	}
+}
+
+// TestCheckFrontmatter_ValidExchange: positive exchange rates produce no diagnostics.
+func TestCheckFrontmatter_ValidExchange(t *testing.T) {
+	fm := document.Frontmatter{
+		Exchange: map[string]decimal.Decimal{
+			"USD_EUR": decimal.NewFromFloat(1.1),
+		},
+	}
+	diags := CheckFrontmatter(fm)
+	if len(diags) != 0 {
+		t.Errorf("expected no diagnostics, got %d: %+v", len(diags), diags)
+	}
+}
+
+// TestCheckFrontmatter_InvalidConvertToValue: convert_to with unknown system value
+// produces one Error diagnostic, anchored at KeyRanges["convert_to"], whose message
+// names both the offending value and the valid set.
+func TestCheckFrontmatter_InvalidConvertToValue(t *testing.T) {
+	keyRange := ast.Range{
+		Start: ast.Position{Line: 2, Column: 1},
+		End:   ast.Position{Line: 2, Column: 22},
+	}
+	fm := document.Frontmatter{
+		ConvertTo: &document.ConvertToConfig{System: "xyz_not_a_value"},
+		KeyRanges: map[string]ast.Range{
+			"convert_to": keyRange,
+		},
+	}
+	diags := CheckFrontmatter(fm)
+	if len(diags) != 1 {
+		t.Fatalf("expected exactly 1 diagnostic, got %d: %+v", len(diags), diags)
+	}
+	d := diags[0]
+	if d.Severity != Error {
+		t.Errorf("expected Severity=Error, got %v", d.Severity)
+	}
+	if !strings.Contains(d.Message, "xyz_not_a_value") {
+		t.Errorf("expected message to mention offending value 'xyz_not_a_value', got %q", d.Message)
+	}
+	if !strings.Contains(d.Message, "si") || !strings.Contains(d.Message, "imperial") {
+		t.Errorf("expected message to list valid set 'si'/'imperial', got %q", d.Message)
+	}
+	if d.Range == nil {
+		t.Fatalf("expected Range to be populated, got nil")
+	}
+	if *d.Range != keyRange {
+		t.Errorf("expected Range %+v, got %+v", keyRange, *d.Range)
+	}
+}
+
+// TestCheckFrontmatter_InvalidConvertTo_NoKeyRanges: when KeyRanges is missing
+// the entry, the diagnostic still emits but with a zero-value Range (fallback).
+func TestCheckFrontmatter_InvalidConvertTo_NoKeyRanges(t *testing.T) {
+	fm := document.Frontmatter{
+		ConvertTo: &document.ConvertToConfig{System: "xyz"},
+	}
+	diags := CheckFrontmatter(fm)
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(diags))
+	}
+	if diags[0].Range == nil {
+		t.Fatalf("expected non-nil Range (zero-value fallback), got nil")
+	}
+	if (*diags[0].Range != ast.Range{}) {
+		t.Errorf("expected zero-value Range fallback, got %+v", *diags[0].Range)
+	}
+}
+
+// TestCheckFrontmatter_ExchangeZeroRate: a zero exchange rate is an Error
+// (zero rates would yield zero-valued conversions silently).
+func TestCheckFrontmatter_ExchangeZeroRate(t *testing.T) {
+	keyRange := ast.Range{
+		Start: ast.Position{Line: 3, Column: 1},
+		End:   ast.Position{Line: 4, Column: 12},
+	}
+	fm := document.Frontmatter{
+		Exchange: map[string]decimal.Decimal{
+			"USD_EUR": decimal.Zero,
+		},
+		KeyRanges: map[string]ast.Range{
+			"exchange": keyRange,
+		},
+	}
+	diags := CheckFrontmatter(fm)
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d: %+v", len(diags), diags)
+	}
+	if diags[0].Severity != Error {
+		t.Errorf("expected Error, got %v", diags[0].Severity)
+	}
+	if !strings.Contains(diags[0].Message, "USD_EUR") {
+		t.Errorf("expected message to name the rate key 'USD_EUR', got %q", diags[0].Message)
+	}
+	if diags[0].Range == nil || *diags[0].Range != keyRange {
+		t.Errorf("expected Range from KeyRanges[exchange], got %+v", diags[0].Range)
+	}
+}
+
+// TestCheckFrontmatter_ExchangeNegativeRate: negative rates are nonsense (Error).
+func TestCheckFrontmatter_ExchangeNegativeRate(t *testing.T) {
+	fm := document.Frontmatter{
+		Exchange: map[string]decimal.Decimal{
+			"USD_EUR": decimal.NewFromFloat(-1),
+		},
+	}
+	diags := CheckFrontmatter(fm)
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(diags))
+	}
+	if diags[0].Severity != Error {
+		t.Errorf("expected Error, got %v", diags[0].Severity)
+	}
+	if !strings.Contains(diags[0].Message, "USD_EUR") {
+		t.Errorf("expected USD_EUR in message, got %q", diags[0].Message)
+	}
+}
+
+// TestCheckFrontmatter_ExtraKeysIgnored_Title: an Extra "title" key produces
+// no diagnostics (the passthrough invariant).
+func TestCheckFrontmatter_ExtraKeysIgnored_Title(t *testing.T) {
+	fm := document.Frontmatter{
+		Extra: []document.ExtraField{{Key: "title", Value: "Hello"}},
+	}
+	diags := CheckFrontmatter(fm)
+	if len(diags) != 0 {
+		t.Errorf("expected no diagnostics for Extra passthrough, got %d: %+v", len(diags), diags)
+	}
+}
+
+// TestCheckFrontmatter_ExtraKeysIgnored_Jekyll: another Jekyll-style Extra key.
+func TestCheckFrontmatter_ExtraKeysIgnored_Jekyll(t *testing.T) {
+	fm := document.Frontmatter{
+		Extra: []document.ExtraField{{Key: "jekyll_layout", Value: "post"}},
+	}
+	diags := CheckFrontmatter(fm)
+	if len(diags) != 0 {
+		t.Errorf("expected no diagnostics for Extra passthrough, got %d: %+v", len(diags), diags)
+	}
+}
+
+// TestCheckFrontmatter_CaseSensitiveEnum: convert_to: SI (uppercase) is rejected.
+// Decision: enum comparison is case-sensitive at the semantic layer. The parser
+// already lowercases input, so any uppercase value reaching CheckFrontmatter was
+// constructed programmatically and should be flagged. Documented in the impl.
+func TestCheckFrontmatter_CaseSensitiveEnum(t *testing.T) {
+	fm := document.Frontmatter{
+		ConvertTo: &document.ConvertToConfig{System: "SI"},
+	}
+	diags := CheckFrontmatter(fm)
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic for uppercase 'SI', got %d", len(diags))
+	}
+}
+
+// TestCheckFrontmatter_MultipleInvalid_OrderedByLine: multiple invalid keys
+// produce diagnostics ordered by KeyRanges.Start.Line (ascending).
+func TestCheckFrontmatter_MultipleInvalid_OrderedByLine(t *testing.T) {
+	fm := document.Frontmatter{
+		ConvertTo: &document.ConvertToConfig{System: "xyz"},
+		Exchange: map[string]decimal.Decimal{
+			"USD_EUR": decimal.Zero,
+		},
+		KeyRanges: map[string]ast.Range{
+			// exchange appears earlier in source
+			"exchange":   {Start: ast.Position{Line: 2, Column: 1}, End: ast.Position{Line: 3, Column: 14}},
+			"convert_to": {Start: ast.Position{Line: 4, Column: 1}, End: ast.Position{Line: 4, Column: 18}},
+		},
+	}
+	diags := CheckFrontmatter(fm)
+	if len(diags) != 2 {
+		t.Fatalf("expected 2 diagnostics, got %d: %+v", len(diags), diags)
+	}
+	if diags[0].Range == nil || diags[1].Range == nil {
+		t.Fatalf("expected both diagnostics to have ranges")
+	}
+	if diags[0].Range.Start.Line >= diags[1].Range.Start.Line {
+		t.Errorf("expected diagnostics ordered by Start.Line ascending; got line %d before line %d",
+			diags[0].Range.Start.Line, diags[1].Range.Start.Line)
+	}
+	// The earlier-line diagnostic should be the exchange one
+	if !strings.Contains(diags[0].Message, "USD_EUR") {
+		t.Errorf("expected first diagnostic to be the exchange one (line 2), got message %q", diags[0].Message)
+	}
+}
+
+// TestCheckFrontmatter_AllSixKeysValid: a populated Frontmatter with all six
+// registered keys set to valid values produces no diagnostics.
+func TestCheckFrontmatter_AllSixKeysValid(t *testing.T) {
+	strict := true
+	fm := document.Frontmatter{
+		Exchange: map[string]decimal.Decimal{
+			"USD_EUR": decimal.NewFromFloat(0.92),
+		},
+		Globals: map[string]string{
+			"tax_rate": "0.32",
+		},
+		Scale:     &document.ScaleConfig{Factor: decimal.NewFromInt(2)},
+		ConvertTo: &document.ConvertToConfig{System: "si"},
+		Measurement: &document.MeasurementFrontmatter{
+			Strict: &strict,
+		},
+		FiscalYearStarts: &document.FiscalYearConfig{Month: 1, Day: 1},
+	}
+	diags := CheckFrontmatter(fm)
+	if len(diags) != 0 {
+		t.Errorf("expected no diagnostics for fully valid frontmatter, got %d: %+v", len(diags), diags)
+	}
+}
+
+// TestCheckFrontmatter_ScaleNonPositive: a non-positive scale factor is an Error.
+// Programmatic construction can bypass the parser's positivity check.
+func TestCheckFrontmatter_ScaleNonPositive(t *testing.T) {
+	fm := document.Frontmatter{
+		Scale: &document.ScaleConfig{Factor: decimal.Zero},
+	}
+	diags := CheckFrontmatter(fm)
+	if len(diags) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d", len(diags))
+	}
+	if diags[0].Severity != Error {
+		t.Errorf("expected Error severity, got %v", diags[0].Severity)
+	}
+}


### PR DESCRIPTION
Plan: docs/plans/2026-04-14-001-feat-frontmatter-first-class-plan.md

9-unit execution extending CalcMark's language surface so frontmatter is first-class: a typed Registry of the 6 CalcMark-specific keys (exchange, globals, scale, convert_to, measurement, fiscal_year_starts), semantic validation, and LSP hover + completion + documentSymbol. Non-CalcMark keys still flow silently through Extra (Markdown convention preserved).

No breaking changes — Frontmatter struct shape and ParseFrontmatter signature unchanged. KeyRanges added as a new additive field.

## Commits
- b412a9b feat(frontmatter): typed Registry of CalcMark-specific keys (Unit 1)
- 76473cf refactor(frontmatter): ParseFrontmatter consults Registry (Unit 2)
- f646cad feat(frontmatter): capture per-key source ranges (Unit 3)
- d96fae6 feat(semantic): CheckFrontmatter diagnostics (Unit 4)
- 9ad815a feat(lsp): frontmatter region + cursor classifier helpers (Unit 5)
- 34f604b feat(lsp): frontmatter hover (Unit 6)
- a67f7dd feat(lsp): frontmatter completion (Unit 7)
- a4859f7 feat(lsp): frontmatter documentSymbol (Unit 8)
- ce89021 test(lsp): consolidated acceptance + close the loop (Unit 9)

## Unblocks
Calcmark-web's plan 2026-04-14-003's Deferred entry (`First-class frontmatter handling in go-calcmark`). Once this lands and a go-calcmark release is cut, calcmark-web's follow-up plan migrates the frontend frontmatter renderer.

## Test plan
- [x] `go test ./...` green across all packages
- [x] Consolidated acceptance test exercises R1-R6 in one session
- [x] Extra-only frontmatter produces zero LSP frontmatter responses (negative coverage)
- [x] Calc-block LSP behavior unchanged (regression guard)

<!-- gh-velocity:pr:136 -->
### Metrics

Opened by `@dvhthomas` (agent-assisted) on 2026-04-15 02:45 UTC. Merged 2026-04-15 11:53 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 9h 7m  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
