### PR TITLE
fix: PI/E semantic constants, CY/FY/CQ/FQ abbreviations, template alias filter

### DIFF
--- a/cmd/calcmark/tui/editor/autocomplete_test.go
+++ b/cmd/calcmark/tui/editor/autocomplete_test.go
@@ -1048,7 +1048,7 @@ func TestDateSuggestions(t *testing.T) {
 		{"ye prefix", "ye", true, []string{"yesterday", "years"}},
 		{"ag prefix", "ag", true, []string{"ago"}},
 		{"thi prefix", "thi", true, []string{"this quarter"}},
-		{"ne prefix", "ne", true, []string{"next weekday", "next month name"}},
+		{"ne prefix", "ne", true, []string{"next quarter", "next fiscal year"}},
 		{"fi prefix", "fi", true, []string{"fiscal quarter", "fiscal year"}},
 		{"xx prefix (no match)", "xx", false, nil},
 	}

--- a/impl/interpreter/date_test.go
+++ b/impl/interpreter/date_test.go
@@ -881,6 +881,14 @@ func TestExtendedRelativeDates(t *testing.T) {
 		{"last month", "d = last month\n", 2026, 3, 1},
 		// last year = Jan 1 of last year
 		{"last year", "d = last year\n", 2025, 1, 1},
+
+		// Period abbreviations (CY/FY/CQ/FQ). Bare forms collide with
+		// the notation parser (Q1-Q4, FQ1-FQ4, FY2026, CY26), so only
+		// relative forms (`this/next/last CY`) are supported.
+		{"next CY", "d = next CY\n", 2027, 1, 1},
+		{"last CY", "d = last CY\n", 2025, 1, 1},
+		{"next CQ", "d = next CQ\n", 2026, 7, 1},
+		{"last CQ", "d = last CQ\n", 2026, 1, 1},
 	}
 
 	for _, tt := range tests {

--- a/impl/interpreter/datetime.go
+++ b/impl/interpreter/datetime.go
@@ -74,9 +74,35 @@ func (interp *Interpreter) evalDurationLiteral(d *ast.DurationLiteral) (types.Ty
 	return types.NewDurationFromString(d.Value, d.Unit)
 }
 
+// periodAbbreviationExpansion normalises the short-form period
+// abbreviations into the canonical phrases the evaluator switch
+// already understands. Keeps the bulk of the switch body unchanged
+// instead of growing it with a dozen new cases.
+var periodAbbreviationExpansion = map[string]string{
+	"cy":      "this year",
+	"fy":      "this fiscal year",
+	"cq":      "this quarter",
+	"fq":      "this fiscal quarter",
+	"this cy": "this year",
+	"next cy": "next year",
+	"last cy": "last year",
+	"this fy": "this fiscal year",
+	"next fy": "next fiscal year",
+	"last fy": "last fiscal year",
+	"this cq": "this quarter",
+	"next cq": "next quarter",
+	"last cq": "last quarter",
+	"this fq": "this fiscal quarter",
+	"next fq": "next fiscal quarter",
+	"last fq": "last fiscal quarter",
+}
+
 func (interp *Interpreter) evalRelativeDateLiteral(r *ast.RelativeDateLiteral) (types.Type, error) {
 	now := interp.now()
 	keyword := strings.ToLower(r.Keyword)
+	if canonical, ok := periodAbbreviationExpansion[keyword]; ok {
+		keyword = canonical
+	}
 
 	switch keyword {
 	case "today":

--- a/spec/features/completion.go
+++ b/spec/features/completion.go
@@ -235,6 +235,21 @@ func DirectiveSuggestions(prefix string, scaleFactor string, globals map[string]
 	return suggestions
 }
 
+// templateDateNames lists registry entries whose name is a TEMPLATE
+// placeholder form, not a literal calcmark expression. The parser
+// cannot consume `this weekday` — the user is expected to type `this
+// Friday` (specific weekday). Surfacing them as completions inserts
+// invalid source. These names exist in the registry for documentation
+// purposes (syntax, example) but must not appear in DateSuggestions.
+var templateDateNames = map[string]bool{
+	"next weekday":    true,
+	"this weekday":    true,
+	"last weekday":    true,
+	"next month name": true,
+	"this month name": true,
+	"last month name": true,
+}
+
 // DateSuggestions returns date keyword suggestions matching prefix.
 // Surfaces date-related features like "today", "next Friday", "this quarter", "ago", "end of".
 func DateSuggestions(prefix string) []Suggestion {
@@ -244,7 +259,7 @@ func DateSuggestions(prefix string) []Suggestion {
 	registry := DefaultRegistry()
 
 	for _, f := range registry.ByCategory(CategoryDate) {
-		if MatchesPrefix(f.Name, prefix) {
+		if !templateDateNames[f.Name] && MatchesPrefix(f.Name, prefix) {
 			suggestions = append(suggestions, Suggestion{
 				Name:        f.Name,
 				Category:    "Date",
@@ -255,6 +270,9 @@ func DateSuggestions(prefix string) []Suggestion {
 		}
 		// Also check aliases for parseable date expressions
 		for _, alias := range f.Aliases {
+			if templateDateNames[alias.Name] {
+				continue
+			}
 			if alias.Parseable && MatchesPrefix(alias.Name, prefix) {
 				suggestions = append(suggestions, Suggestion{
 					Name:        alias.Name,

--- a/spec/features/completion_test.go
+++ b/spec/features/completion_test.go
@@ -439,3 +439,50 @@ func TestFirstWord(t *testing.T) {
 		}
 	}
 }
+
+// TestDateSuggestions_ExcludesTemplateNames verifies that template-
+// form entries (like `this weekday`, `next month name`) are NOT
+// surfaced as literal completions. Users are expected to type a
+// specific weekday (`this Friday`) or month (`next April`) — offering
+// the bare template as a one-shot completion would insert invalid
+// calcmark source.
+func TestDateSuggestions_ExcludesTemplateNames(t *testing.T) {
+	banned := []string{
+		"next weekday", "this weekday", "last weekday",
+		"next month name", "this month name", "last month name",
+	}
+	// Use prefixes that would otherwise match these names.
+	for _, prefix := range []string{"", "this", "last", "next"} {
+		sugg := DateSuggestions(prefix)
+		for _, b := range banned {
+			for _, s := range sugg {
+				if s.Name == b {
+					t.Errorf("DateSuggestions(%q) unexpectedly surfaced template %q", prefix, b)
+				}
+			}
+		}
+	}
+}
+
+// TestDateSuggestions_KeepsLiteralAliases confirms valid literal
+// entries in the features registry survive the template filter.
+// (Keywords like `this week` / `this year` live in the lexer's
+// RelativeDateKeywords map, not the feature registry, so they are
+// not surfaced by DateSuggestions — the lexer tokenises them
+// directly.)
+func TestDateSuggestions_KeepsLiteralAliases(t *testing.T) {
+	required := []string{"today", "this quarter"}
+	sugg := DateSuggestions("")
+	for _, want := range required {
+		found := false
+		for _, s := range sugg {
+			if s.Name == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("DateSuggestions(\"\") should still surface literal %q", want)
+		}
+	}
+}

--- a/spec/lexer/date_keywords.go
+++ b/spec/lexer/date_keywords.go
@@ -22,6 +22,13 @@ var DateKeywords = map[string]TokenType{
 	"friday":    DATE_WEEKDAY,
 	"saturday":  DATE_WEEKDAY,
 	"sunday":    DATE_WEEKDAY,
+
+	// NOTE: bare period abbreviations (CY / FY / CQ / FQ) are NOT
+	// registered here. They collide with the notation parser
+	// (Q1-Q4, FQ1-FQ4, FY2026, CY26) because the word scanner
+	// stops at the first non-letter, consuming `FQ` out of `FQ1`.
+	// Users reach the same semantics via the relative forms below
+	// (`this CY`, `next FY`, `last FQ`, etc.).
 }
 
 // RelativeDateKeywords maps multi-word relative date keywords to token types
@@ -51,6 +58,24 @@ var RelativeDateKeywords = map[string]TokenType{
 	"this quarter": DATE_THIS_QUARTER,
 	"next quarter": DATE_NEXT_QUARTER,
 	"last quarter": DATE_LAST_QUARTER,
+
+	// Period abbreviations with relative prefixes.
+	// Calendar year / fiscal year / calendar quarter / fiscal quarter.
+	"this cy": DATE_THIS_YEAR,
+	"next cy": DATE_NEXT_YEAR,
+	"last cy": DATE_LAST_YEAR,
+
+	"this fy": DATE_THIS_FISCAL_YEAR,
+	"next fy": DATE_NEXT_FISCAL_YEAR,
+	"last fy": DATE_LAST_FISCAL_YEAR,
+
+	"this cq": DATE_THIS_QUARTER,
+	"next cq": DATE_NEXT_QUARTER,
+	"last cq": DATE_LAST_QUARTER,
+
+	"this fq": DATE_THIS_FISCAL_QUARTER,
+	"next fq": DATE_NEXT_FISCAL_QUARTER,
+	"last fq": DATE_LAST_FISCAL_QUARTER,
 
 	// This weekday
 	"this monday":    DATE_THIS_WEEKDAY,

--- a/spec/lexer/date_tokenizer_test.go
+++ b/spec/lexer/date_tokenizer_test.go
@@ -24,6 +24,23 @@ func TestDateKeywordTokenization(t *testing.T) {
 		{"last week", lexer.DATE_LAST_WEEK},
 		{"last month", lexer.DATE_LAST_MONTH},
 		{"last year", lexer.DATE_LAST_YEAR},
+
+		// Period abbreviations — with relative prefix.
+		// Bare forms (CY / FY / CQ / FQ) collide with the notation
+		// parser (Q1-Q4, FQ1-FQ4, FY2026, CY26), so users must use
+		// the relative forms.
+		{"this CY", lexer.DATE_THIS_YEAR},
+		{"next CY", lexer.DATE_NEXT_YEAR},
+		{"last CY", lexer.DATE_LAST_YEAR},
+		{"this FY", lexer.DATE_THIS_FISCAL_YEAR},
+		{"next FY", lexer.DATE_NEXT_FISCAL_YEAR},
+		{"last FY", lexer.DATE_LAST_FISCAL_YEAR},
+		{"this CQ", lexer.DATE_THIS_QUARTER},
+		{"next CQ", lexer.DATE_NEXT_QUARTER},
+		{"last CQ", lexer.DATE_LAST_QUARTER},
+		{"this FQ", lexer.DATE_THIS_FISCAL_QUARTER},
+		{"next FQ", lexer.DATE_NEXT_FISCAL_QUARTER},
+		{"last FQ", lexer.DATE_LAST_FISCAL_QUARTER},
 	}
 
 	for _, tt := range tests {

--- a/spec/semantic/checker_test.go
+++ b/spec/semantic/checker_test.go
@@ -50,6 +50,37 @@ func TestEnvironmentClone(t *testing.T) {
 	}
 }
 
+// TestEnvironmentBuiltinConstants verifies PI and E are pre-defined in
+// the semantic environment so static analysis doesn't flag them as
+// undefined. Mirrors the runtime interpreter's TestBuiltinConstants.
+func TestEnvironmentBuiltinConstants(t *testing.T) {
+	env := NewEnvironment()
+
+	for _, name := range []string{"PI", "E"} {
+		if !env.Has(name) {
+			t.Errorf("expected built-in constant %q to be defined in a fresh semantic environment", name)
+		}
+		val, ok := env.Get(name)
+		if !ok {
+			t.Errorf("Get(%q) returned ok=false; expected true", name)
+			continue
+		}
+		if val == nil {
+			t.Errorf("Get(%q) returned nil type; expected a number type", name)
+		}
+	}
+}
+
+// TestEnvironmentBuiltinConstantsCloneIncludesConstants ensures the
+// constants survive Clone — scoped environments must still resolve
+// built-ins.
+func TestEnvironmentBuiltinConstantsCloneIncludesConstants(t *testing.T) {
+	cloned := NewEnvironment().Clone()
+	if !cloned.Has("PI") || !cloned.Has("E") {
+		t.Error("cloned semantic environment should still contain built-in constants PI and E")
+	}
+}
+
 // TestCurrencyValidation tests currency code validation
 func TestCurrencyValidation(t *testing.T) {
 	tests := []struct {

--- a/spec/semantic/environment.go
+++ b/spec/semantic/environment.go
@@ -5,6 +5,16 @@ import (
 
 	"github.com/CalcMark/go-calcmark/spec/ast"
 	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/shopspring/decimal"
+)
+
+// Mathematical built-in constants. Values mirror the runtime interpreter
+// environment (impl/interpreter/environment.go) so static analysis and
+// evaluation agree on whether a name like "PI" is bound. If the runtime
+// list grows a constant, add it here too.
+var (
+	builtinPI = decimal.RequireFromString("3.14159265358979323846264338327950288419716939937510")
+	builtinE  = decimal.RequireFromString("2.71828182845904523536028747135266249775724709369995")
 )
 
 // VarInfo tracks information about a variable definition
@@ -19,11 +29,25 @@ type Environment struct {
 	vars map[string]*VarInfo
 }
 
-// NewEnvironment creates a new empty environment.
+// NewEnvironment creates a new environment pre-populated with the
+// built-in mathematical constants (PI, E) so the semantic checker
+// doesn't flag references to them as "undefined variable." The
+// runtime interpreter environment does the equivalent via
+// addConstants — this function keeps the two layers aligned.
 func NewEnvironment() *Environment {
-	return &Environment{
+	env := &Environment{
 		vars: make(map[string]*VarInfo),
 	}
+	env.addBuiltinConstants()
+	return env
+}
+
+// addBuiltinConstants registers the mathematical constants the runtime
+// interpreter also registers. The Range field is left nil — these
+// names are not defined at any source location.
+func (e *Environment) addBuiltinConstants() {
+	e.vars["PI"] = &VarInfo{Type: types.NewNumber(builtinPI), Range: nil}
+	e.vars["E"] = &VarInfo{Type: types.NewNumber(builtinE), Range: nil}
 }
 
 // Set stores a variable binding with optional range information.


### PR DESCRIPTION
## Summary

Three independent fixes surfaced while using calcmark-web:

- **PI / E flagged as undefined** — `spec/semantic/environment.go` now registers PI and E as built-in constants, matching the runtime interpreter's `addConstants()` behavior.
- **`next CY` / `last FY` / etc. don't resolve** — Added relative-prefixed period abbreviations (`this|next|last` + `CY|FY|CQ|FQ`) to `RelativeDateKeywords` and canonicalized them in the interpreter via `periodAbbreviationExpansion`. Bare forms (`CY` alone, etc.) are intentionally **not** registered — they collide with the notation parser (`Q1-Q4`, `FQ1-FQ4`, `FY2026`, `CY26`) because the word scanner consumes `FQ` out of `FQ1`.
- **Template aliases surface as invalid completions** — `this weekday`, `next month name`, etc. are authoring templates, not valid calcmark. Added a `templateDateNames` filter in `features/completion.go` so they no longer appear in `DateSuggestions`. They remain `Parseable: true` so snippet expansion still works.

Tests added at each tier (lexer, semantic, interpreter, features). Existing TUI autocomplete test updated to assert post-filter behavior.

## Test plan

- [x] `go test ./...` passes locally
- [ ] CI green on PR
- [ ] Consumer verification in calcmark-web after v1.13.1 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-velocity:pr:138 -->
### Metrics

Opened by `@dvhthomas` (agent-assisted) on 2026-04-18 20:16 UTC. Merged 2026-04-18 20:16 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 38s  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
