### PR TITLE
feat(lsp): period literals + end-of/start-of completion (#140 PR-1a)

### DIFF
--- a/lsp/frontmatter_region_test.go
+++ b/lsp/frontmatter_region_test.go
@@ -9,12 +9,12 @@ import (
 
 func TestDetectRegion(t *testing.T) {
 	cases := []struct {
-		name       string
-		source     string
-		wantOK     bool
-		wantStart  int
-		wantEnd    int
-		wantKeys   map[int]string
+		name      string
+		source    string
+		wantOK    bool
+		wantStart int
+		wantEnd   int
+		wantKeys  map[int]string
 	}{
 		{
 			name:      "well-formed single key",
@@ -105,12 +105,12 @@ func TestClassifyCursor(t *testing.T) {
 	}
 
 	cases := []struct {
-		name     string
-		region   FrontmatterRegion
-		pos      protocol.Position
-		wantIn   bool
-		wantPos  CursorPosition
-		wantKey  string
+		name    string
+		region  FrontmatterRegion
+		pos     protocol.Position
+		wantIn  bool
+		wantPos CursorPosition
+		wantKey string
 	}{
 		{
 			name:    "outside region (after end fence)",

--- a/spec/features/completion.go
+++ b/spec/features/completion.go
@@ -250,22 +250,62 @@ var templateDateNames = map[string]bool{
 	"last month name": true,
 }
 
+// nonPeriodDateNames identifies CategoryDate features that are NOT
+// period-bearing -- they resolve to a single date or a duration, not
+// to a period the user can take the start/end of. The
+// `end of <period>` / `start of <period>` synthesis handler skips
+// these so it does not offer nonsensical combinations like
+// `end of today` or `end of days`.
+//
+// Adding a new CategoryDate feature: if it produces a Period (a
+// span the user can ask for the start or end of), do nothing -- it
+// flows through synthesis automatically. If it produces a Date
+// (point in time) or Duration (length), add it here.
+var nonPeriodDateNames = map[string]bool{
+	"today":     true,
+	"tomorrow":  true,
+	"yesterday": true,
+	"now":       true,
+	"days":      true,
+	"weeks":     true,
+	"months":    true,
+	"years":     true,
+	"from":      true,
+	"ago":       true,
+}
+
 // DateSuggestions returns date keyword suggestions matching prefix.
 // Surfaces date-related features like "today", "next Friday", "this quarter", "ago", "end of".
 func DateSuggestions(prefix string) []Suggestion {
 	prefix = strings.ToLower(prefix)
 	var suggestions []Suggestion
 
+	// `end[ of]?` / `start[ of]?` prefix triggers the synthesis
+	// handler, which prefixes the registered period set with
+	// `end of ` / `start of `. Stays in sync with the registry --
+	// new period kinds light up automatically.
+	if op, isOp, opPrefix := detectEndStartOfPrefix(prefix); isOp {
+		return synthesizeEndStartOfPeriods(op, opPrefix)
+	}
+
 	registry := DefaultRegistry()
 
 	for _, f := range registry.ByCategory(CategoryDate) {
 		if !templateDateNames[f.Name] && MatchesPrefix(f.Name, prefix) {
+			// Snippet-form entries (e.g., year-bearing literals like
+			// `FY${1:NNNN}`) carry their own InsertText. Plain literals
+			// fall back to Name. Downstream LSP layers detect the
+			// `${...}` placeholder and flag InsertTextFormat: Snippet.
+			insertText := f.InsertText
+			if insertText == "" {
+				insertText = f.Name
+			}
 			suggestions = append(suggestions, Suggestion{
 				Name:        f.Name,
 				Category:    "Date",
 				Description: f.Description,
 				Syntax:      f.Syntax,
-				InsertText:  f.Name,
+				InsertText:  insertText,
 			})
 		}
 		// Also check aliases for parseable date expressions
@@ -352,4 +392,69 @@ func firstWord(name string) string {
 		return before
 	}
 	return name
+}
+
+// detectEndStartOfPrefix recognizes the `end[ of]?` / `start[ of]?`
+// prefix shapes that trigger synthesis. Returns:
+//   - op: the operator string ("end of " or "start of ")
+//   - isOp: true when the prefix matches one of these shapes
+//   - opPrefix: the period-name prefix the user has typed beyond
+//     the operator (e.g., "Q" from "end of Q", or "" from "end")
+//
+// Word-boundary check: the prefix must be exactly `end`, `end `,
+// `end of`, `end of `, `end of <text>`, or the `start` equivalents.
+// `ending`, `endorse`, `started` etc. don't match -- the input
+// has to *be* the operator, not just begin with it.
+func detectEndStartOfPrefix(prefix string) (op string, isOp bool, opPrefix string) {
+	for _, candidate := range []string{"end", "start"} {
+		full := candidate + " of"
+		switch {
+		case prefix == candidate:
+			return candidate + " of ", true, ""
+		case strings.HasPrefix(prefix, candidate+" ") && (prefix == candidate+" " || strings.HasPrefix(prefix, full)):
+			// Either "end " (still typing) or "end of..." (typing the period).
+			rest := strings.TrimPrefix(prefix, candidate+" ")
+			rest = strings.TrimPrefix(rest, "of")
+			rest = strings.TrimPrefix(rest, " ")
+			return candidate + " of ", true, rest
+		}
+	}
+	return "", false, ""
+}
+
+// synthesizeEndStartOfPeriods emits `op + <period-name>` items for
+// every registered period-bearing CategoryDate feature whose name
+// matches `opPrefix`. The `nonPeriodDateNames` skip-list filters out
+// non-period entries (today, tomorrow, days, etc.).
+//
+// Snippet propagation: when a period entry has its own InsertText
+// (e.g., FY/CY year-bearing snippets `FY${1:2026}`), the synthesized
+// item carries `op + that-snippet` so editors still treat the year
+// as a placeholder.
+func synthesizeEndStartOfPeriods(op string, opPrefix string) []Suggestion {
+	var out []Suggestion
+	registry := DefaultRegistry()
+
+	opPrefixLower := strings.ToLower(opPrefix)
+
+	for _, f := range registry.ByCategory(CategoryDate) {
+		if templateDateNames[f.Name] || nonPeriodDateNames[f.Name] {
+			continue
+		}
+		if opPrefix != "" && !MatchesPrefix(f.Name, opPrefixLower) {
+			continue
+		}
+		insertBase := f.InsertText
+		if insertBase == "" {
+			insertBase = f.Name
+		}
+		out = append(out, Suggestion{
+			Name:        op + f.Name,
+			Category:    "Date",
+			Description: f.Description,
+			Syntax:      op + f.Syntax,
+			InsertText:  op + insertBase,
+		})
+	}
+	return out
 }

--- a/spec/features/completion_test.go
+++ b/spec/features/completion_test.go
@@ -1,6 +1,7 @@
 package features
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -510,4 +511,411 @@ func TestDateSuggestions_ThisPrefixCoversNamedPeriods(t *testing.T) {
 			t.Errorf("DateSuggestions(\"this\") missing %q; got %v", want, names)
 		}
 	}
+}
+
+// TestDateSuggestions_QPrefixSurfacesCalendarQuarters verifies that
+// typing `Q` in a calc block surfaces the four calendar-quarter
+// literal forms the lexer accepts (`Q1`-`Q4`). Reported 2026-04-28
+// against calcmark-web: typing `FQ` or `Q` produces zero suggestions
+// despite the lexer recognizing `CALENDAR_QUARTER_LITERAL` /
+// `FISCAL_QUARTER_LITERAL` and the evaluator computing them
+// correctly. This test pins the contract: every literal token kind
+// the lexer accepts must be discoverable via prefix completion.
+func TestDateSuggestions_QPrefixSurfacesCalendarQuarters(t *testing.T) {
+	required := []string{"Q1", "Q2", "Q3", "Q4"}
+	got := DateSuggestions("Q")
+	for _, want := range required {
+		found := false
+		for _, s := range got {
+			if s.Name == want {
+				found = true
+				if s.Category != "Date" {
+					t.Errorf("suggestion %q has category %q, want Date", s.Name, s.Category)
+				}
+				break
+			}
+		}
+		if !found {
+			names := make([]string, len(got))
+			for i, s := range got {
+				names[i] = s.Name
+			}
+			t.Errorf("DateSuggestions(\"Q\") missing %q; got %v", want, names)
+		}
+	}
+}
+
+// TestDateSuggestions_QPrefixCaseInsensitive — calcmark identifiers
+// are case-insensitive in the lexer (q1 → CALENDAR_QUARTER_LITERAL).
+// Completion mirrors that: lowercase prefix returns the same set.
+func TestDateSuggestions_QPrefixCaseInsensitive(t *testing.T) {
+	got := DateSuggestions("q")
+	if len(got) < 4 {
+		t.Errorf("DateSuggestions(\"q\") should return at least 4 quarter items; got %d", len(got))
+	}
+}
+
+// TestDateSuggestions_Q1ExactPrefixSelectsOne — typing the literal
+// itself narrows to exactly that entry.
+func TestDateSuggestions_Q1ExactPrefixSelectsOne(t *testing.T) {
+	got := DateSuggestions("Q1")
+	count := 0
+	for _, s := range got {
+		if s.Name == "Q1" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("DateSuggestions(\"Q1\") should match exactly one Q1 entry; got %d matches in %v", count, got)
+	}
+}
+
+// TestDateSuggestions_Q5ReturnsNothingMatchingQ5 — the parser rejects
+// Q5 (`invalid calendar quarter`); completion must not offer it.
+func TestDateSuggestions_Q5ReturnsNothingMatchingQ5(t *testing.T) {
+	got := DateSuggestions("Q5")
+	for _, s := range got {
+		if s.Name == "Q5" {
+			t.Errorf("DateSuggestions(\"Q5\") unexpectedly surfaced %q", s.Name)
+		}
+	}
+}
+
+// TestDateSuggestions_QuarterEntriesHaveDescriptionAndExample —
+// every new entry must carry the full registry shape so hover docs
+// and the LSP detail panel have content to show.
+func TestDateSuggestions_QuarterEntriesHaveDescriptionAndExample(t *testing.T) {
+	got := DateSuggestions("Q")
+	for _, s := range got {
+		if s.Name != "Q1" && s.Name != "Q2" && s.Name != "Q3" && s.Name != "Q4" {
+			continue
+		}
+		if s.Description == "" {
+			t.Errorf("calendar-quarter %q has empty Description", s.Name)
+		}
+		if s.Syntax == "" {
+			t.Errorf("calendar-quarter %q has empty Syntax", s.Name)
+		}
+	}
+}
+
+// TestDateSuggestions_FQPrefixSurfacesFiscalQuarters — typing `FQ`
+// returns FQ1-FQ4. Symmetric to Q1-Q4 but documented as requiring
+// `fiscal_year_starts` frontmatter (the interpreter raises a
+// fiscal-required runtime error otherwise; surfacing that
+// requirement in the completion description prevents user
+// confusion).
+func TestDateSuggestions_FQPrefixSurfacesFiscalQuarters(t *testing.T) {
+	required := []string{"FQ1", "FQ2", "FQ3", "FQ4"}
+	got := DateSuggestions("FQ")
+	for _, want := range required {
+		found := false
+		for _, s := range got {
+			if s.Name == want {
+				found = true
+				if s.Category != "Date" {
+					t.Errorf("suggestion %q has category %q, want Date", s.Name, s.Category)
+				}
+				if !strings.Contains(s.Description, "fiscal_year_starts") {
+					t.Errorf("FQ-family suggestion %q description should mention fiscal_year_starts; got %q",
+						s.Name, s.Description)
+				}
+				break
+			}
+		}
+		if !found {
+			names := make([]string, len(got))
+			for i, s := range got {
+				names[i] = s.Name
+			}
+			t.Errorf("DateSuggestions(\"FQ\") missing %q; got %v", want, names)
+		}
+	}
+}
+
+// TestDateSuggestions_FQ0AndFQ5RejectedByLexer — completion mirrors
+// what the lexer accepts. FQ0 / FQ5 are not valid lexer tokens, so
+// they must not appear as suggestions.
+func TestDateSuggestions_FQ0AndFQ5RejectedByLexer(t *testing.T) {
+	got := DateSuggestions("FQ")
+	for _, s := range got {
+		if s.Name == "FQ0" || s.Name == "FQ5" {
+			t.Errorf("DateSuggestions(\"FQ\") unexpectedly surfaced %q", s.Name)
+		}
+	}
+}
+
+// TestDateSuggestions_FiscalQuarterShorthandAliases — the lexer
+// already accepts `this FQ` / `next FQ` / `last FQ` (verified in
+// spec/lexer/date_tokenizer_test.go). The registry should reflect
+// that by listing them as Parseable aliases on `fiscal quarter`.
+// This test exercises the alias path through DateSuggestions.
+func TestDateSuggestions_FiscalQuarterShorthandAliases(t *testing.T) {
+	wanted := []string{"this FQ", "next FQ", "last FQ"}
+	got := DateSuggestions("this F")
+	gotNext := DateSuggestions("next F")
+	gotLast := DateSuggestions("last F")
+	all := append(append(append([]Suggestion{}, got...), gotNext...), gotLast...)
+	for _, want := range wanted {
+		found := false
+		for _, s := range all {
+			if s.Name == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			names := make([]string, len(all))
+			for i, s := range all {
+				names[i] = s.Name
+			}
+			t.Errorf("expected alias %q across this/next/last F prefix queries; got %v", want, names)
+		}
+	}
+}
+
+// TestDateSuggestions_FiscalYearShorthandAliases — `this FY` /
+// `next FY` / `last FY` are lexed equivalently; same registry
+// alias treatment.
+func TestDateSuggestions_FiscalYearShorthandAliases(t *testing.T) {
+	wanted := []string{"this FY", "next FY", "last FY"}
+	all := append(append(append(
+		[]Suggestion{},
+		DateSuggestions("this F")...),
+		DateSuggestions("next F")...),
+		DateSuggestions("last F")...)
+	for _, want := range wanted {
+		found := false
+		for _, s := range all {
+			if s.Name == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected alias %q across this/next/last F prefix queries", want)
+		}
+	}
+}
+
+// TestDateSuggestions_FYPrefixSurfacesYearLiteralSnippet — typing
+// `FY` returns a single snippet completion that fills in the current
+// calendar year as a placeholder. The lexer recognizes `FY26` and
+// `FY2026` as FISCAL_YEAR_LITERAL; this entry is the discoverability
+// path. The snippet's InsertText carries `${1:NNNN}` so editors can
+// honor it as a placeholder. The registry stores the snippet text;
+// LSP-layer conversion to `InsertTextFormat: Snippet` happens
+// downstream in lsp/completion.go (covered by U3's lsp/ test).
+func TestDateSuggestions_FYPrefixSurfacesYearLiteralSnippet(t *testing.T) {
+	got := DateSuggestions("FY")
+	found := false
+	for _, s := range got {
+		// Allow a single FY entry whose InsertText contains
+		// `${1:` (the snippet placeholder marker).
+		if s.Name == "FY" && strings.Contains(s.InsertText, "${1:") {
+			found = true
+			if !strings.Contains(s.Description, "fiscal_year_starts") {
+				t.Errorf("FY snippet description should mention fiscal_year_starts; got %q", s.Description)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("DateSuggestions(\"FY\") missing FY snippet entry with ${1:NNNN} placeholder; got %v", got)
+	}
+}
+
+// TestDateSuggestions_FYSnippetDefaultsToCurrentYear — the
+// placeholder default is `now.Year()` so users see a sensible
+// pre-filled value. Format: `FY${1:2026}`.
+func TestDateSuggestions_FYSnippetDefaultsToCurrentYear(t *testing.T) {
+	got := DateSuggestions("FY")
+	for _, s := range got {
+		if s.Name != "FY" {
+			continue
+		}
+		// The exact year value depends on `time.Now()` at call time;
+		// verify the placeholder is exactly 4 digits in the default
+		// position so editors can interpret it as a year.
+		if !strings.Contains(s.InsertText, "${1:20") {
+			t.Errorf("FY snippet should default to a current-millennium year (FY${1:20YY}); got %q", s.InsertText)
+		}
+		return
+	}
+	t.Fatalf("no FY entry returned by DateSuggestions(\"FY\")")
+}
+
+// TestDateSuggestions_CYPrefixSurfacesYearLiteralSnippet — symmetric
+// to FY, for calendar years.
+func TestDateSuggestions_CYPrefixSurfacesYearLiteralSnippet(t *testing.T) {
+	got := DateSuggestions("CY")
+	found := false
+	for _, s := range got {
+		if s.Name == "CY" && strings.Contains(s.InsertText, "${1:") {
+			found = true
+			if s.Description == "" {
+				t.Errorf("CY snippet description should be non-empty")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("DateSuggestions(\"CY\") missing CY snippet entry; got %v", got)
+	}
+}
+
+// TestDateSuggestions_EndPrefixSynthesizesEndOfPeriods — typing
+// `end` returns synthesized `end of <period>` items, derived from
+// the registered period-bearing date features. The synthesis
+// handler skips non-period date entries (`today`, `tomorrow`,
+// `days`, `weeks`, etc.) via a local skip-list. New period kinds
+// added to the registry automatically flow through this handler
+// without manual registry expansion.
+func TestDateSuggestions_EndPrefixSynthesizesEndOfPeriods(t *testing.T) {
+	got := DateSuggestions("end")
+	required := []string{
+		"end of Q1", "end of Q2", "end of Q3", "end of Q4",
+		"end of FQ1", "end of FQ2", "end of FQ3", "end of FQ4",
+		"end of this month", "end of this quarter", "end of this year",
+		"end of fiscal quarter", "end of fiscal year",
+	}
+	for _, want := range required {
+		found := false
+		for _, s := range got {
+			if s.Name == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			names := make([]string, len(got))
+			for i, s := range got {
+				names[i] = s.Name
+			}
+			t.Errorf("DateSuggestions(\"end\") missing %q; got %v", want, names)
+		}
+	}
+}
+
+// TestDateSuggestions_EndOfPrefixEquivalentToEnd — typing `end of`
+// returns the same synthesized set as `end` (the trailing space + of
+// don't change which period set is offered).
+func TestDateSuggestions_EndOfPrefixEquivalentToEnd(t *testing.T) {
+	gotEnd := DateSuggestions("end")
+	gotEndOf := DateSuggestions("end of")
+	endNames := nameSet(gotEnd)
+	endOfNames := nameSet(gotEndOf)
+	for name := range endNames {
+		if !endOfNames[name] {
+			t.Errorf("DateSuggestions(\"end of\") missing %q present in DateSuggestions(\"end\")", name)
+		}
+	}
+}
+
+// TestDateSuggestions_EndOfQNarrowsToCalendarQuarters — partial
+// prefix narrows the synthesized set.
+func TestDateSuggestions_EndOfQNarrowsToCalendarQuarters(t *testing.T) {
+	got := DateSuggestions("end of Q")
+	required := []string{"end of Q1", "end of Q2", "end of Q3", "end of Q4"}
+	for _, want := range required {
+		found := false
+		for _, s := range got {
+			if s.Name == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("DateSuggestions(\"end of Q\") missing %q", want)
+		}
+	}
+	// Should NOT include FQ-family items (different prefix).
+	for _, s := range got {
+		if strings.HasPrefix(s.Name, "end of FQ") {
+			t.Errorf("DateSuggestions(\"end of Q\") unexpectedly surfaced FQ-family item %q", s.Name)
+		}
+	}
+}
+
+// TestDateSuggestions_StartPrefixMirrorsEnd — `start of <period>`
+// is the symmetric form. Same synthesized set with `start` prefix.
+func TestDateSuggestions_StartPrefixMirrorsEnd(t *testing.T) {
+	got := DateSuggestions("start")
+	required := []string{
+		"start of Q1", "start of FQ1",
+		"start of this month", "start of fiscal quarter",
+	}
+	for _, want := range required {
+		found := false
+		for _, s := range got {
+			if s.Name == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			names := make([]string, len(got))
+			for i, s := range got {
+				names[i] = s.Name
+			}
+			t.Errorf("DateSuggestions(\"start\") missing %q; got %v", want, names)
+		}
+	}
+}
+
+// TestDateSuggestions_EndPrefixSkipsNonPeriodEntries — synthesis
+// excludes non-period date features (today, tomorrow, days, weeks)
+// because `end of today` is not a meaningful expression.
+func TestDateSuggestions_EndPrefixSkipsNonPeriodEntries(t *testing.T) {
+	got := DateSuggestions("end")
+	for _, s := range got {
+		for _, banned := range []string{
+			"end of today", "end of tomorrow", "end of yesterday", "end of now",
+			"end of days", "end of weeks", "end of months", "end of years",
+			"end of from", "end of ago",
+		} {
+			if s.Name == banned {
+				t.Errorf("DateSuggestions(\"end\") unexpectedly synthesized %q", banned)
+			}
+		}
+	}
+}
+
+// TestDateSuggestions_EndingDoesNotMatchSynthesis — the literal
+// English word `ending` should NOT trigger synthesis. The handler
+// must use a word-boundary check, not a naive prefix match.
+func TestDateSuggestions_EndingDoesNotMatchSynthesis(t *testing.T) {
+	got := DateSuggestions("ending")
+	for _, s := range got {
+		if strings.HasPrefix(s.Name, "end of") {
+			t.Errorf("DateSuggestions(\"ending\") incorrectly synthesized %q", s.Name)
+		}
+	}
+}
+
+// TestDateSuggestions_EndOfFYPropagatesSnippet — the year-bearing
+// FY/CY entries carry snippet placeholders. The synthesis handler
+// must propagate them so `end of FY${1:NNNN}` is offered (rather
+// than `end of FY` with no placeholder).
+func TestDateSuggestions_EndOfFYPropagatesSnippet(t *testing.T) {
+	got := DateSuggestions("end of FY")
+	found := false
+	for _, s := range got {
+		if s.Name == "end of FY" && strings.Contains(s.InsertText, "${1:") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("DateSuggestions(\"end of FY\") should offer snippet `end of FY${1:NNNN}`; got %v", got)
+	}
+}
+
+// nameSet — small helper for set-membership comparisons.
+func nameSet(ss []Suggestion) map[string]bool {
+	m := make(map[string]bool, len(ss))
+	for _, s := range ss {
+		m[s.Name] = true
+	}
+	return m
 }

--- a/spec/features/registry.go
+++ b/spec/features/registry.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/CalcMark/go-calcmark/spec/identifiers"
 	"github.com/CalcMark/go-calcmark/spec/types"
@@ -50,6 +51,13 @@ type Feature struct {
 	Params      []types.ParamSpec // Parameter specifications for functions (empty for non-functions)
 	Example     string            // Example usage (function-call form for help display)
 	NLExample   string            // Natural language example for autosuggest (e.g., "100 MB/s over 1 day")
+	// InsertText is the literal text to insert when the user accepts
+	// this completion. When empty, suggestion-builders fall back to
+	// `Name`. Use the LSP `${N:default}` snippet syntax for entries
+	// that need user-fillable placeholders (e.g., year-bearing date
+	// literals like `FY${1:NNNN}`). When set, downstream LSP layers
+	// flag the resulting completion item as InsertTextFormat: Snippet.
+	InsertText string
 }
 
 // Match checks if a query matches this feature (case-insensitive prefix match).
@@ -625,16 +633,131 @@ func getDateFeatures() []Feature {
 			Category:    CategoryDate,
 			Syntax:      "this fiscal quarter",
 			Description: "First day of the current fiscal quarter (requires fiscal_year_starts frontmatter)",
-			Aliases:     []Alias{{Name: "next fiscal quarter", Parseable: true}, {Name: "last fiscal quarter", Parseable: true}},
-			Example:     "this fiscal quarter",
+			// `this FQ` / `next FQ` / `last FQ` shorthand forms are
+			// already accepted by the lexer (see
+			// spec/lexer/date_tokenizer_test.go); registering them
+			// as Parseable aliases makes the registry truthful and
+			// surfaces them in completion when the user types `this F`,
+			// `next F`, or `last F`.
+			Aliases: []Alias{
+				{Name: "next fiscal quarter", Parseable: true},
+				{Name: "last fiscal quarter", Parseable: true},
+				{Name: "this FQ", Parseable: true},
+				{Name: "next FQ", Parseable: true},
+				{Name: "last FQ", Parseable: true},
+			},
+			Example: "this fiscal quarter",
 		},
 		{
 			Name:        "fiscal year",
 			Category:    CategoryDate,
 			Syntax:      "this fiscal year",
 			Description: "First day of the current fiscal year (requires fiscal_year_starts frontmatter)",
-			Aliases:     []Alias{{Name: "next fiscal year", Parseable: true}, {Name: "last fiscal year", Parseable: true}},
-			Example:     "this fiscal year",
+			Aliases: []Alias{
+				{Name: "next fiscal year", Parseable: true},
+				{Name: "last fiscal year", Parseable: true},
+				{Name: "this FY", Parseable: true},
+				{Name: "next FY", Parseable: true},
+				{Name: "last FY", Parseable: true},
+			},
+			Example: "this fiscal year",
+		},
+		// Calendar-quarter literals (Q1-Q4). The lexer recognizes
+		// `Q1`-`Q4` as CALENDAR_QUARTER_LITERAL tokens and the
+		// interpreter resolves each to the first day of the
+		// corresponding calendar quarter (Jan/Apr/Jul/Oct 1 of the
+		// current year). Registering here makes them discoverable via
+		// LSP completion -- prior to this, typing `Q` returned zero
+		// suggestions despite the language fully supporting the form.
+		// User report 2026-04-28 (calcmark-web): "I'm not sure what
+		// to even type to get FQ or FY. Or the 'end of FQ2'."
+		{
+			Name:        "Q1",
+			Category:    CategoryDate,
+			Syntax:      "Q1",
+			Description: "First day of calendar quarter 1 (Jan 1 of the current year)",
+			Example:     "end of Q1",
+		},
+		{
+			Name:        "Q2",
+			Category:    CategoryDate,
+			Syntax:      "Q2",
+			Description: "First day of calendar quarter 2 (Apr 1 of the current year)",
+			Example:     "end of Q2",
+		},
+		{
+			Name:        "Q3",
+			Category:    CategoryDate,
+			Syntax:      "Q3",
+			Description: "First day of calendar quarter 3 (Jul 1 of the current year)",
+			Example:     "end of Q3",
+		},
+		{
+			Name:        "Q4",
+			Category:    CategoryDate,
+			Syntax:      "Q4",
+			Description: "First day of calendar quarter 4 (Oct 1 of the current year)",
+			Example:     "end of Q4",
+		},
+		// Fiscal-quarter literals (FQ1-FQ4). The lexer recognizes
+		// `FQ1`-`FQ4` as FISCAL_QUARTER_LITERAL tokens. Resolution
+		// requires `fiscal_year_starts` in the document frontmatter
+		// -- evaluation without it produces a "fiscal expressions
+		// require a 'fiscal_year_starts' frontmatter key" diagnostic.
+		// Description copy mentions the requirement so users see it
+		// before typing.
+		{
+			Name:        "FQ1",
+			Category:    CategoryDate,
+			Syntax:      "FQ1",
+			Description: "First day of fiscal quarter 1 (per fiscal_year_starts frontmatter)",
+			Example:     "end of FQ1",
+		},
+		{
+			Name:        "FQ2",
+			Category:    CategoryDate,
+			Syntax:      "FQ2",
+			Description: "First day of fiscal quarter 2 (3 months after fiscal_year_starts)",
+			Example:     "end of FQ2",
+		},
+		{
+			Name:        "FQ3",
+			Category:    CategoryDate,
+			Syntax:      "FQ3",
+			Description: "First day of fiscal quarter 3 (6 months after fiscal_year_starts)",
+			Example:     "end of FQ3",
+		},
+		{
+			Name:        "FQ4",
+			Category:    CategoryDate,
+			Syntax:      "FQ4",
+			Description: "First day of fiscal quarter 4 (9 months after fiscal_year_starts; requires fiscal_year_starts frontmatter)",
+			Example:     "end of FQ4",
+		},
+		// Year-bearing literals (FY, CY) are snippet completions: the
+		// LSP placeholder `${1:<current-year>}` lets the user accept
+		// the suggestion and have the year pre-selected for editing.
+		// Year is captured at registry-build time -- this is a
+		// `sync.Once` per-process value, so the default reflects the
+		// year the process started (LSP servers re-spawn frequently
+		// enough that this stays current). Year arithmetic is the
+		// interpreter's job; the registry just makes the literal
+		// shape discoverable.
+		{
+			Name:        "FY",
+			Category:    CategoryDate,
+			Syntax:      "FY<NNNN>",
+			Description: "Specific fiscal year start (Microsoft convention: FY2027 with July start = Jul 1 2026 -> Jun 30 2027). Requires fiscal_year_starts frontmatter.",
+			InsertText:  fmt.Sprintf("FY${1:%d}", time.Now().Year()),
+			Example:     "end of FY2027",
+		},
+		{
+			Name:        "CY",
+			Category:    CategoryDate,
+			Syntax:      "CY<NNNN>",
+			Description: "Specific calendar year start (Jan 1 of that year). Two-digit forms (CY26) interpreted as 2000+NN.",
+			InsertText:  fmt.Sprintf("CY${1:%d}", time.Now().Year()),
+			Example:     "end of CY2026",
 		},
 	}
 }


### PR DESCRIPTION
## Summary

Closes the user discoverability gap for period-bearing date literals (`Q1`–`Q4`, `FQ1`–`FQ4`, `FY`, `CY`) and the `end of <period>` / `start of <period>` operators. PR-1a of the two-PR plan in #140; PR-1b will land the structural refactor.

User report from `calcmark-web` 2026-04-28: "Fiscal Quarter (FQ1) doesn't work even with the frontmatter defined. I'm not sure what to even type to get FQ or FY. Or the 'end of FQ2'." Eval already worked end-to-end; only completion was silent.

## Empirical baseline

Before this PR, against `v1.14.0`:

| Prefix | Suggestions returned |
| --- | --- |
| `Q` / `Q1` / `FQ` / `FQ1` / `FY` / `CY` | (nothing) |
| `end` / `end of` | (nothing) |
| `this` | `this month`, `this quarter`, ... (works) |

After this PR:

| Prefix | Suggestions returned |
| --- | --- |
| `Q` | `Q1`, `Q2`, `Q3`, `Q4` |
| `FQ` | `FQ1`, `FQ2`, `FQ3`, `FQ4` (each description mentions `fiscal_year_starts`) |
| `FY` | `FY${1:2026}` snippet (current year as default) |
| `CY` | `CY${1:2026}` snippet |
| `this F` / `next F` / `last F` | shorthand aliases (`this FQ`, `this FY`, ...) |
| `end` | 10+ synthesized `end of <period>` items |
| `end of Q` | narrows to calendar quarters only |
| `end of FY` | snippet `end of FY${1:2026}` |
| `start` / `start of` | symmetric to `end` |
| `ending` | (nothing — word-boundary check) |

## Changes

### `spec/features/registry.go`
- `Q1`–`Q4`, `FQ1`–`FQ4` registry entries (CategoryDate). FQ-family description copy mentions `fiscal_year_starts` requirement so users see it before typing.
- `FY` / `CY` snippet entries with `${1:NNNN}` placeholder defaulting to `time.Now().Year()` at registry-build time.
- `Feature.InsertText` field added — populated for snippet entries; empty for plain literals (which fall back to `Name` at suggestion-build time).
- `this FQ` / `next FQ` / `last FQ` registered as `Parseable: true` aliases on the existing `fiscal quarter` entry. Same for FY. The lexer already accepts these (see `spec/lexer/date_tokenizer_test.go`); the registry was silent.

### `spec/features/completion.go`
- `DateSuggestions` detects `end[ of]?` / `start[ of]?` prefixes via `detectEndStartOfPrefix` (word-boundary check — `ending` doesn't trigger).
- `synthesizeEndStartOfPeriods` walks `CategoryDate` features, skips non-period entries via a local `nonPeriodDateNames` set (today, tomorrow, days, weeks, ...), emits `op + name` items. Snippet `InsertText` propagates so `end of FY${1:2026}` is offered as a snippet completion.
- New period kinds added to the registry automatically flow through synthesis without manual handler updates.

### Tests (+14 new test cases)

5-layer coverage per `AGENTS.md`'s extensive-testing mandate:

- **Lexer**: existing tests untouched; verified backward-compat.
- **Parser**: existing tests untouched.
- **Type-checker / semantic**: existing tests untouched.
- **Registry / completion**: 14 new tests covering Q/FQ/FY/CY prefix returns, case-insensitivity, invalid forms (Q5/FQ0), description-mentions-fiscal_year_starts invariant, alias visibility, snippet placeholder shape, end/start synthesis correctness, narrowing prefixes, word-boundary on `ending`, snippet propagation through synthesis.
- **LSP**: existing `lsp/completion_test.go` tests still pass — the new entries surface naturally through the existing `dateCompletionItems` path.

### Drive-by
- `lsp/frontmatter_region_test.go` got auto-fmt'd by `go fmt ./...` during `task test` (pre-existing fmt drift, not behaviourally significant).

## Backwards compatibility

- All existing parser/eval/lexer/semantic tests pass unchanged.
- `Suggestion` shape unchanged.
- `Feature` shape gained one optional field (`InsertText`) — existing entries leave it empty and fall back to `Name`.
- `spec/`-never-imports-`impl/` invariant preserved (`TestSpecNeverImportsImpl` still passes).
- The downstream `calcmark-web/web/handlers_eval_fy_repro_test.go` 5 tests will continue to pass after `cmw` bumps `go-calcmark` (verified locally via `go.mod replace` against this branch).

## Test plan
- [x] `task test` — all packages green
- [ ] `task quality` — passes for all *new* code; modernize flags two pre-existing warnings (`spec/document/frontmatter.go:907`, `spec/semantic/frontmatter_check.go:125`) that exist on `main` too. Out of scope for this PR; happy to add a follow-up.
- [x] Manual: `DateSuggestions("FQ")` returns 4 items, `DateSuggestions("end of FQ")` returns 4 items, `DateSuggestions("ending")` returns 0 items.

## What's next

PR-1b (tracked in #140) introduces:
- `*types.Period` first-class type with `PeriodKind` enum
- `ast.EndOfExpr` / `ast.StartOfExpr` structured AST nodes (replaces the string-flatten at `spec/parser/primary.go:352`)
- Type-checker rules — inline-AST only, does NOT extend `TypeKind` enum (avoids API break)
- Interpreter dispatch by `PeriodKind` — removes `strings.HasPrefix(keyword, "end of ")` at `:175` and `:385`
- Audit of 5 downstream `*types.Date` assertion sites
- Variables-as-periods (`q = Q1; e = end of q`) as emergent runtime capability

Detailed plan at `calcmark-web` PR https://github.com/CalcMark/cmw/pull/63.

<!-- gh-velocity:pr:141 -->
### Metrics

Opened by `@dvhthomas` on 2026-04-29 17:13 UTC. Merged 2026-04-30 17:59 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 1d 0h  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
