### PR TITLE
fix(test): wrap watch-loop log buffer with mutex to fix data race

### DIFF
--- a/cmd/calcmark/cmd/watch_test.go
+++ b/cmd/calcmark/cmd/watch_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -14,6 +15,27 @@ import (
 	"github.com/CalcMark/go-calcmark/format"
 	"github.com/fsnotify/fsnotify"
 )
+
+// syncBuf is a goroutine-safe wrapper around bytes.Buffer used by tests
+// that capture watchServer.logf output. The watchLoop goroutine writes
+// concurrently with the test goroutine reading String(); a bare
+// bytes.Buffer would race (caught by `go test -race`).
+type syncBuf struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (s *syncBuf) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.Write(p)
+}
+
+func (s *syncBuf) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.b.String()
+}
 
 func TestRenderFile(t *testing.T) {
 	// Create a temp .cm file
@@ -282,8 +304,9 @@ func TestWatchLoop_LogsOnChange(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Capture stderr
-	var buf bytes.Buffer
+	// Capture stderr through a goroutine-safe buffer (the watchLoop
+	// goroutine writes concurrently with this test reading String()).
+	var buf syncBuf
 	srv := &watchServer{
 		filename: cmFile,
 		mode:     calcmark.CM,


### PR DESCRIPTION
Surfaced during the frontmatter-first-class derisking pass on PR #136. Pre-existing race, unrelated to that PR's scope; fixed here in isolation.

## Problem
`TestWatchLoop_LogsOnChange` uses a bare `bytes.Buffer` as the `watchServer`'s `logw` target. The `watchLoop` goroutine writes via `fmt.Fprintf` concurrently with the test goroutine reading via `buf.String()`. `go test -race` catches it.

## Fix
Wrap with a small `syncBuf` (mutex around `bytes.Buffer`) used in the test file only. Production code untouched — `watchServer.logw` stays `io.Writer`-typed.

## Verification
- `go test -race ./cmd/calcmark/cmd/` green
- Full repo `go test -race ./...` green across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-velocity:pr:137 -->
### Metrics

Opened by `@dvhthomas` on 2026-04-15 11:50 UTC. Merged 2026-04-15 11:52 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 2m  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
