### PR TITLE
v2.0 Period type system — release candidate

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -65,6 +65,12 @@ changelog:
 
 homebrew_casks:
   - name: calcmark
+    # `skip_upload: auto` keeps pre-releases (v2.0.0-rc.1, v2.0.0-beta.X,
+    # anything matching SemVer's prerelease syntax) OUT of the Homebrew
+    # tap, so users running `brew install calcmark/tap/calcmark` keep
+    # getting the latest stable. Stable tags (vX.Y.Z) still update the
+    # cask normally.
+    skip_upload: auto
     repository:
       owner: CalcMark
       name: homebrew-tap

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,156 @@
+# Changelog
+
+All notable changes to `go-calcmark` are documented in this file. The format
+follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+The v1.x history lives in the git log (`git log v1.0.0..v1.14.0`) and was
+not previously captured here. This file starts at the v2.0 cycle and will
+track every release going forward.
+
+## [Unreleased]
+
+## [2.0.0-rc.1] — 2026-04-30
+
+The 2.0 cycle promotes calendar/fiscal periods to a first-class type and
+makes period-bearing language (Q1, FQ1, `this fiscal year`, `between A and
+B`, `length of Q3`) behave consistently across the parser, interpreter,
+formatters, and editor surfaces. The work spans 26 commits since v1.14.0.
+
+### Breaking
+
+- **Period-bearing keywords now evaluate to `*types.Period`, not `Date`.**
+  `Q1`, `FQ2`, `CY2026`, `FY2027`, `this month`, `this fiscal quarter`, bare
+  month names like `April`, etc. now produce a `Period` value instead of
+  the period's start `Date`. Code that consumed the result as a `Date` must
+  read `.Start` (the start day) or use the explicit `start of <period>`
+  operator. The `End` field is now also populated for every period kind.
+- **`Period + Duration` arithmetic extends from the period's END, not its
+  start.** Pre-v2: `Q1 + 30 days` = Jan 1 + 30 = Jan 31. v2: `Q1 + 30 days`
+  = Mar 31 + 30 = Apr 30. Documents that want the old "from the start"
+  behavior now write `start of Q1 + 30 days` explicitly. The asymmetric
+  rule matches how people describe ranges in conversation ("a week after
+  Q1 ends") and removes the silent ambiguity of pre-v2 arithmetic.
+- **`grow` / `compound` / `depreciate` 3-arg form: the periods argument
+  must be a plain Number.** v1 silently coerced a Duration: `compound
+  $1000 by 5% over 3 years` interpreted `3 years` as 3 iterations. v2
+  rejects the Duration with a clear diagnostic and asks for the count
+  without a unit (`over 3`). The 4-arg form with `compounded monthly`
+  still accepts a Duration as the time argument because that form has
+  separate iteration semantics. Fixes the only remaining unit→count
+  coercion in the language.
+- **`between` is now a reserved keyword.** Documents that previously used
+  `between` as an identifier (variable name, function-call positional)
+  must rename it.
+- **Spaces are no longer permitted in identifiers.** Identifiers like
+  `tax rate` must use `tax_rate`. (This change shipped progressively
+  across the v1 series; v2.0 removes the last remaining quirks.)
+
+### Added
+
+- **First-class `Period` type** (`spec/types/period.go`). Concrete kinds:
+  `PeriodCalendarQuarter`, `PeriodCalendarYear`, `PeriodCalendarMonth`,
+  `PeriodFiscalQuarter`, `PeriodFiscalYear`, `PeriodRelativeQuarter`,
+  `PeriodRelativeFiscalQuarter`, `PeriodRelativeYear`,
+  `PeriodRelativeFiscalYear`, `PeriodCustom`. Every Period carries both
+  `Start` and `End` (closed interval, day precision).
+- **First-class `end of <period>` and `start of <period>` operators.**
+  `end of Q1` = Mar 31; `start of FQ2` = the first day of fiscal quarter 2.
+  Compose with every period kind.
+- **Custom date ranges** via `between A and B` and the equivalent
+  `from A to B`. Produces a `PeriodCustom` spanning the two dates
+  inclusive. Backed by `ast.BetweenExpr` and `types.NewCustomPeriod`.
+- **Period→Duration conversion** via `length of <period>` and
+  `days in <period>`. `length of Q1` returns the Duration covering the
+  quarter; `days in Q1` returns the day count as a Number.
+- **Period basis conversion** via `<period> as fiscal` and
+  `<period> as calendar`. Year-grain conversions match by label
+  (`CY2026 as fiscal` → `FY2026`); quarter-grain conversions preserve the
+  underlying date range and pick the FQ whose dates contain the input
+  midpoint.
+- **Bare month names parse as period literals.** `April` (with no year)
+  resolves to April of the current year as a `PeriodCalendarMonth`.
+  `April 2027` resolves to April 2027.
+- **Directed notation** for relative periods: `next FQ1` / `last CY26` /
+  `this Q1`. Combines a direction prefix with year-bearing notation.
+- **Bare `fiscal quarter` / `fiscal year` aliases for `this`.** Documents
+  can write `next fiscal quarter` and `last fiscal year` without the
+  redundant `this` prefix.
+- **`calendar_year_offset` frontmatter key** (`before` / `after`) selects
+  whether an FY label refers to the calendar year the FY ends in
+  (default — Australian government year, US tax year, most publicly
+  traded companies) or the calendar year the FY starts in (some
+  companies). Has no effect when `fiscal_year_starts: january`. Backed by
+  `types.FYLabelMode`, `NewFiscalYearWithMode`, `NewFiscalQuarterWithMode`,
+  and `Interpreter.SetFiscalCalendar`.
+- **Configurable date format** via `cm config date_format` and
+  `cm config period_date_format`. Locale-aware DSL (`MON dd, YYYY`,
+  `dd-MON-YYYY`, etc.) backed by the `goodsign/monday` library so weekday
+  and month names render in the user's locale.
+- **LSP completion + documentation for period vocabulary.** Period
+  literals (`Q1`, `FY2027`), the `end of` / `start of` operators, the
+  `between` / `from-to` / `length of` / `days in` keywords, and the
+  `as fiscal/calendar` conversion all surface in completion popups with
+  hover documentation. New `keywordPhrases` LSP request lets editors
+  highlight multi-word keyword phrases as a single chip.
+- **Documentation:** new sections in
+  [`docs/user-guide/dates.md`](site/content/docs/user-guide/dates.md)
+  (Fiscal Periods → `calendar_year_offset`) and
+  [`docs/user-guide/frontmatter.md`](site/content/docs/user-guide/frontmatter.md)
+  (Fiscal Calendar) covering both keys with worked examples.
+
+### Changed
+
+- **Period display is locale-aware and compact.** A Period now renders as
+  a `dd-MON-YYYY → dd-MON-YYYY` range (single day collapses to one
+  date) using the configured date format and the user's locale, instead
+  of the kind-bare label that pre-v2 relative kinds produced.
+- **Period stores `End` natively.** Pre-v2 code that recomputed the end
+  from `Start` + kind-specific math can now read `period.End` directly.
+
+### Fixed
+
+- `NewFiscalQuarter` correctly labels the FY by the year it ends in (the
+  default labeling). Previously the label drifted by one in some Jan-start
+  configurations.
+- Period TUI output renders the date range for relative kinds (was: bare
+  label for `this fiscal quarter` etc.).
+- Doc examples (`testdata/examples/datacenter-cost.cm`,
+  `embedded-datacenter-cost.md`, `investment-growth.cm`) updated to the
+  v2 plain-Number iteration count for `grow` / `compound` / `depreciate`.
+
+### Internal
+
+- `spec/features/registry.go` now catalogs the v2.0 period operators
+  (`between`, `length of`, `days in`, `as fiscal/calendar`,
+  `start of`/`end of`) plus the previously-missing `fiscal_year_starts`
+  and the new `calendar_year_offset` frontmatter entries.
+- Semantic checker arms collapsed and rewritten for the new period AST
+  nodes; transitional shim removed.
+- Interpreter `evalNode` rewritten so all period keywords return
+  `*types.Period` directly instead of going through a date-coercion
+  shim.
+- Classifier recognises bare-line `end of Q1` as a calculation rather
+  than prose (was: misclassified before U2.5).
+
+### Migration notes
+
+If your documents do any of the following, update them before bumping
+to v2.0.0:
+
+1. Use `period + duration` arithmetic and rely on extending from the
+   start. Replace `Q1 + 30 days` with `start of Q1 + 30 days` to keep
+   the v1 behavior, or accept the v2 end-extension semantics if that's
+   what you actually meant.
+2. Pass a Duration as the period count to `grow`/`compound`/`depreciate`
+   in the 3-arg form. Replace `over 5 years` with `over 5`.
+3. Use a variable named `between`. Rename it.
+4. Have a multi-word identifier with spaces. Rename to use underscores.
+
+Documents that don't touch any of the above need no changes — period
+literals (`Q1`, `FY2027`) read identically; `start of <period>` was
+always the explicit form; the new `between` / `length of` / `days in`
+keywords are net-new vocabulary.
+
+[Unreleased]: https://github.com/CalcMark/go-calcmark/compare/v2.0.0-rc.1...HEAD
+[2.0.0-rc.1]: https://github.com/CalcMark/go-calcmark/compare/v1.14.0...v2.0.0-rc.1

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Press Ctrl+H (or F1) in the TUI editor for keybindings.
 
 - [Documentation](https://calcmark.org/docs/) - Complete documentation with examples
 - [Language Reference](https://calcmark.org/docs/language-reference/) - Formal language specification
+- [CHANGELOG](CHANGELOG.md) - Release notes and migration guides
 
 ## Development
 

--- a/cmd/calcmark/cmd/convert.go
+++ b/cmd/calcmark/cmd/convert.go
@@ -127,11 +127,14 @@ func runConvert(filename string) error {
 	}
 
 	// Build conversion options.
+	cfg := config.Get()
 	opts := calcmark.Options{
-		Mode:     mode,
-		Format:   formatName,
-		Template: templateContent,
-		Locale:   config.Get().Locale,
+		Mode:             mode,
+		Format:           formatName,
+		Template:         templateContent,
+		Locale:           cfg.Locale,
+		DateFormat:       cfg.Formatter.DateFormat,
+		PeriodDateFormat: cfg.Formatter.PeriodDateFormat,
 	}
 
 	// Convert.

--- a/cmd/calcmark/cmd/root.go
+++ b/cmd/calcmark/cmd/root.go
@@ -119,15 +119,21 @@ func init() {
 // Must be called after config.Load() (i.e., inside or after PersistentPreRunE).
 // Invalid locale falls back to en-US with a warning to stderr.
 func localeFormatter() display.Formatter {
-	locale := config.Get().Locale
+	cfg := config.Get()
+	locale := cfg.Locale
+	var dcfg display.DisplayConfig
 	if locale == "" {
-		return display.DefaultFormatter()
+		dcfg = display.DefaultConfig()
+	} else {
+		var err error
+		dcfg, err = display.NewConfig(locale)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "calcmark: invalid locale %q, using en-US: %v\n", locale, err)
+			dcfg = display.DefaultConfig()
+		}
 	}
-	dcfg, err := display.NewConfig(locale)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "calcmark: invalid locale %q, using en-US: %v\n", locale, err)
-		return display.DefaultFormatter()
-	}
+	dcfg.DateFormat = cfg.Formatter.DateFormat
+	dcfg.PeriodDateFormat = cfg.Formatter.PeriodDateFormat
 	return display.NewFormatter(dcfg)
 }
 
@@ -152,6 +158,9 @@ func tuiFormatter() display.Formatter {
 
 	// Enable Unicode fractions by default; user can disable in config
 	dcfg.UnicodeFractions = cfg.TUI.UnicodeFractions == nil || *cfg.TUI.UnicodeFractions
+
+	dcfg.DateFormat = cfg.Formatter.DateFormat
+	dcfg.PeriodDateFormat = cfg.Formatter.PeriodDateFormat
 
 	return display.NewFormatter(dcfg)
 }

--- a/cmd/calcmark/config/defaults.toml
+++ b/cmd/calcmark/config/defaults.toml
@@ -50,6 +50,24 @@ verbose = false
 include_errors = true
 default_format = "text"
 
+# Date display format. DSL tokens (longest match first):
+#   YYYY = 4-digit year   YY = 2-digit year
+#   MMMM = January   MMM = Jan
+#   MON = JAN (uppercase)   mon = jan (lowercase)
+#   MM = 01   M = 1   dd = 02   d = 2
+#   EEEE = Monday   EEE = Mon
+# Quote literal letters with single quotes: 'T'YYYY -> T2026.
+# Empty (default) uses the locale's date layout (e.g., "Mon, Jan 2, 2026" en-US).
+# Example: date_format = "MON dd, YYYY"   ->   APR 01, 2026
+date_format = ""
+
+# Date format for endpoints inside Period output ("01-Jan-2026 – 31-Mar-2026").
+# Falls back to date_format then to the built-in compact "dd-MON-YYYY".
+# Set this independently when a verbose date_format would make twin-date
+# output hard to read.
+# Example: period_date_format = "YYYY-MM-dd"   ->   2026-01-01 – 2026-03-31
+period_date_format = ""
+
 [measurement]
 # How bare volume names (gallon, pint, cup, fl oz) are interpreted.
 # "us" = US Customary (default), "imperial" = Imperial (UK).

--- a/cmd/calcmark/config/types.go
+++ b/cmd/calcmark/config/types.go
@@ -67,6 +67,18 @@ type FormatterConfig struct {
 	Verbose       bool   `mapstructure:"verbose" toml:"verbose"`
 	IncludeErrors bool   `mapstructure:"include_errors" toml:"include_errors"`
 	DefaultFormat string `mapstructure:"default_format" toml:"default_format"`
+
+	// DateFormat is a user DSL string overriding the locale default
+	// for Date display (e.g., "MON dd, YYYY", "YYYY-MM-dd").
+	// See format/display/date_format_dsl.go for supported tokens.
+	// Empty (default) uses the locale's date layout.
+	DateFormat string `mapstructure:"date_format" toml:"date_format"`
+
+	// PeriodDateFormat is the user DSL for date endpoints inside
+	// Period output. Empty falls back to DateFormat, then to the
+	// built-in compact "dd-MON-YYYY". Set this independently when
+	// the verbose DateFormat would make twin-date output unreadable.
+	PeriodDateFormat string `mapstructure:"period_date_format" toml:"period_date_format"`
 }
 
 // MeasurementConfig holds default measurement conventions.

--- a/cmd/calcmark/config/validate.go
+++ b/cmd/calcmark/config/validate.go
@@ -32,16 +32,18 @@ func (r *ValidationResult) OK() bool {
 // struct understands (excluding tui.theme.* which has its own known set).
 var knownKeys = map[string]bool{
 	"locale":                   true,
-	"tui.color_mode":           true,
-	"tui.dark_mode":            true,
-	"tui.unicode_fractions":    true,
-	"formatter.verbose":        true,
-	"formatter.include_errors": true,
-	"formatter.default_format": true,
-	"measurement.volume":       true,
-	"measurement.mass":         true,
-	"measurement.ton":          true,
-	"measurement.strict":       true,
+	"tui.color_mode":               true,
+	"tui.dark_mode":                true,
+	"tui.unicode_fractions":        true,
+	"formatter.verbose":            true,
+	"formatter.include_errors":     true,
+	"formatter.default_format":     true,
+	"formatter.date_format":        true,
+	"formatter.period_date_format": true,
+	"measurement.volume":           true,
+	"measurement.mass":             true,
+	"measurement.ton":              true,
+	"measurement.strict":           true,
 }
 
 // ValidateHexColor reports whether s is a valid hex color string.

--- a/convert.go
+++ b/convert.go
@@ -34,6 +34,17 @@ type Options struct {
 	Format   string // Output format: "html", "md", "text", "json" (default: "html")
 	Template string // Go template content for wrapping HTML output (optional)
 	Locale   string // BCP 47 locale for number formatting (default: "en-US")
+
+	// DateFormat overrides the locale's default date layout for Date
+	// values. Uses the user-friendly DSL ("MON dd, YYYY", etc.) —
+	// see format/display/date_format_dsl.go for tokens. Empty string
+	// uses locale default.
+	DateFormat string
+
+	// PeriodDateFormat overrides the date layout used for endpoints
+	// inside Period output. Empty falls back to DateFormat, then to
+	// the built-in compact "dd-MON-YYYY".
+	PeriodDateFormat string
 }
 
 // validFormats is the set of recognized output format names.
@@ -111,7 +122,7 @@ func convertCM(input string, opts Options) (string, error) {
 	}
 
 	eval := impldoc.NewEvaluator()
-	eval.SetDisplayFormatter(localeFormatter(opts.Locale))
+	eval.SetDisplayFormatter(localeFormatterWithFormats(opts.Locale, opts.DateFormat, opts.PeriodDateFormat))
 	evalErr := eval.Evaluate(doc)
 	if evalErr != nil && !errors.Is(evalErr, impldoc.ErrPartialEvaluation) {
 		return "", fmt.Errorf("evaluation error: %w", evalErr)
@@ -157,7 +168,7 @@ func convertEmbedded(input string, opts Options) (string, error) {
 	}
 
 	segments := embedded.Scan(input)
-	df := localeFormatter(opts.Locale)
+	df := localeFormatterWithFormats(opts.Locale, opts.DateFormat, opts.PeriodDateFormat)
 
 	var out strings.Builder
 	var errCount int
@@ -314,5 +325,25 @@ func localeFormatter(locale string) display.Formatter {
 	if err != nil {
 		return display.DefaultFormatter()
 	}
+	return display.NewFormatter(cfg)
+}
+
+// localeFormatterWithFormats is the localeFormatter overload that
+// also threads the user-configurable date format DSL strings into
+// the resulting Formatter. Used by Convert when the Options carry
+// DateFormat / PeriodDateFormat overrides.
+func localeFormatterWithFormats(locale, dateFormat, periodDateFormat string) display.Formatter {
+	var cfg display.DisplayConfig
+	if locale == "" {
+		cfg = display.DefaultConfig()
+	} else {
+		var err error
+		cfg, err = display.NewConfig(locale)
+		if err != nil {
+			cfg = display.DefaultConfig()
+		}
+	}
+	cfg.DateFormat = dateFormat
+	cfg.PeriodDateFormat = periodDateFormat
 	return display.NewFormatter(cfg)
 }

--- a/format/display/config.go
+++ b/format/display/config.go
@@ -29,6 +29,20 @@ type DisplayConfig struct {
 	// UnicodeFractions enables Unicode Number Forms (e.g., ½, ⅓, ¾) for fraction display.
 	// Only used in TUI; JSON and CLI output always uses ASCII fractions.
 	UnicodeFractions bool
+
+	// DateFormat overrides the locale's default date layout when set.
+	// Uses the user-friendly DSL (see date_format_dsl.go): "MON dd,
+	// YYYY", "YYYY-MM-dd", etc. Empty string falls back to the
+	// locale's default ("Mon, Jan 2, 2006" for en-US).
+	DateFormat string
+
+	// PeriodDateFormat overrides the date layout used for endpoints
+	// inside a Period's display ("01-Jan-2026 – 31-Mar-2026"). Empty
+	// string falls back to the dd-MON-YYYY default. When DateFormat
+	// is set but PeriodDateFormat is not, the period default still
+	// applies — Period output stays compact even when single-Date
+	// output is set to a verbose layout.
+	PeriodDateFormat string
 }
 
 // DefaultConfig returns the en-US display configuration.

--- a/format/display/date_format_dsl.go
+++ b/format/display/date_format_dsl.go
@@ -1,0 +1,179 @@
+package display
+
+import (
+	"strings"
+	"time"
+
+	"github.com/goodsign/monday"
+)
+
+// User-facing date format DSL. Translates a small set of common
+// tokens to Go's reference layout so users don't have to memorize
+// `2006-01-02 15:04:05`.
+//
+// Tokens (longest match first; literal characters pass through):
+//
+//   YYYY  4-digit year                2006
+//   YY    2-digit year                06
+//   MMMM  Full month name (locale)    January / janvier / Januar
+//   MMM   Short month name (locale)   Jan / janv. / Jan.
+//   MON   Short month, UPPERCASE      JAN / JANV. / JAN.
+//   mon   Short month, lowercase      jan / janv. / jan.
+//   MM    2-digit month number        01
+//   M     Month number (no pad)       1
+//   dd    2-digit day                 02
+//   d     Day (no pad)                2
+//   EEEE  Full weekday (locale)       Monday / lundi / Montag
+//   EEE   Short weekday (locale)      Mon / lun. / Mo.
+//
+// Month-name case transforms (MON / mon) are applied after monday
+// formats the locale name — so "MON" with locale fr_FR for April
+// returns "AVR." (locale's abbreviation, uppercased).
+//
+// Anything else passes through literally. Quote any letter you
+// want preserved as-is by surrounding it with single quotes — e.g.
+// "'T'YYYY" emits "T2026".
+//
+// Returns the Go layout (suitable for monday.Format) and a post-
+// processor that handles MON / mon case transforms.
+
+// upperMonthMarker / lowerMonthMarker bracket month-name spans in
+// the layout that need post-format case conversion. They're ASCII
+// control characters that won't appear in normal date output.
+const (
+	upperMonthOpen  = "\x02"
+	upperMonthClose = "\x03"
+	lowerMonthOpen  = "\x04"
+	lowerMonthClose = "\x05"
+)
+
+// translateUserDateFormat converts a DSL string to a Go time
+// layout + post-processor. Returns the original string unchanged
+// (and an identity post-processor) if the input is empty.
+func translateUserDateFormat(dsl string) (layout string, postProcess func(string) string) {
+	if dsl == "" {
+		return "", func(s string) string { return s }
+	}
+
+	var b strings.Builder
+	hasUpper := false
+	hasLower := false
+
+	i := 0
+	for i < len(dsl) {
+		// Quoted literal: 'X' -> X (skip the quotes)
+		if dsl[i] == '\'' {
+			j := i + 1
+			for j < len(dsl) && dsl[j] != '\'' {
+				b.WriteByte(dsl[j])
+				j++
+			}
+			if j < len(dsl) {
+				j++ // skip closing quote
+			}
+			i = j
+			continue
+		}
+
+		// Token table — longest match first.
+		switch {
+		case hasPrefix(dsl, i, "YYYY"):
+			b.WriteString("2006")
+			i += 4
+		case hasPrefix(dsl, i, "YY"):
+			b.WriteString("06")
+			i += 2
+		case hasPrefix(dsl, i, "MMMM"):
+			b.WriteString("January")
+			i += 4
+		case hasPrefix(dsl, i, "MMM"):
+			b.WriteString("Jan")
+			i += 3
+		case hasPrefix(dsl, i, "MON"):
+			b.WriteString(upperMonthOpen + "Jan" + upperMonthClose)
+			hasUpper = true
+			i += 3
+		case hasPrefix(dsl, i, "mon"):
+			b.WriteString(lowerMonthOpen + "Jan" + lowerMonthClose)
+			hasLower = true
+			i += 3
+		case hasPrefix(dsl, i, "MM"):
+			b.WriteString("01")
+			i += 2
+		case hasPrefix(dsl, i, "M"):
+			// Don't match if the next char is one we'd otherwise
+			// pair with (already-handled longer token caught above).
+			b.WriteString("1")
+			i++
+		case hasPrefix(dsl, i, "dd"):
+			b.WriteString("02")
+			i += 2
+		case hasPrefix(dsl, i, "d"):
+			b.WriteString("2")
+			i++
+		case hasPrefix(dsl, i, "EEEE"):
+			b.WriteString("Monday")
+			i += 4
+		case hasPrefix(dsl, i, "EEE"):
+			b.WriteString("Mon")
+			i += 3
+		default:
+			b.WriteByte(dsl[i])
+			i++
+		}
+	}
+
+	layout = b.String()
+	if !hasUpper && !hasLower {
+		return layout, func(s string) string { return s }
+	}
+	return layout, func(s string) string {
+		if hasUpper {
+			s = applyCaseBetweenMarkers(s, upperMonthOpen, upperMonthClose, strings.ToUpper)
+		}
+		if hasLower {
+			s = applyCaseBetweenMarkers(s, lowerMonthOpen, lowerMonthClose, strings.ToLower)
+		}
+		return s
+	}
+}
+
+func hasPrefix(s string, i int, prefix string) bool {
+	return i+len(prefix) <= len(s) && s[i:i+len(prefix)] == prefix
+}
+
+// applyCaseBetweenMarkers walks s, finds open/close marker pairs,
+// applies transform to the substring between them, and strips the
+// markers. Pairs that span the entire string or are unpaired are
+// left as-is (markers stripped).
+func applyCaseBetweenMarkers(s, open, close string, transform func(string) string) string {
+	var b strings.Builder
+	for {
+		i := strings.Index(s, open)
+		if i < 0 {
+			b.WriteString(s)
+			return b.String()
+		}
+		b.WriteString(s[:i])
+		rest := s[i+len(open):]
+		j := strings.Index(rest, close)
+		if j < 0 {
+			b.WriteString(rest)
+			return b.String()
+		}
+		b.WriteString(transform(rest[:j]))
+		s = rest[j+len(close):]
+	}
+}
+
+// formatDateWithDSL formats t using a user DSL string. Empty DSL
+// returns "" so callers can detect "no override" and fall back to
+// locale defaults. Locale flows through monday for month / weekday
+// names.
+func formatDateWithDSL(t time.Time, dsl string, locale monday.Locale) string {
+	if dsl == "" {
+		return ""
+	}
+	layout, postProcess := translateUserDateFormat(dsl)
+	return postProcess(monday.Format(t, layout, locale))
+}

--- a/format/display/date_format_dsl_test.go
+++ b/format/display/date_format_dsl_test.go
@@ -1,0 +1,142 @@
+package display
+
+import (
+	"testing"
+	"time"
+
+	"github.com/CalcMark/go-calcmark/spec/types"
+	"golang.org/x/text/language"
+)
+
+// Tests for the user-facing date format DSL — verifies the full
+// DateFormat / PeriodDateFormat config flow from a DSL string
+// through to formatted output, plus that locale month names still
+// flow through the custom layout.
+
+func TestDateFormatDSL_TokenTranslation(t *testing.T) {
+	// April 4, 2026 (a Saturday) — distinctive across all token slots.
+	tt := time.Date(2026, time.April, 4, 0, 0, 0, 0, time.UTC)
+
+	cases := []struct {
+		dsl, want string
+	}{
+		// User's example.
+		{"MON dd, YYYY", "APR 04, 2026"},
+		// Common ISO-ish.
+		{"YYYY-MM-dd", "2026-04-04"},
+		// Compact dd-MON-YYYY (matches Period default).
+		{"dd-MON-YYYY", "04-APR-2026"},
+		// Lowercase month.
+		{"dd mon YYYY", "04 apr 2026"},
+		// Full names.
+		{"EEEE, MMMM d, YYYY", "Saturday, April 4, 2026"},
+		// 2-digit year.
+		{"d/M/YY", "4/4/26"},
+		// Short weekday + month.
+		{"EEE MMM dd", "Sat Apr 04"},
+		// Quoted literal letters.
+		{"'T'YYYY-MM-dd", "T2026-04-04"},
+		// Mix of MON and other tokens.
+		{"YYYY-MON-dd", "2026-APR-04"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.dsl, func(t *testing.T) {
+			got := formatDateWithDSL(tt, tc.dsl, defaultDateFormat.locale)
+			if got != tc.want {
+				t.Errorf("formatDateWithDSL(%q) = %q, want %q", tc.dsl, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDateFormatDSL_LocalePassthrough(t *testing.T) {
+	tt := time.Date(2026, time.April, 4, 0, 0, 0, 0, time.UTC)
+	dsl := "MON dd, YYYY"
+
+	usLocale := dateFormats["en_US"].locale
+	frLocale := dateFormats["fr_FR"].locale
+
+	usOut := formatDateWithDSL(tt, dsl, usLocale)
+	frOut := formatDateWithDSL(tt, dsl, frLocale)
+
+	// en-US: "APR 04, 2026"
+	if usOut != "APR 04, 2026" {
+		t.Errorf("en-US output = %q, want %q", usOut, "APR 04, 2026")
+	}
+	// fr-FR: locale's short month for April is "avr." → "AVR. 04, 2026"
+	// (uppercase preserves the dot).
+	if frOut == usOut {
+		t.Errorf("fr-FR output should differ from en-US; both are %q", usOut)
+	}
+}
+
+func TestDisplayConfig_DateFormatOverride(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.DateFormat = "MON dd, YYYY"
+	f := NewFormatter(cfg)
+
+	d := types.NewDateFromTime(time.Date(2026, time.April, 4, 0, 0, 0, 0, time.UTC))
+	got := f.FormatDate(d)
+	if got != "APR 04, 2026" {
+		t.Errorf("FormatDate with DateFormat=%q = %q, want %q",
+			cfg.DateFormat, got, "APR 04, 2026")
+	}
+}
+
+func TestDisplayConfig_DateFormatOverrideAppliesToPeriod(t *testing.T) {
+	// When DateFormat is set but PeriodDateFormat is NOT, the period
+	// output uses DateFormat too. Mirrors the user's expectation
+	// that "set the date format in config" affects all date-bearing
+	// output uniformly.
+	cfg := DefaultConfig()
+	cfg.DateFormat = "MON dd, YYYY"
+	f := NewFormatter(cfg)
+
+	q1, err := types.NewCalendarQuarter(2026, 1)
+	if err != nil {
+		t.Fatalf("NewCalendarQuarter: %v", err)
+	}
+	got := f.Format(q1)
+	want := "JAN 01, 2026 – MAR 31, 2026"
+	if got != want {
+		t.Errorf("Format(Q1) with DateFormat override = %q, want %q", got, want)
+	}
+}
+
+func TestDisplayConfig_PeriodDateFormatOverride(t *testing.T) {
+	// PeriodDateFormat takes precedence over DateFormat for periods.
+	cfg := DefaultConfig()
+	cfg.DateFormat = "MMMM d, YYYY"   // verbose for single dates
+	cfg.PeriodDateFormat = "YYYY-MM-dd" // compact for periods
+	f := NewFormatter(cfg)
+
+	d := types.NewDateFromTime(time.Date(2026, time.April, 4, 0, 0, 0, 0, time.UTC))
+	if got, want := f.FormatDate(d), "April 4, 2026"; got != want {
+		t.Errorf("FormatDate = %q, want %q", got, want)
+	}
+
+	q1, _ := types.NewCalendarQuarter(2026, 1)
+	if got, want := f.Format(q1), "2026-01-01 – 2026-03-31"; got != want {
+		t.Errorf("Format(Q1) = %q, want %q", got, want)
+	}
+}
+
+func TestDisplayConfig_NoOverride_UsesLocaleDefault(t *testing.T) {
+	// Empty DateFormat / PeriodDateFormat → existing locale behavior.
+	cfg := DefaultConfig()
+	cfg.Tag = language.AmericanEnglish
+	f := NewFormatter(cfg)
+
+	d := types.NewDateFromTime(time.Date(2026, time.April, 4, 0, 0, 0, 0, time.UTC))
+	if got := f.FormatDate(d); got == "" {
+		t.Error("FormatDate with empty DateFormat returned empty string")
+	}
+
+	q1, _ := types.NewCalendarQuarter(2026, 1)
+	got := f.Format(q1)
+	// Default Period format is dd-MON-YYYY.
+	if got != "01-Jan-2026 – 31-Mar-2026" {
+		t.Errorf("Format(Q1) with no override = %q, want default %q",
+			got, "01-Jan-2026 – 31-Mar-2026")
+	}
+}

--- a/format/display/formatter.go
+++ b/format/display/formatter.go
@@ -277,12 +277,21 @@ func (f Formatter) FormatDuration(d *types.Duration) string {
 // Uses abbreviated day-of-week and month names with locale-specific ordering.
 // Examples: "Wed, Jan 12, 2025" (en-US), "Mi., 12. Jan. 2025" (de-DE).
 //
+// When DisplayConfig.DateFormat is set, that DSL string overrides the
+// locale default — see date_format_dsl.go for the supported tokens
+// (MON dd, YYYY etc.). The locale still applies to month / weekday
+// names within the custom layout.
+//
 // The machine-readable Date.String() ("Monday, January 2, 2006") is intentionally
 // different — it is the model layer's precise representation. This method is the
 // display layer's human-friendly form.
 func (f Formatter) FormatDate(d *types.Date) string {
 	if d == nil {
 		return ""
+	}
+	if f.cfg.DateFormat != "" {
+		df := getDateFormat(f.cfg.Tag)
+		return formatDateWithDSL(d.Time, f.cfg.DateFormat, df.locale)
 	}
 	df := getDateFormat(f.cfg.Tag)
 	return formatDate(d.Time, df)
@@ -322,6 +331,21 @@ func (f Formatter) FormatPeriod(p *types.Period) string {
 		return p.String()
 	}
 	df := getDateFormat(f.cfg.Tag)
+
+	// Resolution order:
+	//   1. PeriodDateFormat (period-specific override)
+	//   2. DateFormat       (general date override)
+	//   3. dd-MON-YYYY      (compact default tuned for twin display)
+	dsl := f.cfg.PeriodDateFormat
+	if dsl == "" {
+		dsl = f.cfg.DateFormat
+	}
+	if dsl != "" {
+		startStr := formatDateWithDSL(p.Start.Time, dsl, df.locale)
+		endStr := formatDateWithDSL(p.End.Time, dsl, df.locale)
+		return startStr + " – " + endStr
+	}
+
 	const layout = "02-Jan-2006"
 	startStr := monday.Format(p.Start.Time, layout, df.locale)
 	endStr := monday.Format(p.End.Time, layout, df.locale)

--- a/format/display/formatter.go
+++ b/format/display/formatter.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/CalcMark/go-calcmark/spec/types"
 	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/goodsign/monday"
 	"github.com/shopspring/decimal"
 )
 
@@ -287,19 +288,30 @@ func (f Formatter) FormatDate(d *types.Date) string {
 	return formatDate(d.Time, df)
 }
 
-// FormatPeriod renders a Period for human display. v2.0 default
-// includes the resolved date range so the user sees concrete
-// boundaries — the bare kind label ("last fiscal quarter") gave
-// no indication of which dates it referred to. Format:
+// FormatPeriod renders a Period for human display as a compact
+// start–end range using the dd-MON-YYYY layout:
 //
-//   Named/calendar:  "Calendar Q1 2026 (Jan 1 – Mar 31, 2026)"
-//   Fiscal:          "Fiscal Year 2027 (Jul 1, 2026 – Jun 30, 2027)"
-//   Named-month:     "April 2026 (Apr 1 – Apr 30, 2026)"
-//   Relative:        "last fiscal quarter (Dec 1, 2025 – Feb 28, 2026)"
-//   Custom:          "Apr 15 – Jul 4, 2026"  (no kind label, dates only)
+//   Q1                       → "01-Jan-2026 – 31-Mar-2026"
+//   this fiscal quarter      → "01-Apr-2026 – 30-Jun-2026"
+//   April                    → "01-Apr-2026 – 30-Apr-2026"
+//   between Apr 15 and Jul 4 → "15-Apr-2026 – 04-Jul-2026"
 //
-// The dash is an en-dash to read naturally; uses FormatDate for
-// locale-aware month/day abbreviations.
+// Why no kind label: the source already names the period
+// (`this fiscal quarter`, `Q1`, etc.). Echoing the label as part
+// of the result is redundant — same reason `today` resolves to a
+// formatted date without echoing "today". Period values surface
+// the boundaries; the kind context lives in the source line.
+//
+// Why dd-MON-YYYY (not the regular FormatDate output): a Period
+// renders TWO dates side-by-side, so each one needs to be compact.
+// FormatDate's day-of-week prefix ("Wed, Apr 1, 2026") is great
+// for a single Date but reads as noise when twinned. dd-MON-YYYY
+// is unambiguous (no MM/DD vs DD/MM ambiguity) and locale-aware
+// for the month abbreviation via the existing monday library.
+//
+// The kind label is still available via Period.String() for
+// diagnostics / debug output / JSON `value` field, where the
+// surrounding source isn't visible.
 func (f Formatter) FormatPeriod(p *types.Period) string {
 	if p == nil {
 		return ""
@@ -309,12 +321,11 @@ func (f Formatter) FormatPeriod(p *types.Period) string {
 		// both. Fall back to the kind label if invariant breaks.
 		return p.String()
 	}
-	startStr := f.FormatDate(p.Start)
-	endStr := f.FormatDate(p.End)
-	if p.Kind == types.PeriodCustom {
-		return startStr + " – " + endStr
-	}
-	return p.String() + " (" + startStr + " – " + endStr + ")"
+	df := getDateFormat(f.cfg.Tag)
+	const layout = "02-Jan-2006"
+	startStr := monday.Format(p.Start.Time, layout, df.locale)
+	endStr := monday.Format(p.End.Time, layout, df.locale)
+	return startStr + " – " + endStr
 }
 
 // FormatPercentage formats a percentage in human-readable form.

--- a/format/display/formatter.go
+++ b/format/display/formatter.go
@@ -105,6 +105,13 @@ func (f Formatter) Format(t types.Type) string {
 		return f.FormatPercentage(v)
 	case *types.Time:
 		return v.String()
+	case *types.Period:
+		// v2.0: Period values render via String() — named periods
+		// (Calendar Q1 2026, Fiscal Year 2027, April 2026, etc.)
+		// surface human-readable labels; PeriodCustom shows the
+		// ISO start-to-end span. The value-type's String() method
+		// is the single source of truth.
+		return v.String()
 	default:
 		return fmt.Sprintf("%v", t)
 	}

--- a/format/display/formatter.go
+++ b/format/display/formatter.go
@@ -106,12 +106,7 @@ func (f Formatter) Format(t types.Type) string {
 	case *types.Time:
 		return v.String()
 	case *types.Period:
-		// v2.0: Period values render via String() — named periods
-		// (Calendar Q1 2026, Fiscal Year 2027, April 2026, etc.)
-		// surface human-readable labels; PeriodCustom shows the
-		// ISO start-to-end span. The value-type's String() method
-		// is the single source of truth.
-		return v.String()
+		return f.FormatPeriod(v)
 	default:
 		return fmt.Sprintf("%v", t)
 	}
@@ -290,6 +285,36 @@ func (f Formatter) FormatDate(d *types.Date) string {
 	}
 	df := getDateFormat(f.cfg.Tag)
 	return formatDate(d.Time, df)
+}
+
+// FormatPeriod renders a Period for human display. v2.0 default
+// includes the resolved date range so the user sees concrete
+// boundaries — the bare kind label ("last fiscal quarter") gave
+// no indication of which dates it referred to. Format:
+//
+//   Named/calendar:  "Calendar Q1 2026 (Jan 1 – Mar 31, 2026)"
+//   Fiscal:          "Fiscal Year 2027 (Jul 1, 2026 – Jun 30, 2027)"
+//   Named-month:     "April 2026 (Apr 1 – Apr 30, 2026)"
+//   Relative:        "last fiscal quarter (Dec 1, 2025 – Feb 28, 2026)"
+//   Custom:          "Apr 15 – Jul 4, 2026"  (no kind label, dates only)
+//
+// The dash is an en-dash to read naturally; uses FormatDate for
+// locale-aware month/day abbreviations.
+func (f Formatter) FormatPeriod(p *types.Period) string {
+	if p == nil {
+		return ""
+	}
+	if p.Start == nil || p.End == nil {
+		// Defensive: every factory in spec/types/period.go populates
+		// both. Fall back to the kind label if invariant breaks.
+		return p.String()
+	}
+	startStr := f.FormatDate(p.Start)
+	endStr := f.FormatDate(p.End)
+	if p.Kind == types.PeriodCustom {
+		return startStr + " – " + endStr
+	}
+	return p.String() + " (" + startStr + " – " + endStr + ")"
 }
 
 // FormatPercentage formats a percentage in human-readable form.

--- a/format/display/period_test.go
+++ b/format/display/period_test.go
@@ -9,129 +9,112 @@ import (
 	"golang.org/x/text/language"
 )
 
-// U14 — display formatter renders *types.Period via FormatPeriod.
-// Default form includes both the kind label AND the date range so
-// users see concrete boundaries instead of an opaque label like
-// "last fiscal quarter".
-//
-// Format:
-//   Named/calendar:   "<label> (<start> – <end>)"
-//   Custom:           "<start> – <end>"  (no label; the dates are the value)
+// U14 — display formatter renders *types.Period via FormatPeriod
+// as a compact dd-MON-YYYY range. No kind label: the source
+// already names the period (`this fiscal quarter`, `Q1`), and
+// echoing the label is noise — same reason `today` doesn't echo
+// "today" in its formatted Date output.
 
 func TestFormatPeriod(t *testing.T) {
 	f := NewFormatter(DefaultConfig())
 
-	// Calendar quarter — label + range.
+	// Calendar quarter Q1 2026 = Jan 1 – Mar 31.
 	q1, err := types.NewCalendarQuarter(2026, 1)
 	if err != nil {
 		t.Fatalf("NewCalendarQuarter: %v", err)
 	}
-	got := f.Format(q1)
-	if !strings.HasPrefix(got, "Calendar Q1 2026 (") {
-		t.Errorf("Format(Q1 2026) = %q, should start with %q", got, "Calendar Q1 2026 (")
-	}
-	if !strings.Contains(got, "Jan") || !strings.Contains(got, "Mar") {
-		t.Errorf("Format(Q1 2026) = %q, should contain start/end month names", got)
+	if got, want := f.Format(q1), "01-Jan-2026 – 31-Mar-2026"; got != want {
+		t.Errorf("Format(Q1 2026) = %q, want %q", got, want)
 	}
 
-	// Calendar year.
+	// Calendar year 2026.
 	cy := types.NewCalendarYear(2026)
-	got = f.Format(cy)
-	if !strings.HasPrefix(got, "Calendar Year 2026 (") {
-		t.Errorf("Format(CY2026) = %q, should start with %q", got, "Calendar Year 2026 (")
+	if got, want := f.Format(cy), "01-Jan-2026 – 31-Dec-2026"; got != want {
+		t.Errorf("Format(CY2026) = %q, want %q", got, want)
 	}
 
-	// Fiscal year.
+	// Fiscal year 2027 (July start) = Jul 1 2026 – Jun 30 2027.
 	fy := types.NewFiscalYear(2027, time.July, 1)
-	got = f.Format(fy)
-	if !strings.HasPrefix(got, "Fiscal Year 2027 (") {
-		t.Errorf("Format(FY2027) = %q, should start with %q", got, "Fiscal Year 2027 (")
-	}
-	if !strings.Contains(got, "Jul") || !strings.Contains(got, "Jun") {
-		t.Errorf("Format(FY2027) = %q, should mention Jul/Jun boundaries", got)
+	if got, want := f.Format(fy), "01-Jul-2026 – 30-Jun-2027"; got != want {
+		t.Errorf("Format(FY2027) = %q, want %q", got, want)
 	}
 
-	// Calendar month.
+	// Calendar month April 2026.
 	apr := types.NewCalendarMonth(2026, time.April)
-	got = f.Format(apr)
-	if !strings.HasPrefix(got, "April 2026 (") {
-		t.Errorf("Format(April 2026) = %q, should start with %q", got, "April 2026 (")
+	if got, want := f.Format(apr), "01-Apr-2026 – 30-Apr-2026"; got != want {
+		t.Errorf("Format(April 2026) = %q, want %q", got, want)
 	}
 
-	// Custom period — dates only, no label.
+	// Custom period.
 	start := types.NewDateFromTime(time.Date(2026, time.April, 15, 0, 0, 0, 0, time.UTC))
 	end := types.NewDateFromTime(time.Date(2026, time.July, 4, 0, 0, 0, 0, time.UTC))
 	custom, err := types.NewCustomPeriod(start, end)
 	if err != nil {
 		t.Fatalf("NewCustomPeriod: %v", err)
 	}
-	got = f.Format(custom)
-	if strings.Contains(got, "Period") || strings.Contains(got, "(") {
-		t.Errorf("Format(custom period) = %q, should be dates only without label or parens", got)
-	}
-	if !strings.Contains(got, "Apr") || !strings.Contains(got, "Jul") {
-		t.Errorf("Format(custom period) = %q, should reference Apr and Jul", got)
+	if got, want := f.Format(custom), "15-Apr-2026 – 04-Jul-2026"; got != want {
+		t.Errorf("Format(custom) = %q, want %q", got, want)
 	}
 }
 
-// TestFormatPeriod_RelativeIncludesDates — regression for the
-// reported bug: `last fiscal quarter` (and other relative kinds)
-// rendered as just the bare kind label, giving no indication of
-// which dates the period covered. The display formatter must
-// surface concrete boundaries for every relative kind.
-func TestFormatPeriod_RelativeIncludesDates(t *testing.T) {
+// TestFormatPeriod_RelativeShowsOnlyDates — regression for the
+// reported bug: `this fiscal quarter` rendered as
+// "this fiscal quarter (Wed, Apr 1, 2026 – Tue, Jun 30, 2026)" —
+// echoing the source line and using the verbose Date format.
+// FormatPeriod must surface ONLY the resolved dates in the compact
+// dd-MON-YYYY layout.
+func TestFormatPeriod_RelativeShowsOnlyDates(t *testing.T) {
 	f := NewFormatter(DefaultConfig())
-	now := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC) // Apr 15, 2026
-	// fiscal_year_starts: June 1 → FQ4 of FY2026 = Mar 1 - May 31 2026.
-	// last fiscal quarter (FQ3) = Dec 1 2025 - Feb 28 2026.
-	p := types.NewRelativeFiscalQuarter(now, time.June, 1, -1)
+	now := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+	p := types.NewRelativeFiscalQuarter(now, time.July, 1, 0) // FY starts July
 	got := f.Format(p)
-	if got == "last fiscal quarter" {
-		t.Fatalf("Format returned bare label %q with no date range — regression of the user-reported bug", got)
+
+	if strings.Contains(got, "fiscal quarter") {
+		t.Errorf("Format(this fiscal quarter) = %q, must not echo the kind label", got)
 	}
-	if !strings.Contains(got, "last fiscal quarter") {
-		t.Errorf("Format(last fiscal quarter) = %q, should contain the kind label", got)
+	if strings.Contains(got, "(") || strings.Contains(got, ")") {
+		t.Errorf("Format(this fiscal quarter) = %q, no parens — just dates", got)
 	}
-	if !strings.Contains(got, "(") || !strings.Contains(got, ")") {
-		t.Errorf("Format(last fiscal quarter) = %q, should include date range in parens", got)
+	if strings.Contains(got, "Wed") || strings.Contains(got, "Tue") {
+		t.Errorf("Format(this fiscal quarter) = %q, must use compact dd-MON-YYYY (no day-of-week)", got)
+	}
+	// FY starts July; April 15 sits in FQ4 (Apr-Jun) of FY2026.
+	want := "01-Apr-2026 – 30-Jun-2026"
+	if got != want {
+		t.Errorf("Format(this fiscal quarter) = %q, want %q", got, want)
 	}
 }
 
-// TestFormatPeriod_DatesAreLocalized — the date range in
-// FormatPeriod's output goes through FormatDate, which respects
-// the formatter's locale (Tag) via getDateFormat. en-US uses
-// month-first ("Apr 15"); de-DE uses day-first ("15. Apr."); etc.
-//
-// This locks the contract that period output IS locale-aware so a
-// future refactor can't accidentally hardcode an ASCII format that
-// regresses non-English users.
-func TestFormatPeriod_DatesAreLocalized(t *testing.T) {
-	q1, err := types.NewCalendarQuarter(2026, 1)
+// TestFormatPeriod_MonthAbbrevIsLocalized — the dd-MON-YYYY layout
+// still uses the locale's month-name abbreviation via the monday
+// library, so non-English users see e.g. "01-mars-2026" (fr) /
+// "01-Mär-2026" (de) / "01-Jan-2026" (en) for the same dates.
+// Locks the locale contract so a future refactor can't accidentally
+// hardcode English month names.
+func TestFormatPeriod_MonthAbbrevIsLocalized(t *testing.T) {
+	q3, err := types.NewCalendarQuarter(2026, 3) // Jul–Sep, distinctive across locales
 	if err != nil {
 		t.Fatalf("NewCalendarQuarter: %v", err)
 	}
 
 	usCfg := DefaultConfig()
 	usCfg.Tag = language.AmericanEnglish
-	usOut := NewFormatter(usCfg).Format(q1)
+	usOut := NewFormatter(usCfg).Format(q3)
 
-	deCfg := DefaultConfig()
-	deCfg.Tag = language.German
-	deOut := NewFormatter(deCfg).Format(q1)
+	frCfg := DefaultConfig()
+	frCfg.Tag = language.French
+	frOut := NewFormatter(frCfg).Format(q3)
 
-	// en-US uses "Jan" (English short month).
-	if !strings.Contains(usOut, "Jan") {
-		t.Errorf("en-US output %q should contain English `Jan`", usOut)
+	// en-US: "Jul" for July.
+	if !strings.Contains(usOut, "Jul") {
+		t.Errorf("en-US output %q should contain English `Jul`", usOut)
 	}
-	// de-DE uses "Jan." (German short month with period; monday lib's
-	// LocaleDeDE convention).
-	if !strings.Contains(deOut, "Jan.") {
-		t.Errorf("de-DE output %q should contain German short-month form `Jan.`", deOut)
+	// fr-FR: "juil." for juillet (monday LocaleFrFR convention).
+	if !strings.Contains(frOut, "juil") {
+		t.Errorf("fr-FR output %q should contain French `juil` (juillet abbrev)", frOut)
 	}
 
-	// Outputs must differ — if they're identical the locale path
-	// isn't being threaded through.
-	if usOut == deOut {
-		t.Errorf("en-US and de-DE outputs are identical (%q); locale isn't being applied", usOut)
+	if usOut == frOut {
+		t.Errorf("en-US and fr-FR outputs are identical (%q); locale isn't being applied", usOut)
 	}
 }

--- a/format/display/period_test.go
+++ b/format/display/period_test.go
@@ -1,0 +1,57 @@
+package display
+
+import (
+	"testing"
+	"time"
+
+	"github.com/CalcMark/go-calcmark/spec/types"
+)
+
+// U14 — display formatter renders *types.Period via Period.String().
+// The String() method is the single source of truth for human-
+// readable Period output; this test pins what each kind renders to
+// so accidental drift surfaces.
+
+func TestFormatPeriod(t *testing.T) {
+	f := NewFormatter(DefaultConfig())
+
+	// Calendar quarter.
+	q1, err := types.NewCalendarQuarter(2026, 1)
+	if err != nil {
+		t.Fatalf("NewCalendarQuarter: %v", err)
+	}
+	if got := f.Format(q1); got != "Calendar Q1 2026" {
+		t.Errorf("Format(Q1 2026) = %q, want %q", got, "Calendar Q1 2026")
+	}
+
+	// Calendar year.
+	cy := types.NewCalendarYear(2026)
+	if got := f.Format(cy); got != "Calendar Year 2026" {
+		t.Errorf("Format(CY2026) = %q, want %q", got, "Calendar Year 2026")
+	}
+
+	// Fiscal year.
+	fy := types.NewFiscalYear(2027, time.July, 1)
+	if got := f.Format(fy); got != "Fiscal Year 2027" {
+		t.Errorf("Format(FY2027) = %q, want %q", got, "Fiscal Year 2027")
+	}
+
+	// Calendar month.
+	apr := types.NewCalendarMonth(2026, time.April)
+	if got := f.Format(apr); got != "April 2026" {
+		t.Errorf("Format(April 2026) = %q, want %q", got, "April 2026")
+	}
+
+	// Custom period — `between Apr 15 2026 and Jul 4 2026`.
+	start := types.NewDateFromTime(time.Date(2026, time.April, 15, 0, 0, 0, 0, time.UTC))
+	end := types.NewDateFromTime(time.Date(2026, time.July, 4, 0, 0, 0, 0, time.UTC))
+	custom, err := types.NewCustomPeriod(start, end)
+	if err != nil {
+		t.Fatalf("NewCustomPeriod: %v", err)
+	}
+	got := f.Format(custom)
+	want := "2026-04-15 to 2026-07-04"
+	if got != want {
+		t.Errorf("Format(custom period) = %q, want %q", got, want)
+	}
+}

--- a/format/display/period_test.go
+++ b/format/display/period_test.go
@@ -1,57 +1,137 @@
 package display
 
 import (
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/CalcMark/go-calcmark/spec/types"
+	"golang.org/x/text/language"
 )
 
-// U14 — display formatter renders *types.Period via Period.String().
-// The String() method is the single source of truth for human-
-// readable Period output; this test pins what each kind renders to
-// so accidental drift surfaces.
+// U14 — display formatter renders *types.Period via FormatPeriod.
+// Default form includes both the kind label AND the date range so
+// users see concrete boundaries instead of an opaque label like
+// "last fiscal quarter".
+//
+// Format:
+//   Named/calendar:   "<label> (<start> – <end>)"
+//   Custom:           "<start> – <end>"  (no label; the dates are the value)
 
 func TestFormatPeriod(t *testing.T) {
 	f := NewFormatter(DefaultConfig())
 
-	// Calendar quarter.
+	// Calendar quarter — label + range.
 	q1, err := types.NewCalendarQuarter(2026, 1)
 	if err != nil {
 		t.Fatalf("NewCalendarQuarter: %v", err)
 	}
-	if got := f.Format(q1); got != "Calendar Q1 2026" {
-		t.Errorf("Format(Q1 2026) = %q, want %q", got, "Calendar Q1 2026")
+	got := f.Format(q1)
+	if !strings.HasPrefix(got, "Calendar Q1 2026 (") {
+		t.Errorf("Format(Q1 2026) = %q, should start with %q", got, "Calendar Q1 2026 (")
+	}
+	if !strings.Contains(got, "Jan") || !strings.Contains(got, "Mar") {
+		t.Errorf("Format(Q1 2026) = %q, should contain start/end month names", got)
 	}
 
 	// Calendar year.
 	cy := types.NewCalendarYear(2026)
-	if got := f.Format(cy); got != "Calendar Year 2026" {
-		t.Errorf("Format(CY2026) = %q, want %q", got, "Calendar Year 2026")
+	got = f.Format(cy)
+	if !strings.HasPrefix(got, "Calendar Year 2026 (") {
+		t.Errorf("Format(CY2026) = %q, should start with %q", got, "Calendar Year 2026 (")
 	}
 
 	// Fiscal year.
 	fy := types.NewFiscalYear(2027, time.July, 1)
-	if got := f.Format(fy); got != "Fiscal Year 2027" {
-		t.Errorf("Format(FY2027) = %q, want %q", got, "Fiscal Year 2027")
+	got = f.Format(fy)
+	if !strings.HasPrefix(got, "Fiscal Year 2027 (") {
+		t.Errorf("Format(FY2027) = %q, should start with %q", got, "Fiscal Year 2027 (")
+	}
+	if !strings.Contains(got, "Jul") || !strings.Contains(got, "Jun") {
+		t.Errorf("Format(FY2027) = %q, should mention Jul/Jun boundaries", got)
 	}
 
 	// Calendar month.
 	apr := types.NewCalendarMonth(2026, time.April)
-	if got := f.Format(apr); got != "April 2026" {
-		t.Errorf("Format(April 2026) = %q, want %q", got, "April 2026")
+	got = f.Format(apr)
+	if !strings.HasPrefix(got, "April 2026 (") {
+		t.Errorf("Format(April 2026) = %q, should start with %q", got, "April 2026 (")
 	}
 
-	// Custom period — `between Apr 15 2026 and Jul 4 2026`.
+	// Custom period — dates only, no label.
 	start := types.NewDateFromTime(time.Date(2026, time.April, 15, 0, 0, 0, 0, time.UTC))
 	end := types.NewDateFromTime(time.Date(2026, time.July, 4, 0, 0, 0, 0, time.UTC))
 	custom, err := types.NewCustomPeriod(start, end)
 	if err != nil {
 		t.Fatalf("NewCustomPeriod: %v", err)
 	}
-	got := f.Format(custom)
-	want := "2026-04-15 to 2026-07-04"
-	if got != want {
-		t.Errorf("Format(custom period) = %q, want %q", got, want)
+	got = f.Format(custom)
+	if strings.Contains(got, "Period") || strings.Contains(got, "(") {
+		t.Errorf("Format(custom period) = %q, should be dates only without label or parens", got)
+	}
+	if !strings.Contains(got, "Apr") || !strings.Contains(got, "Jul") {
+		t.Errorf("Format(custom period) = %q, should reference Apr and Jul", got)
+	}
+}
+
+// TestFormatPeriod_RelativeIncludesDates — regression for the
+// reported bug: `last fiscal quarter` (and other relative kinds)
+// rendered as just the bare kind label, giving no indication of
+// which dates the period covered. The display formatter must
+// surface concrete boundaries for every relative kind.
+func TestFormatPeriod_RelativeIncludesDates(t *testing.T) {
+	f := NewFormatter(DefaultConfig())
+	now := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC) // Apr 15, 2026
+	// fiscal_year_starts: June 1 → FQ4 of FY2026 = Mar 1 - May 31 2026.
+	// last fiscal quarter (FQ3) = Dec 1 2025 - Feb 28 2026.
+	p := types.NewRelativeFiscalQuarter(now, time.June, 1, -1)
+	got := f.Format(p)
+	if got == "last fiscal quarter" {
+		t.Fatalf("Format returned bare label %q with no date range — regression of the user-reported bug", got)
+	}
+	if !strings.Contains(got, "last fiscal quarter") {
+		t.Errorf("Format(last fiscal quarter) = %q, should contain the kind label", got)
+	}
+	if !strings.Contains(got, "(") || !strings.Contains(got, ")") {
+		t.Errorf("Format(last fiscal quarter) = %q, should include date range in parens", got)
+	}
+}
+
+// TestFormatPeriod_DatesAreLocalized — the date range in
+// FormatPeriod's output goes through FormatDate, which respects
+// the formatter's locale (Tag) via getDateFormat. en-US uses
+// month-first ("Apr 15"); de-DE uses day-first ("15. Apr."); etc.
+//
+// This locks the contract that period output IS locale-aware so a
+// future refactor can't accidentally hardcode an ASCII format that
+// regresses non-English users.
+func TestFormatPeriod_DatesAreLocalized(t *testing.T) {
+	q1, err := types.NewCalendarQuarter(2026, 1)
+	if err != nil {
+		t.Fatalf("NewCalendarQuarter: %v", err)
+	}
+
+	usCfg := DefaultConfig()
+	usCfg.Tag = language.AmericanEnglish
+	usOut := NewFormatter(usCfg).Format(q1)
+
+	deCfg := DefaultConfig()
+	deCfg.Tag = language.German
+	deOut := NewFormatter(deCfg).Format(q1)
+
+	// en-US uses "Jan" (English short month).
+	if !strings.Contains(usOut, "Jan") {
+		t.Errorf("en-US output %q should contain English `Jan`", usOut)
+	}
+	// de-DE uses "Jan." (German short month with period; monday lib's
+	// LocaleDeDE convention).
+	if !strings.Contains(deOut, "Jan.") {
+		t.Errorf("de-DE output %q should contain German short-month form `Jan.`", deOut)
+	}
+
+	// Outputs must differ — if they're identical the locale path
+	// isn't being threaded through.
+	if usOut == deOut {
+		t.Errorf("en-US and de-DE outputs are identical (%q); locale isn't being applied", usOut)
 	}
 }

--- a/format/json_formatter.go
+++ b/format/json_formatter.go
@@ -72,6 +72,16 @@ type JSONResult struct {
 	IsExplicit    bool     `json:"is_explicit,omitempty"`
 	Error         string   `json:"error,omitempty"`
 	Variable      string   `json:"variable,omitempty"`
+	// Period decomposition (v2.0). Populated only when Type ==
+	// "period". Start and End are ISO date strings (YYYY-MM-DD)
+	// covering the closed-interval span. PeriodKind is the canonical
+	// kind name: calendar_quarter / fiscal_quarter / calendar_year /
+	// fiscal_year / calendar_month / named_month / relative_week /
+	// relative_month / relative_year / relative_quarter /
+	// relative_fiscal_quarter / relative_fiscal_year / custom.
+	PeriodStart string `json:"period_start,omitempty"`
+	PeriodEnd   string `json:"period_end,omitempty"`
+	PeriodKind  string `json:"period_kind,omitempty"`
 }
 
 // JSONDiagnostic represents an error or warning with position info.
@@ -151,7 +161,55 @@ func populateResult(jr *JSONResult, result types.Type) {
 		}
 	case *types.Boolean:
 		jr.Type = "boolean"
+	case *types.Period:
+		// v2.0 Period: human-readable label via String() in Value;
+		// machine-readable Start/End/Kind for downstream consumers.
+		jr.Type = "period"
+		if v.Start != nil {
+			jr.PeriodStart = v.Start.Time.Format("2006-01-02")
+		}
+		if v.End != nil {
+			jr.PeriodEnd = v.End.Time.Format("2006-01-02")
+		}
+		jr.PeriodKind = periodKindName(v.Kind)
 	}
+}
+
+// periodKindName returns the canonical lowercased name for a
+// PeriodKind. JSON consumers (cmw, LSP, integrations) match against
+// these strings — keep them stable. New kinds added to types.PeriodKind
+// must register a name here too; "unknown" is a fallback that signals
+// drift between the two enums.
+func periodKindName(k types.PeriodKind) string {
+	switch k {
+	case types.PeriodCalendarQuarter:
+		return "calendar_quarter"
+	case types.PeriodFiscalQuarter:
+		return "fiscal_quarter"
+	case types.PeriodCalendarMonth:
+		return "calendar_month"
+	case types.PeriodCalendarYear:
+		return "calendar_year"
+	case types.PeriodFiscalYear:
+		return "fiscal_year"
+	case types.PeriodNamedMonth:
+		return "named_month"
+	case types.PeriodRelativeWeek:
+		return "relative_week"
+	case types.PeriodRelativeMonth:
+		return "relative_month"
+	case types.PeriodRelativeYear:
+		return "relative_year"
+	case types.PeriodRelativeQuarter:
+		return "relative_quarter"
+	case types.PeriodRelativeFiscalQuarter:
+		return "relative_fiscal_quarter"
+	case types.PeriodRelativeFiscalYear:
+		return "relative_fiscal_year"
+	case types.PeriodCustom:
+		return "custom"
+	}
+	return "unknown"
 }
 
 // Format writes the document as JSON to the writer.

--- a/format/json_period_test.go
+++ b/format/json_period_test.go
@@ -1,0 +1,89 @@
+package format
+
+import (
+	"testing"
+	"time"
+
+	"github.com/CalcMark/go-calcmark/spec/types"
+)
+
+// U14 — JSON formatter populates period_start, period_end, and
+// period_kind fields for *types.Period values. cmw and other
+// downstream consumers match against the canonical kind strings.
+
+func TestPopulateResult_PeriodCalendarQuarter(t *testing.T) {
+	q1, err := types.NewCalendarQuarter(2026, 1)
+	if err != nil {
+		t.Fatalf("NewCalendarQuarter: %v", err)
+	}
+	jr := JSONResult{}
+	populateResult(&jr, q1)
+
+	if jr.Type != "period" {
+		t.Errorf("Type = %q, want %q", jr.Type, "period")
+	}
+	if jr.PeriodKind != "calendar_quarter" {
+		t.Errorf("PeriodKind = %q, want %q", jr.PeriodKind, "calendar_quarter")
+	}
+	if jr.PeriodStart != "2026-01-01" {
+		t.Errorf("PeriodStart = %q, want %q", jr.PeriodStart, "2026-01-01")
+	}
+	if jr.PeriodEnd != "2026-03-31" {
+		t.Errorf("PeriodEnd = %q, want %q", jr.PeriodEnd, "2026-03-31")
+	}
+}
+
+func TestPopulateResult_PeriodFiscalYear(t *testing.T) {
+	fy := types.NewFiscalYear(2027, time.July, 1)
+	jr := JSONResult{}
+	populateResult(&jr, fy)
+
+	if jr.PeriodKind != "fiscal_year" {
+		t.Errorf("PeriodKind = %q, want %q", jr.PeriodKind, "fiscal_year")
+	}
+	// FY2027 (Jul start) = Jul 1 2026 to Jun 30 2027.
+	if jr.PeriodStart != "2026-07-01" {
+		t.Errorf("PeriodStart = %q, want %q", jr.PeriodStart, "2026-07-01")
+	}
+	if jr.PeriodEnd != "2027-06-30" {
+		t.Errorf("PeriodEnd = %q, want %q", jr.PeriodEnd, "2027-06-30")
+	}
+}
+
+func TestPopulateResult_PeriodCustom(t *testing.T) {
+	start := types.NewDateFromTime(time.Date(2026, time.April, 15, 0, 0, 0, 0, time.UTC))
+	end := types.NewDateFromTime(time.Date(2026, time.July, 4, 0, 0, 0, 0, time.UTC))
+	custom, err := types.NewCustomPeriod(start, end)
+	if err != nil {
+		t.Fatalf("NewCustomPeriod: %v", err)
+	}
+	jr := JSONResult{}
+	populateResult(&jr, custom)
+
+	if jr.PeriodKind != "custom" {
+		t.Errorf("PeriodKind = %q, want %q", jr.PeriodKind, "custom")
+	}
+	if jr.PeriodStart != "2026-04-15" {
+		t.Errorf("PeriodStart = %q, want %q", jr.PeriodStart, "2026-04-15")
+	}
+	if jr.PeriodEnd != "2026-07-04" {
+		t.Errorf("PeriodEnd = %q, want %q", jr.PeriodEnd, "2026-07-04")
+	}
+}
+
+// TestPeriodKindName_AllKindsCovered guards against drift between
+// types.PeriodKind and the JSON-name registry. If a new PeriodKind
+// is added to spec/types/ but periodKindName isn't extended, this
+// test surfaces the gap by failing on "unknown".
+func TestPeriodKindName_AllKindsCovered(t *testing.T) {
+	// Iterate from PeriodCalendarQuarter (iota=0) through
+	// PeriodCustom (iota=12). If types.PeriodCustom changes ordinal,
+	// update this loop.
+	last := types.PeriodCustom
+	for k := types.PeriodCalendarQuarter; k <= last; k++ {
+		got := periodKindName(k)
+		if got == "unknown" {
+			t.Errorf("PeriodKind ordinal %d → %q (no registered name)", k, got)
+		}
+	}
+}

--- a/impl/document/evaluator.go
+++ b/impl/document/evaluator.go
@@ -34,6 +34,17 @@ func NewDirectiveResolver(fm *document.Frontmatter) interpreter.DirectiveResolve
 	return &frontmatterDirectiveResolver{fm: fm}
 }
 
+// toFYLabelMode bridges the document layer's CalendarYearOffset enum
+// to the types layer's FYLabelMode. Kept narrow so the document
+// package doesn't import the types package's mode constants directly
+// at every call site.
+func toFYLabelMode(off document.CalendarYearOffset) types.FYLabelMode {
+	if off == document.CalendarYearOffsetAfter {
+		return types.FYLabelByStartYear
+	}
+	return types.FYLabelByEndYear
+}
+
 type frontmatterDirectiveResolver struct {
 	fm *document.Frontmatter
 }
@@ -534,9 +545,14 @@ func (e *Evaluator) evaluateCalcBlockSelective(blockID string, block *document.C
 		if fm.Measurement != nil {
 			interp.SetMeasurement(&fm.Measurement.MeasurementConfig)
 		}
-		// Wire fiscal year configuration for FQ/FY expressions
+		// Wire fiscal year configuration for FQ/FY expressions, including
+		// the optional calendar_year_offset (defaults to "before").
 		if fm.FiscalYearStarts != nil {
-			interp.SetFiscalYearStarts(fm.FiscalYearStarts.Month, fm.FiscalYearStarts.Day)
+			interp.SetFiscalCalendar(
+				fm.FiscalYearStarts.Month,
+				fm.FiscalYearStarts.Day,
+				toFYLabelMode(fm.CalendarYearOffset),
+			)
 		}
 	}
 	results := make([]types.Type, 0, len(nodes))
@@ -757,9 +773,14 @@ func (e *Evaluator) evaluateCalcBlockWithDoc(blockID string, block *document.Cal
 		if fm.Measurement != nil {
 			interp.SetMeasurement(&fm.Measurement.MeasurementConfig)
 		}
-		// Wire fiscal year configuration for FQ/FY expressions
+		// Wire fiscal year configuration for FQ/FY expressions, including
+		// the optional calendar_year_offset (defaults to "before").
 		if fm.FiscalYearStarts != nil {
-			interp.SetFiscalYearStarts(fm.FiscalYearStarts.Month, fm.FiscalYearStarts.Day)
+			interp.SetFiscalCalendar(
+				fm.FiscalYearStarts.Month,
+				fm.FiscalYearStarts.Day,
+				toFYLabelMode(fm.CalendarYearOffset),
+			)
 		}
 	}
 	results := make([]types.Type, 0, len(nodes))

--- a/impl/interpreter/date_test.go
+++ b/impl/interpreter/date_test.go
@@ -94,8 +94,8 @@ func TestValidDateCreation(t *testing.T) {
 				t.Fatalf("Expected 1 result, got %d", len(results))
 			}
 
-			if _, ok := results[0].(*types.Date); !ok {
-				t.Errorf("Expected *types.Date, got %T (%v)", results[0], results[0])
+			if !resultIsDateOrPeriod(results[0]) {
+				t.Errorf("Expected *types.Date or *types.Period, got %T (%v)", results[0], results[0])
 			}
 		})
 	}
@@ -273,10 +273,7 @@ func TestDateKeywords(t *testing.T) {
 				t.Fatalf("Expected 1 result, got %d", len(results))
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			gotYear := date.Time.Year()
 			gotMonth := int(date.Time.Month())
@@ -344,10 +341,7 @@ func TestPinnedClockIsolation(t *testing.T) {
 				t.Fatalf("Expected 1 result, got %d", len(results))
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			gotYear := date.Time.Year()
 			gotMonth := int(date.Time.Month())
@@ -397,10 +391,7 @@ func TestDateLiterals(t *testing.T) {
 				t.Fatalf("Expected 1 result, got %d", len(results))
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			wantYear := tt.wantYear
 			if wantYear == 0 {
@@ -485,10 +476,7 @@ func TestDateArithmeticEval(t *testing.T) {
 				t.Fatalf("Expected 1 result, got %d", len(results))
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			gotYear := date.Time.Year()
 			gotMonth := int(date.Time.Month())
@@ -573,10 +561,7 @@ func TestCalendarCorrectMonthArithmetic(t *testing.T) {
 				t.Fatalf("Expected 1 result, got %d", len(results))
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			gotYear := date.Time.Year()
 			gotMonth := int(date.Time.Month())
@@ -685,10 +670,7 @@ func TestDateLiteralArithmetic(t *testing.T) {
 				t.Fatalf("Expected 1 result, got %d", len(results))
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			gotYear := date.Time.Year()
 			gotMonth := int(date.Time.Month())
@@ -909,10 +891,7 @@ func TestExtendedRelativeDates(t *testing.T) {
 				t.Fatalf("Expected 1 result, got %d", len(results))
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			gotYear := date.Time.Year()
 			gotMonth := int(date.Time.Month())
@@ -978,10 +957,7 @@ func TestXFromYSyntax(t *testing.T) {
 				t.Fatalf("Expected 1 result, got %d", len(results))
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			gotYear := date.Time.Year()
 			gotMonth := int(date.Time.Month())
@@ -1054,10 +1030,7 @@ func TestWeekdayExpressions(t *testing.T) {
 				t.Fatalf("Expected 1 result, got %d", len(results))
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			gotYear := date.Time.Year()
 			gotMonth := int(date.Time.Month())
@@ -1124,10 +1097,7 @@ func TestRelativeMonthExpressions(t *testing.T) {
 				t.Fatalf("Expected 1 result, got %d", len(results))
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			gotYear := date.Time.Year()
 			gotMonth := int(date.Time.Month())
@@ -1183,10 +1153,7 @@ func TestFiscalWithDayOffset(t *testing.T) {
 				t.Fatalf("Eval error = %v", err)
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			gotYear := date.Time.Year()
 			gotMonth := int(date.Time.Month())
@@ -1235,10 +1202,7 @@ func TestAgoExpressions(t *testing.T) {
 				t.Fatalf("Expected 1 result, got %d", len(results))
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			gotYear := date.Time.Year()
 			gotMonth := int(date.Time.Month())
@@ -1284,10 +1248,7 @@ func TestSubDayAgoExpressions(t *testing.T) {
 				t.Fatalf("Eval error = %v", err)
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			if date.Time.Day() != tt.wantDay {
 				t.Errorf("Day = %d, want %d", date.Time.Day(), tt.wantDay)
@@ -1368,10 +1329,7 @@ func TestEndOfExpressions(t *testing.T) {
 				t.Fatalf("Expected 1 result, got %d", len(results))
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			gotYear := date.Time.Year()
 			gotMonth := int(date.Time.Month())
@@ -1400,7 +1358,7 @@ func TestEndOfComposition(t *testing.T) {
 		t.Fatalf("Eval error = %v", err)
 	}
 
-	date := results[0].(*types.Date)
+	date := resultStartDate(t, results[0])
 	if date.Time.Month() != 6 || date.Time.Day() != 16 {
 		t.Errorf("end of this quarter - 2 weeks: got %s, want Jun 16",
 			date.Time.Format("2006-01-02"))
@@ -1422,7 +1380,7 @@ func TestFromNow(t *testing.T) {
 		t.Fatalf("Eval error = %v", err)
 	}
 
-	date := results[0].(*types.Date)
+	date := resultStartDate(t, results[0])
 	// "now" preserves time, so 2 weeks from now at 14:30 = Apr 22 14:30
 	if date.Time.Day() != 22 || date.Time.Month() != 4 {
 		t.Errorf("2 weeks from now: got %s, want Apr 22",
@@ -1488,10 +1446,7 @@ func TestExtendedFromTargets(t *testing.T) {
 				t.Fatalf("Expected 1 result, got %d", len(results))
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			gotYear := date.Time.Year()
 			gotMonth := int(date.Time.Month())
@@ -1553,10 +1508,7 @@ func TestCalendarQuarterExpressions(t *testing.T) {
 				t.Fatalf("Expected 1 result, got %d", len(results))
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			gotYear := date.Time.Year()
 			gotMonth := int(date.Time.Month())
@@ -1620,10 +1572,7 @@ func TestFiscalExpressions(t *testing.T) {
 				t.Fatalf("Expected 1 result, got %d", len(results))
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			gotYear := date.Time.Year()
 			gotMonth := int(date.Time.Month())
@@ -1673,7 +1622,7 @@ func TestWeekdayComposition(t *testing.T) {
 		t.Fatalf("Eval error = %v", err)
 	}
 
-	date := results[0].(*types.Date)
+	date := resultStartDate(t, results[0])
 	if date.Time.Year() != 2026 || date.Time.Month() != 4 || date.Time.Day() != 24 {
 		t.Errorf("next Friday + 2 weeks: got %s, want 2026-04-24",
 			date.Time.Format("2006-01-02"))
@@ -1798,10 +1747,7 @@ func TestSubDayDurationArithmetic(t *testing.T) {
 				t.Fatalf("Eval error = %v", err)
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			if date.HasTime != tt.wantHas {
 				t.Errorf("HasTime = %v, want %v", date.HasTime, tt.wantHas)
@@ -1856,10 +1802,7 @@ func TestFiscalYearAndQuarterCompleteCoverage(t *testing.T) {
 				t.Fatalf("Eval error = %v", err)
 			}
 
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T", results[0])
-			}
+			date := resultStartDate(t, results[0])
 
 			gotYear := date.Time.Year()
 			gotMonth := int(date.Time.Month())
@@ -1888,13 +1831,21 @@ func TestCalendarQuarterNotation(t *testing.T) {
 		wantMonth int
 		wantDay   int
 	}{
+		// resultStartDate unwraps Period.Start, so Q1's start (Jan 1)
+		// is what these check against.
 		{"Q1", "d = Q1\n", 2026, 1, 1},
 		{"Q2", "d = Q2\n", 2026, 4, 1},
 		{"Q3", "d = Q3\n", 2026, 7, 1},
 		{"Q4", "d = Q4\n", 2026, 10, 1},
 		{"q1 lowercase", "d = q1\n", 2026, 1, 1},
 		{"q3 lowercase", "d = q3\n", 2026, 7, 1},
-		{"Q1 + 30 days", "d = Q1 + 30 days\n", 2026, 1, 31},
+		// v2.0 BREAKING: Period + Duration extends from the END of
+		// the period (per the brainstorm's asymmetric arithmetic).
+		// Pre-v2: Q1 + 30 days = Jan 1 + 30 = Jan 31.
+		// v2:     Q1 + 30 days = Mar 31 + 30 = Apr 30.
+		// Users who want Jan 31 write `start of Q1 + 30 days`.
+		{"Q1 + 30 days (v2 end-extends)", "d = Q1 + 30 days\n", 2026, 4, 30},
+		{"start of Q1 + 30 days (date arith)", "d = start of Q1 + 30 days\n", 2026, 1, 31},
 	}
 
 	for _, tt := range tests {
@@ -1911,10 +1862,7 @@ func TestCalendarQuarterNotation(t *testing.T) {
 			if len(results) != 1 {
 				t.Fatalf("Expected 1 result, got %d", len(results))
 			}
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T (%v)", results[0], results[0])
-			}
+			date := resultStartDate(t, results[0])
 			if date.Time.Year() != tt.wantYear || int(date.Time.Month()) != tt.wantMonth || date.Time.Day() != tt.wantDay {
 				t.Errorf("Got %d-%02d-%02d, want %d-%02d-%02d",
 					date.Time.Year(), int(date.Time.Month()), date.Time.Day(),
@@ -1954,10 +1902,7 @@ func TestFiscalQuarterNotation(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Eval(%q) error = %v", tt.input, err)
 			}
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T (%v)", results[0], results[0])
-			}
+			date := resultStartDate(t, results[0])
 			if date.Time.Year() != tt.wantYear || int(date.Time.Month()) != tt.wantMonth || date.Time.Day() != tt.wantDay {
 				t.Errorf("Got %d-%02d-%02d, want %d-%02d-%02d",
 					date.Time.Year(), int(date.Time.Month()), date.Time.Day(),
@@ -2018,10 +1963,7 @@ func TestFiscalYearNotation(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Eval(%q) error = %v", tt.input, err)
 			}
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T (%v)", results[0], results[0])
-			}
+			date := resultStartDate(t, results[0])
 			if date.Time.Year() != tt.wantYear || int(date.Time.Month()) != tt.wantMonth || date.Time.Day() != tt.wantDay {
 				t.Errorf("Got %d-%02d-%02d, want %d-%02d-%02d",
 					date.Time.Year(), int(date.Time.Month()), date.Time.Day(),
@@ -2046,7 +1988,11 @@ func TestCalendarYearNotation(t *testing.T) {
 		{"CY26 short", "d = CY26\n", 2026, 1, 1},
 		{"CY01 short", "d = CY01\n", 2001, 1, 1},
 		{"cy2026 lowercase", "d = cy2026\n", 2026, 1, 1},
-		{"CY2026 + 6 months", "d = CY2026 + 6 months\n", 2026, 7, 1},
+		// v2.0 BREAKING: Period + Duration extends from the END.
+		// CY2026 = Jan 1 2026 - Dec 31 2026. + 6 months = Jun 30 2027.
+		// Users who want Jul 1 2026 write `start of CY2026 + 6 months`.
+		{"CY2026 + 6 months (v2 end-extends)", "d = CY2026 + 6 months\n", 2027, 6, 30},
+		{"start of CY2026 + 6 months (date arith)", "d = start of CY2026 + 6 months\n", 2026, 7, 1},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -2059,10 +2005,7 @@ func TestCalendarYearNotation(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Eval(%q) error = %v", tt.input, err)
 			}
-			date, ok := results[0].(*types.Date)
-			if !ok {
-				t.Fatalf("Expected *types.Date, got %T (%v)", results[0], results[0])
-			}
+			date := resultStartDate(t, results[0])
 			if date.Time.Year() != tt.wantYear || int(date.Time.Month()) != tt.wantMonth || date.Time.Day() != tt.wantDay {
 				t.Errorf("Got %d-%02d-%02d, want %d-%02d-%02d",
 					date.Time.Year(), int(date.Time.Month()), date.Time.Day(),

--- a/impl/interpreter/date_test.go
+++ b/impl/interpreter/date_test.go
@@ -1533,7 +1533,7 @@ func TestFiscalExpressions(t *testing.T) {
 		wantMonth        int
 		wantDay          int
 	}{
-		// Microsoft FY starts July. Aug 2026 = FQ1 of FY starting Jul 2026
+		// July-start fiscal calendar. Aug 2026 = FQ1 of FY starting Jul 2026
 		{"this fiscal quarter Aug+July", time.Date(2026, 8, 15, 0, 0, 0, 0, time.UTC), 7,
 			"d = this fiscal quarter\n", 2026, 7, 1},
 		// Oct 2026 = FQ2 (Oct-Dec)
@@ -1939,7 +1939,8 @@ func TestFiscalYearNotation(t *testing.T) {
 		wantMonth int
 		wantDay   int
 	}{
-		// FY = year it ENDS in (Microsoft convention).
+		// Default labeling: FY = year it ENDS in (Australian government year,
+		// US tax year, most publicly traded companies).
 		// FY2027 with July start = Jul 1, 2026 (ends Jun 30, 2027)
 		// FY2026 with July start = Jul 1, 2025 (ends Jun 30, 2026)
 		{"FY2027 (ends 2027)", "d = FY2027\n", 2026, 7, 1},
@@ -1955,6 +1956,50 @@ func TestFiscalYearNotation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			interp := newTestInterpreterWithClock(clock)
 			interp.SetFiscalYearStarts(7, 1)
+			nodes, err := parser.Parse(tt.input)
+			if err != nil {
+				t.Fatalf("Parse(%q) error = %v", tt.input, err)
+			}
+			results, err := interp.Eval(nodes)
+			if err != nil {
+				t.Fatalf("Eval(%q) error = %v", tt.input, err)
+			}
+			date := resultStartDate(t, results[0])
+			if date.Time.Year() != tt.wantYear || int(date.Time.Month()) != tt.wantMonth || date.Time.Day() != tt.wantDay {
+				t.Errorf("Got %d-%02d-%02d, want %d-%02d-%02d",
+					date.Time.Year(), int(date.Time.Month()), date.Time.Day(),
+					tt.wantYear, tt.wantMonth, tt.wantDay)
+			}
+		})
+	}
+}
+
+// TestFiscalYearNotation_LabelByStartYear pins the
+// `calendar_year_offset: after` behavior — FY label = year FY
+// STARTS in. Mirrors TestFiscalYearNotation but configures the
+// interpreter via SetFiscalCalendar with FYLabelByStartYear, so
+// `fy2026` with a Feb-2 start resolves to Feb 2 2026 → Feb 1 2027
+// (the case from the user's 2026-04-30 bug report).
+func TestFiscalYearNotation_LabelByStartYear(t *testing.T) {
+	clock := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name      string
+		input     string
+		wantYear  int
+		wantMonth int
+		wantDay   int
+	}{
+		// Feb 2 start, label-by-start-year:
+		//   FY2026 → starts Feb 2 2026, ends Feb 1 2027
+		//   FY2025 → starts Feb 2 2025, ends Feb 1 2026
+		{"FY2026 (Feb-2 start, by-start-year)", "d = FY2026\n", 2026, 2, 2},
+		{"FY2025 (Feb-2 start, by-start-year)", "d = FY2025\n", 2025, 2, 2},
+		{"fy2026 lowercase", "d = fy2026\n", 2026, 2, 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interp := newTestInterpreterWithClock(clock)
+			interp.SetFiscalCalendar(2, 2, types.FYLabelByStartYear)
 			nodes, err := parser.Parse(tt.input)
 			if err != nil {
 				t.Fatalf("Parse(%q) error = %v", tt.input, err)

--- a/impl/interpreter/datetime.go
+++ b/impl/interpreter/datetime.go
@@ -94,6 +94,13 @@ var periodAbbreviationExpansion = map[string]string{
 	"this fq": "this fiscal quarter",
 	"next fq": "next fiscal quarter",
 	"last fq": "last fiscal quarter",
+
+	// Bare-form fiscal aliases (lexer admits the phrase, eval treats
+	// it as `this <X>`). `end of fiscal quarter` reads naturally —
+	// users already configure fiscal_year_starts in frontmatter, so
+	// the implicit `this` is unambiguous.
+	"fiscal quarter": "this fiscal quarter",
+	"fiscal year":    "this fiscal year",
 }
 
 func (interp *Interpreter) evalRelativeDateLiteral(r *ast.RelativeDateLiteral) (types.Type, error) {

--- a/impl/interpreter/datetime.go
+++ b/impl/interpreter/datetime.go
@@ -194,6 +194,7 @@ func (interp *Interpreter) evalFiscalExpression(keyword string, now time.Time) (
 	fc := interp.fiscalYearStarts
 	fyStartMonth := time.Month(fc.month)
 	fyStartDay := fc.day
+	mode := fc.labelMode
 
 	// v2.0: fiscal relatives return *types.Period.
 	switch keyword {
@@ -204,26 +205,29 @@ func (interp *Interpreter) evalFiscalExpression(keyword string, now time.Time) (
 	case "last fiscal quarter":
 		return types.NewRelativeFiscalQuarter(now, fyStartMonth, fyStartDay, -1), nil
 	case "this fiscal year":
-		fy := fiscalYearLabel(now, fyStartMonth, fyStartDay)
-		return types.NewFiscalYear(fy, fyStartMonth, fyStartDay), nil
+		fy := fiscalYearLabel(now, fyStartMonth, fyStartDay, mode)
+		return types.NewFiscalYearWithMode(fy, fyStartMonth, fyStartDay, mode), nil
 	case "next fiscal year":
-		fy := fiscalYearLabel(now, fyStartMonth, fyStartDay) + 1
-		return types.NewFiscalYear(fy, fyStartMonth, fyStartDay), nil
+		fy := fiscalYearLabel(now, fyStartMonth, fyStartDay, mode) + 1
+		return types.NewFiscalYearWithMode(fy, fyStartMonth, fyStartDay, mode), nil
 	case "last fiscal year":
-		fy := fiscalYearLabel(now, fyStartMonth, fyStartDay) - 1
-		return types.NewFiscalYear(fy, fyStartMonth, fyStartDay), nil
+		fy := fiscalYearLabel(now, fyStartMonth, fyStartDay, mode) - 1
+		return types.NewFiscalYearWithMode(fy, fyStartMonth, fyStartDay, mode), nil
 	default:
 		return nil, fmt.Errorf("unknown fiscal expression: %q", keyword)
 	}
 }
 
-// fiscalYearLabel returns the FY *label* (the year the FY ENDS in,
-// per Microsoft convention) for the fiscal year containing `now`.
-// E.g., now = 2026-08-15 with fyStart = July → FY label = 2027.
-func fiscalYearLabel(now time.Time, fyStartMonth time.Month, fyStartDay int) int {
-	// fiscalYearWithDay returns the calendar year the FY STARTS in.
+// fiscalYearLabel returns the FY *label* for the fiscal year
+// containing `now`, honoring the document's labeling convention.
+//
+//   - FYLabelByEndYear (default): label = calendar year the FY ENDS
+//     in. E.g., now=2026-08-15 with Jul-start FY → label 2027.
+//   - FYLabelByStartYear: label = calendar year the FY STARTS in.
+//     Same `now` with `calendar_year_offset: after` → label 2026.
+func fiscalYearLabel(now time.Time, fyStartMonth time.Month, fyStartDay int, mode types.FYLabelMode) int {
 	startYear := fiscalYearWithDay(now, fyStartMonth, fyStartDay)
-	if fyStartMonth > time.January {
+	if mode == types.FYLabelByEndYear && fyStartMonth > time.January {
 		return startYear + 1
 	}
 	return startYear
@@ -326,7 +330,7 @@ func (interp *Interpreter) evalNotation(keyword string, now time.Time) (types.Ty
 		// next/last/this FY relative to `now`.
 		fy := fiscalYearWithDay(now, fyStartMonth, fyStartDay) + yearOffset
 		fyStart := time.Date(fy, fyStartMonth, fyStartDay, 0, 0, 0, 0, time.UTC)
-		return types.NewFiscalQuarter(fyStart, q)
+		return types.NewFiscalQuarterWithMode(fyStart, q, fc.labelMode)
 
 	case "FY":
 		if interp.fiscalYearStarts == nil {
@@ -341,7 +345,7 @@ func (interp *Interpreter) evalNotation(keyword string, now time.Time) (types.Ty
 		}
 		fyLabel += yearOffset
 		fc := interp.fiscalYearStarts
-		return types.NewFiscalYear(fyLabel, time.Month(fc.month), fc.day), nil
+		return types.NewFiscalYearWithMode(fyLabel, time.Month(fc.month), fc.day, fc.labelMode), nil
 
 	case "CY":
 		year, err := strconv.Atoi(value)

--- a/impl/interpreter/datetime.go
+++ b/impl/interpreter/datetime.go
@@ -165,18 +165,13 @@ func (interp *Interpreter) evalRelativeDateLiteral(r *ast.RelativeDateLiteral) (
 			return d, err
 		}
 
-		// "start of <period>" — strip prefix and evaluate the inner period
-		if strings.HasPrefix(keyword, "start of ") {
-			inner := keyword[len("start of "):]
-			innerNode := &ast.RelativeDateLiteral{Keyword: inner, SourceText: inner}
-			return interp.evalRelativeDateLiteral(innerNode)
-		}
-
-		// "end of <period>" — evaluate inner period to get start, then find last day
-		if strings.HasPrefix(keyword, "end of ") {
-			inner := keyword[len("end of "):]
-			return interp.evalEndOf(inner, now)
-		}
+		// "start of <period>" / "end of <period>" string-prefix
+		// dispatches were retired here (and at the equivalent site
+		// in evalNotation) when the parser started emitting
+		// ast.EndOfExpr / ast.StartOfExpr structured nodes. Operator
+		// dispatch now happens at the AST layer (see evalEndOfExpr /
+		// evalStartOfExpr); reaching this branch with a string-form
+		// "end of ..." keyword would mean the parser regressed.
 
 		// Try weekday expressions: "friday", "this friday", "next friday", "last friday"
 		if d, ok := interp.resolveWeekdayExpression(keyword, now); ok {
@@ -380,17 +375,13 @@ func fiscalQuarterStart(calYear int, calMonth, fyStartMonth time.Month) (int, ti
 
 // evalNotation handles Q:N, FQ:N, FY:YYYY, CY:YYYY notation.
 // Returns (nil, nil) if keyword is not a notation pattern.
+//
+// The two HasPrefix(keyword, "end of ") / "start of " dispatches
+// that lived here previously were retired when the parser started
+// emitting ast.EndOfExpr / ast.StartOfExpr -- operator dispatch
+// happens at the AST layer (evalEndOfExpr / evalStartOfExpr) and
+// flows back into evalEndOfNotation via the AST inner.
 func (interp *Interpreter) evalNotation(keyword string, now time.Time) (types.Type, error) {
-	// Check for "end of" + notation
-	if strings.HasPrefix(keyword, "end of ") {
-		inner := keyword[len("end of "):]
-		return interp.evalEndOfNotation(inner, now)
-	}
-	if strings.HasPrefix(keyword, "start of ") {
-		inner := keyword[len("start of "):]
-		return interp.evalNotation(inner, now)
-	}
-
 	parts := strings.SplitN(keyword, ":", 2)
 	if len(parts) != 2 {
 		return nil, nil // not a notation
@@ -704,4 +695,78 @@ func parseUTCOffset(offset *ast.UTCOffset) (int, error) {
 	}
 
 	return totalMinutes, nil
+}
+
+// evalEndOfExpr evaluates `end of <period>`. The parser emits this
+// AST shape (ast.EndOfExpr) for any well-formed `end of X`
+// expression. Dispatch flow:
+//
+//   1. Inspect the AST inner (NOT the evaluated value -- the inner's
+//      structure tells us which period kind it is, even when the
+//      same evaluated Date could correspond to multiple periods).
+//   2. For *ast.RelativeDateLiteral, dispatch via the existing
+//      keyword-keyed evalEndOf / evalEndOfNotation. The keyword is
+//      already in the canonical form the helpers understand
+//      ("Q:1" / "FQ:3" / "this month" / etc.).
+//   3. For *ast.Identifier, return a clear runtime error -- the
+//      variable holds a Date (today) and we can't recover which
+//      period kind produced it. R9 (variables-as-periods) is
+//      deferred to a future PR that introduces a Period value type
+//      and threads it through evalRelativeDateLiteral / Environment.
+//   4. For everything else (literals like 5 or "2026-01-01"),
+//      return a runtime error -- the type checker (U9) catches
+//      these statically too, but the runtime guard ensures
+//      correctness even when the type-check escape (e.g., a
+//      checker bug) lets one through.
+//
+// Replaces the prior strings.HasPrefix(keyword, "end of ") dispatch
+// at evalRelativeDateLiteral and evalNotation -- both removed.
+func (interp *Interpreter) evalEndOfExpr(e *ast.EndOfExpr) (types.Type, error) {
+	if e.Period == nil {
+		return nil, fmt.Errorf("end of: missing inner expression")
+	}
+	now := interp.now()
+
+	switch inner := e.Period.(type) {
+	case *ast.RelativeDateLiteral:
+		// Existing helpers handle every period-bearing keyword
+		// (Q:N, FQ:N, FY:NNNN, CY:NNNN, this/next/last
+		// week/month/year/quarter/fiscal-quarter/fiscal-year, named
+		// months). evalEndOfForKeyword routes to the right helper.
+		// Lowercase the keyword to match the casing convention in
+		// the existing helpers' switch statements (e.g.
+		// resolveMonthExpression's canonicalMonths map is
+		// lowercase-keyed) -- evalRelativeDateLiteral lowercases
+		// at line 102 before its own switch, so dispatching here
+		// must do the same.
+		return interp.evalEndOfForKeyword(strings.ToLower(inner.Keyword), now)
+	case *ast.Identifier:
+		// R9 demoted -- the variable's bound value is a Date in the
+		// current value-type model, not a Period. Surfacing this as
+		// a clear runtime error keeps the user oriented; a future
+		// PR introducing *types.Period through evalRelativeDateLiteral
+		// + Environment binding will let this case work emergently.
+		return nil, fmt.Errorf("end of %s: variable-bound periods are not yet supported; use the period literal directly (e.g. `end of Q1`) until upstream Period value-type plumbing lands", inner.Name)
+	default:
+		return nil, fmt.Errorf("end of: inner expression must be a period (got %T); valid examples: `end of Q1`, `end of this month`, `end of FY2027`", e.Period)
+	}
+}
+
+// evalStartOfExpr evaluates `start of <period>`. Symmetric to
+// evalEndOfExpr but trivial -- start of a period is just the
+// period's start date, which is what evaluating the inner literal
+// already returns.
+func (interp *Interpreter) evalStartOfExpr(s *ast.StartOfExpr) (types.Type, error) {
+	if s.Period == nil {
+		return nil, fmt.Errorf("start of: missing inner expression")
+	}
+	switch inner := s.Period.(type) {
+	case *ast.RelativeDateLiteral:
+		// Inner literal's evaluation IS the period start.
+		return interp.evalRelativeDateLiteral(inner)
+	case *ast.Identifier:
+		return nil, fmt.Errorf("start of %s: variable-bound periods are not yet supported; use the period literal directly (e.g. `start of Q1`) until upstream Period value-type plumbing lands", inner.Name)
+	default:
+		return nil, fmt.Errorf("start of: inner expression must be a period (got %T); valid examples: `start of Q1`, `start of this month`", s.Period)
+	}
 }

--- a/impl/interpreter/datetime.go
+++ b/impl/interpreter/datetime.go
@@ -276,7 +276,25 @@ func fiscalQuarterStart(calYear int, calMonth, fyStartMonth time.Month) (int, ti
 // happens at the AST layer (evalEndOfExpr / evalStartOfExpr) and
 // flows back into evalEndOfNotation via the AST inner.
 func (interp *Interpreter) evalNotation(keyword string, now time.Time) (types.Type, error) {
-	parts := strings.SplitN(keyword, ":", 2)
+	// Strip optional direction prefix: `next FQ:1` / `last CY:2026` /
+	// `this Q:1` mean "the Nth quarter / year of the relative
+	// fiscal/calendar year". The parser produces these forms when
+	// the user writes `next FQ1` / `last CY2026` etc. (see
+	// directed-notation parser path in spec/parser/primary.go).
+	yearOffset := 0
+	rest := keyword
+	for _, dir := range []struct {
+		prefix string
+		offset int
+	}{{"next ", +1}, {"last ", -1}, {"this ", 0}} {
+		if strings.HasPrefix(strings.ToLower(rest), dir.prefix) {
+			yearOffset = dir.offset
+			rest = rest[len(dir.prefix):]
+			break
+		}
+	}
+
+	parts := strings.SplitN(rest, ":", 2)
 	if len(parts) != 2 {
 		return nil, nil // not a notation
 	}
@@ -285,12 +303,13 @@ func (interp *Interpreter) evalNotation(keyword string, now time.Time) (types.Ty
 	switch prefix {
 	case "Q":
 		// v2.0: Q1-Q4 evaluates to Period (calendar quarter of the
-		// current year). Resolved against `now`'s year.
+		// current calendar year). yearOffset shifts the year for
+		// `next Q1` / `last Q4`.
 		q, err := strconv.Atoi(value)
 		if err != nil || q < 1 || q > 4 {
 			return nil, fmt.Errorf("invalid calendar quarter: Q%s", value)
 		}
-		return types.NewCalendarQuarter(now.Year(), q)
+		return types.NewCalendarQuarter(now.Year()+yearOffset, q)
 
 	case "FQ":
 		if interp.fiscalYearStarts == nil {
@@ -303,9 +322,9 @@ func (interp *Interpreter) evalNotation(keyword string, now time.Time) (types.Ty
 		fc := interp.fiscalYearStarts
 		fyStartMonth := time.Month(fc.month)
 		fyStartDay := fc.day
-		// FQ1 starts at the fiscal year start; the fiscal year
-		// containing `now` anchors which FQ year-cycle this is.
-		fy := fiscalYearWithDay(now, fyStartMonth, fyStartDay)
+		// FQ1 starts at the fiscal year start; yearOffset selects
+		// next/last/this FY relative to `now`.
+		fy := fiscalYearWithDay(now, fyStartMonth, fyStartDay) + yearOffset
 		fyStart := time.Date(fy, fyStartMonth, fyStartDay, 0, 0, 0, 0, time.UTC)
 		return types.NewFiscalQuarter(fyStart, q)
 
@@ -320,6 +339,7 @@ func (interp *Interpreter) evalNotation(keyword string, now time.Time) (types.Ty
 		if fyLabel < 100 {
 			fyLabel += 2000 // 2-digit: FY27 = 2027
 		}
+		fyLabel += yearOffset
 		fc := interp.fiscalYearStarts
 		return types.NewFiscalYear(fyLabel, time.Month(fc.month), fc.day), nil
 
@@ -331,6 +351,7 @@ func (interp *Interpreter) evalNotation(keyword string, now time.Time) (types.Ty
 		if year < 100 {
 			year += 2000 // 2-digit: CY26 = 2026
 		}
+		year += yearOffset
 		return types.NewCalendarYear(year), nil
 	}
 

--- a/impl/interpreter/datetime.go
+++ b/impl/interpreter/datetime.go
@@ -740,6 +740,25 @@ func (interp *Interpreter) evalEndOfExpr(e *ast.EndOfExpr) (types.Type, error) {
 		// at line 102 before its own switch, so dispatching here
 		// must do the same.
 		return interp.evalEndOfForKeyword(strings.ToLower(inner.Keyword), now)
+	case *ast.DateLiteral:
+		// Bare month names like `April` parse as DateLiteral with
+		// implicit Day=1, Year=nil and SourceText that contains no
+		// digits. Pre-PR-1b, `end of April` worked through the old
+		// string-prefix dispatch's resolveEndOfMonth fallback. The
+		// new AST-based dispatch initially rejected DateLiteral
+		// outright; this arm restores the bare-month-name path.
+		// Discriminator matches the semantic checker (see
+		// spec/semantic/end_of_check.go) -- accept iff SourceText
+		// has no digits.
+		//
+		// Transitional shim. The downstream brainstorm decided April
+		// should become a Period type entirely; once that migration
+		// lands, the parser will emit Period-bearing AST directly
+		// and this arm collapses.
+		if !sourceTextHasDigit(inner.SourceText) {
+			return interp.evalEndOfForKeyword("this "+strings.ToLower(inner.Month), now)
+		}
+		return nil, fmt.Errorf("end of: inner expression must be a period; got specific date %s", inner.SourceText)
 	case *ast.Identifier:
 		// R9 demoted -- the variable's bound value is a Date in the
 		// current value-type model, not a Period. Surfacing this as
@@ -764,9 +783,33 @@ func (interp *Interpreter) evalStartOfExpr(s *ast.StartOfExpr) (types.Type, erro
 	case *ast.RelativeDateLiteral:
 		// Inner literal's evaluation IS the period start.
 		return interp.evalRelativeDateLiteral(inner)
+	case *ast.DateLiteral:
+		// Bare month name (no digits in SourceText) means "the first
+		// day of <month>". Same shim as evalEndOfExpr's DateLiteral
+		// arm; mirrors the semantic checker's accept rule.
+		if !sourceTextHasDigit(inner.SourceText) {
+			// `start of April` = `this April` start = April 1.
+			node := &ast.RelativeDateLiteral{Keyword: "this " + strings.ToLower(inner.Month)}
+			return interp.evalRelativeDateLiteral(node)
+		}
+		return nil, fmt.Errorf("start of: inner expression must be a period; got specific date %s", inner.SourceText)
 	case *ast.Identifier:
 		return nil, fmt.Errorf("start of %s: variable-bound periods are not yet supported; use the period literal directly (e.g. `start of Q1`) until upstream Period value-type plumbing lands", inner.Name)
 	default:
 		return nil, fmt.Errorf("start of: inner expression must be a period (got %T); valid examples: `start of Q1`, `start of this month`", s.Period)
 	}
+}
+
+// sourceTextHasDigit reports whether s contains any digit. Used to
+// distinguish bare month names (`April`) from specific dates
+// (`April 15`, `Apr 1 2026`); both produce *ast.DateLiteral but only
+// the former is period-bearing. Mirrors the semantic checker's
+// helper of the same name.
+func sourceTextHasDigit(s string) bool {
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			return true
+		}
+	}
+	return false
 }

--- a/impl/interpreter/datetime.go
+++ b/impl/interpreter/datetime.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/CalcMark/go-calcmark/spec/ast"
 	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/shopspring/decimal"
 )
 
 // Date and time literal evaluation.
@@ -105,6 +104,7 @@ func (interp *Interpreter) evalRelativeDateLiteral(r *ast.RelativeDateLiteral) (
 	}
 
 	switch keyword {
+	// True date keywords — single point in time, return Date.
 	case "today":
 		return types.NewDateFromTime(now), nil
 	case "now":
@@ -115,49 +115,41 @@ func (interp *Interpreter) evalRelativeDateLiteral(r *ast.RelativeDateLiteral) (
 		return types.NewDateFromTime(now.AddDate(0, 0, 1)), nil
 	case "yesterday":
 		return types.NewDateFromTime(now.AddDate(0, 0, -1)), nil
-	// Period expressions: this/next/last week/month/year
+
+	// v2.0: period keywords return *types.Period (the whole span)
+	// rather than the START date. Callers that historically
+	// type-asserted *types.Date use asDate() to unwrap to Period.Start.
 	case "this week":
-		// Monday of current week
-		daysFromMonday := (int(now.Weekday()) - int(time.Monday) + 7) % 7
-		return types.NewDateFromTime(now.AddDate(0, 0, -daysFromMonday)), nil
+		return relativeWeekPeriod(now, 0), nil
 	case "next week":
-		daysFromMonday := (int(now.Weekday()) - int(time.Monday) + 7) % 7
-		monday := now.AddDate(0, 0, -daysFromMonday)
-		return types.NewDateFromTime(monday.AddDate(0, 0, 7)), nil
+		return relativeWeekPeriod(now, +1), nil
 	case "last week":
-		daysFromMonday := (int(now.Weekday()) - int(time.Monday) + 7) % 7
-		monday := now.AddDate(0, 0, -daysFromMonday)
-		return types.NewDateFromTime(monday.AddDate(0, 0, -7)), nil
+		return relativeWeekPeriod(now, -1), nil
 	case "this month":
-		return types.NewDateFromTime(time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)), nil
+		return relativeMonthPeriod(now, 0), nil
 	case "next month":
-		return types.NewDateFromTime(time.Date(now.Year(), now.Month()+1, 1, 0, 0, 0, 0, time.UTC)), nil
+		return relativeMonthPeriod(now, +1), nil
 	case "last month":
-		return types.NewDateFromTime(time.Date(now.Year(), now.Month()-1, 1, 0, 0, 0, 0, time.UTC)), nil
+		return relativeMonthPeriod(now, -1), nil
 	case "this year":
-		return types.NewDateFromTime(time.Date(now.Year(), 1, 1, 0, 0, 0, 0, time.UTC)), nil
+		return relativeYearPeriod(now, 0), nil
 	case "next year":
-		return types.NewDateFromTime(time.Date(now.Year()+1, 1, 1, 0, 0, 0, 0, time.UTC)), nil
+		return relativeYearPeriod(now, +1), nil
 	case "last year":
-		return types.NewDateFromTime(time.Date(now.Year()-1, 1, 1, 0, 0, 0, 0, time.UTC)), nil
+		return relativeYearPeriod(now, -1), nil
 
 	// Fiscal expressions (require fiscal_year_starts)
 	case "this fiscal quarter", "next fiscal quarter", "last fiscal quarter",
 		"this fiscal year", "next fiscal year", "last fiscal year":
 		return interp.evalFiscalExpression(keyword, now)
 
-	// Calendar quarter expressions
+	// Calendar quarter expressions — return Period.
 	case "this quarter":
-		q := calendarQuarterStart(now.Month())
-		return types.NewDateFromTime(time.Date(now.Year(), q, 1, 0, 0, 0, 0, time.UTC)), nil
+		return types.NewRelativeQuarter(now, 0), nil
 	case "next quarter":
-		q := calendarQuarterStart(now.Month())
-		t := time.Date(now.Year(), q+3, 1, 0, 0, 0, 0, time.UTC) // Go normalizes month > 12
-		return types.NewDateFromTime(t), nil
+		return types.NewRelativeQuarter(now, +1), nil
 	case "last quarter":
-		q := calendarQuarterStart(now.Month())
-		t := time.Date(now.Year(), q-3, 1, 0, 0, 0, 0, time.UTC) // Go normalizes month < 1
-		return types.NewDateFromTime(t), nil
+		return types.NewRelativeQuarter(now, -1), nil
 
 	default:
 		// Notation: Q:1, FQ:3, FY:2026, CY:26
@@ -185,119 +177,6 @@ func (interp *Interpreter) evalRelativeDateLiteral(r *ast.RelativeDateLiteral) (
 	}
 }
 
-// evalEndOf resolves "end of <period>" to the last day of that period.
-// Strategy: find the start of the NEXT period, then subtract 1 day.
-func (interp *Interpreter) evalEndOf(innerKeyword string, now time.Time) (types.Type, error) {
-	// Map the period to its "next" equivalent to find the boundary
-	nextPeriod := ""
-	switch innerKeyword {
-	case "this week":
-		nextPeriod = "next week"
-	case "next week":
-		// end of next week = start of the week after next - 1 day
-		daysFromMonday := (int(now.Weekday()) - int(time.Monday) + 7) % 7
-		monday := now.AddDate(0, 0, -daysFromMonday)
-		startOfWeekAfterNext := monday.AddDate(0, 0, 14)
-		return types.NewDateFromTime(startOfWeekAfterNext.AddDate(0, 0, -1)), nil
-	case "last week":
-		nextPeriod = "this week"
-	case "this month":
-		nextPeriod = "next month"
-	case "next month":
-		t := time.Date(now.Year(), now.Month()+2, 1, 0, 0, 0, 0, time.UTC)
-		return types.NewDateFromTime(t.AddDate(0, 0, -1)), nil
-	case "last month":
-		nextPeriod = "this month"
-	case "this year":
-		return types.NewDateFromTime(time.Date(now.Year(), 12, 31, 0, 0, 0, 0, time.UTC)), nil
-	case "next year":
-		return types.NewDateFromTime(time.Date(now.Year()+1, 12, 31, 0, 0, 0, 0, time.UTC)), nil
-	case "last year":
-		return types.NewDateFromTime(time.Date(now.Year()-1, 12, 31, 0, 0, 0, 0, time.UTC)), nil
-	case "this quarter":
-		q := calendarQuarterStart(now.Month())
-		nextQ := time.Date(now.Year(), q+3, 1, 0, 0, 0, 0, time.UTC)
-		return types.NewDateFromTime(nextQ.AddDate(0, 0, -1)), nil
-	case "next quarter":
-		q := calendarQuarterStart(now.Month())
-		nextNextQ := time.Date(now.Year(), q+6, 1, 0, 0, 0, 0, time.UTC)
-		return types.NewDateFromTime(nextNextQ.AddDate(0, 0, -1)), nil
-	case "last quarter":
-		q := calendarQuarterStart(now.Month())
-		thisQ := time.Date(now.Year(), q, 1, 0, 0, 0, 0, time.UTC)
-		return types.NewDateFromTime(thisQ.AddDate(0, 0, -1)), nil
-	case "this fiscal quarter", "next fiscal quarter", "last fiscal quarter",
-		"this fiscal year", "next fiscal year", "last fiscal year":
-		return interp.evalEndOfFiscal(innerKeyword, now)
-	default:
-		// Try named months: "end of january", "end of next april"
-		if d, ok := resolveEndOfMonth(innerKeyword, now); ok {
-			return d, nil
-		}
-		return nil, fmt.Errorf("'end of' not supported for: %q", innerKeyword)
-	}
-
-	// Generic path: evaluate the next period and subtract 1 day
-	nextNode := &ast.RelativeDateLiteral{Keyword: nextPeriod, SourceText: nextPeriod}
-	nextStart, err := interp.evalRelativeDateLiteral(nextNode)
-	if err != nil {
-		return nil, err
-	}
-	nextDate := nextStart.(*types.Date)
-	return types.NewDateFromTime(nextDate.Time.AddDate(0, 0, -1)), nil
-}
-
-// evalEndOfFiscal handles "end of this/next/last fiscal quarter/year".
-func (interp *Interpreter) evalEndOfFiscal(keyword string, now time.Time) (types.Type, error) {
-	if interp.fiscalYearStarts == nil {
-		return nil, fmt.Errorf("fiscal expressions require a 'fiscal_year_starts' frontmatter key")
-	}
-
-	fc := interp.fiscalYearStarts
-	fyStartMonth := time.Month(fc.month)
-	fyStartDay := fc.day
-
-	switch keyword {
-	case "this fiscal quarter":
-		y, m := fiscalQuarterStart(now.Year(), now.Month(), fyStartMonth)
-		nextFQ := time.Date(y, m+3, fyStartDay, 0, 0, 0, 0, time.UTC)
-		return types.NewDateFromTime(nextFQ.AddDate(0, 0, -1)), nil
-	case "next fiscal quarter":
-		y, m := fiscalQuarterStart(now.Year(), now.Month(), fyStartMonth)
-		nextNextFQ := time.Date(y, m+6, fyStartDay, 0, 0, 0, 0, time.UTC)
-		return types.NewDateFromTime(nextNextFQ.AddDate(0, 0, -1)), nil
-	case "last fiscal quarter":
-		y, m := fiscalQuarterStart(now.Year(), now.Month(), fyStartMonth)
-		thisFQ := time.Date(y, m, fyStartDay, 0, 0, 0, 0, time.UTC)
-		return types.NewDateFromTime(thisFQ.AddDate(0, 0, -1)), nil
-	case "this fiscal year":
-		fy := fiscalYearWithDay(now, fyStartMonth, fyStartDay)
-		nextFYStart := time.Date(fy+1, fyStartMonth, fyStartDay, 0, 0, 0, 0, time.UTC)
-		return types.NewDateFromTime(nextFYStart.AddDate(0, 0, -1)), nil
-	case "next fiscal year":
-		fy := fiscalYearWithDay(now, fyStartMonth, fyStartDay) + 1
-		nextFYStart := time.Date(fy+1, fyStartMonth, fyStartDay, 0, 0, 0, 0, time.UTC)
-		return types.NewDateFromTime(nextFYStart.AddDate(0, 0, -1)), nil
-	case "last fiscal year":
-		fy := fiscalYearWithDay(now, fyStartMonth, fyStartDay) - 1
-		nextFYStart := time.Date(fy+1, fyStartMonth, fyStartDay, 0, 0, 0, 0, time.UTC)
-		return types.NewDateFromTime(nextFYStart.AddDate(0, 0, -1)), nil
-	}
-	return nil, fmt.Errorf("unknown fiscal end-of expression: %q", keyword)
-}
-
-// resolveEndOfMonth handles "end of january", "end of next april", etc.
-func resolveEndOfMonth(keyword string, now time.Time) (*types.Date, bool) {
-	// First resolve the month start, then find the last day
-	startDate, ok := resolveMonthExpression(keyword, now)
-	if !ok {
-		return nil, false
-	}
-	// Last day of the month = first day of next month - 1 day
-	lastDay := time.Date(startDate.Time.Year(), startDate.Time.Month()+1, 0, 0, 0, 0, 0, time.UTC)
-	return types.NewDateFromTime(lastDay), true
-}
-
 // evalFiscalExpression evaluates fiscal quarter and fiscal year expressions.
 // Requires fiscal_year_starts to be configured via frontmatter.
 func (interp *Interpreter) evalFiscalExpression(keyword string, now time.Time) (types.Type, error) {
@@ -309,30 +188,38 @@ func (interp *Interpreter) evalFiscalExpression(keyword string, now time.Time) (
 	fyStartMonth := time.Month(fc.month)
 	fyStartDay := fc.day
 
+	// v2.0: fiscal relatives return *types.Period.
 	switch keyword {
 	case "this fiscal quarter":
-		y, m := fiscalQuarterStart(now.Year(), now.Month(), fyStartMonth)
-		return types.NewDateFromTime(time.Date(y, m, fyStartDay, 0, 0, 0, 0, time.UTC)), nil
+		return types.NewRelativeFiscalQuarter(now, fyStartMonth, fyStartDay, 0), nil
 	case "next fiscal quarter":
-		y, m := fiscalQuarterStart(now.Year(), now.Month(), fyStartMonth)
-		t := time.Date(y, m+3, fyStartDay, 0, 0, 0, 0, time.UTC) // Go normalizes
-		return types.NewDateFromTime(t), nil
+		return types.NewRelativeFiscalQuarter(now, fyStartMonth, fyStartDay, +1), nil
 	case "last fiscal quarter":
-		y, m := fiscalQuarterStart(now.Year(), now.Month(), fyStartMonth)
-		t := time.Date(y, m-3, fyStartDay, 0, 0, 0, 0, time.UTC) // Go normalizes
-		return types.NewDateFromTime(t), nil
+		return types.NewRelativeFiscalQuarter(now, fyStartMonth, fyStartDay, -1), nil
 	case "this fiscal year":
-		y := fiscalYearWithDay(now, fyStartMonth, fyStartDay)
-		return types.NewDateFromTime(time.Date(y, fyStartMonth, fyStartDay, 0, 0, 0, 0, time.UTC)), nil
+		fy := fiscalYearLabel(now, fyStartMonth, fyStartDay)
+		return types.NewFiscalYear(fy, fyStartMonth, fyStartDay), nil
 	case "next fiscal year":
-		y := fiscalYearWithDay(now, fyStartMonth, fyStartDay) + 1
-		return types.NewDateFromTime(time.Date(y, fyStartMonth, fyStartDay, 0, 0, 0, 0, time.UTC)), nil
+		fy := fiscalYearLabel(now, fyStartMonth, fyStartDay) + 1
+		return types.NewFiscalYear(fy, fyStartMonth, fyStartDay), nil
 	case "last fiscal year":
-		y := fiscalYearWithDay(now, fyStartMonth, fyStartDay) - 1
-		return types.NewDateFromTime(time.Date(y, fyStartMonth, fyStartDay, 0, 0, 0, 0, time.UTC)), nil
+		fy := fiscalYearLabel(now, fyStartMonth, fyStartDay) - 1
+		return types.NewFiscalYear(fy, fyStartMonth, fyStartDay), nil
 	default:
 		return nil, fmt.Errorf("unknown fiscal expression: %q", keyword)
 	}
+}
+
+// fiscalYearLabel returns the FY *label* (the year the FY ENDS in,
+// per Microsoft convention) for the fiscal year containing `now`.
+// E.g., now = 2026-08-15 with fyStart = July → FY label = 2027.
+func fiscalYearLabel(now time.Time, fyStartMonth time.Month, fyStartDay int) int {
+	// fiscalYearWithDay returns the calendar year the FY STARTS in.
+	startYear := fiscalYearWithDay(now, fyStartMonth, fyStartDay)
+	if fyStartMonth > time.January {
+		return startYear + 1
+	}
+	return startYear
 }
 
 // fiscalYear returns the calendar year in which the fiscal year begins (month-only, day=1).
@@ -390,12 +277,13 @@ func (interp *Interpreter) evalNotation(keyword string, now time.Time) (types.Ty
 
 	switch prefix {
 	case "Q":
+		// v2.0: Q1-Q4 evaluates to Period (calendar quarter of the
+		// current year). Resolved against `now`'s year.
 		q, err := strconv.Atoi(value)
 		if err != nil || q < 1 || q > 4 {
 			return nil, fmt.Errorf("invalid calendar quarter: Q%s", value)
 		}
-		month := time.Month((q-1)*3 + 1) // Q1=Jan, Q2=Apr, Q3=Jul, Q4=Oct
-		return types.NewDateFromTime(time.Date(now.Year(), month, 1, 0, 0, 0, 0, time.UTC)), nil
+		return types.NewCalendarQuarter(now.Year(), q)
 
 	case "FQ":
 		if interp.fiscalYearStarts == nil {
@@ -408,15 +296,11 @@ func (interp *Interpreter) evalNotation(keyword string, now time.Time) (types.Ty
 		fc := interp.fiscalYearStarts
 		fyStartMonth := time.Month(fc.month)
 		fyStartDay := fc.day
-		// FQ1 starts at fiscal year start month, FQ2 = +3 months, etc.
+		// FQ1 starts at the fiscal year start; the fiscal year
+		// containing `now` anchors which FQ year-cycle this is.
 		fy := fiscalYearWithDay(now, fyStartMonth, fyStartDay)
-		fqMonth := time.Month(int(fyStartMonth) + (q-1)*3)
-		fqYear := fy
-		for fqMonth > 12 {
-			fqMonth -= 12
-			fqYear++
-		}
-		return types.NewDateFromTime(time.Date(fqYear, fqMonth, fyStartDay, 0, 0, 0, 0, time.UTC)), nil
+		fyStart := time.Date(fy, fyStartMonth, fyStartDay, 0, 0, 0, 0, time.UTC)
+		return types.NewFiscalQuarter(fyStart, q)
 
 	case "FY":
 		if interp.fiscalYearStarts == nil {
@@ -430,14 +314,7 @@ func (interp *Interpreter) evalNotation(keyword string, now time.Time) (types.Ty
 			fyLabel += 2000 // 2-digit: FY27 = 2027
 		}
 		fc := interp.fiscalYearStarts
-		// FY is labeled by the year it ENDS in (Microsoft convention).
-		// FY2027 with July start = starts Jul 1, 2026 (ends Jun 30, 2027).
-		// When fiscal starts in January, FY label = start year (no offset).
-		startYear := fyLabel
-		if fc.month > 1 {
-			startYear = fyLabel - 1
-		}
-		return types.NewDateFromTime(time.Date(startYear, time.Month(fc.month), fc.day, 0, 0, 0, 0, time.UTC)), nil
+		return types.NewFiscalYear(fyLabel, time.Month(fc.month), fc.day), nil
 
 	case "CY":
 		year, err := strconv.Atoi(value)
@@ -447,104 +324,10 @@ func (interp *Interpreter) evalNotation(keyword string, now time.Time) (types.Ty
 		if year < 100 {
 			year += 2000 // 2-digit: CY26 = 2026
 		}
-		return types.NewDateFromTime(time.Date(year, 1, 1, 0, 0, 0, 0, time.UTC)), nil
+		return types.NewCalendarYear(year), nil
 	}
 
 	return nil, nil
-}
-
-// evalEndOfNotation handles "end of Q2", "end of FQ1".
-func (interp *Interpreter) evalEndOfNotation(keyword string, now time.Time) (types.Type, error) {
-	startDate, err := interp.evalNotation(keyword, now)
-	if err != nil {
-		return nil, err
-	}
-	if startDate == nil {
-		return nil, nil
-	}
-	d := startDate.(*types.Date)
-	// End of quarter = start of quarter + 3 months - 1 day
-	endDate := time.Date(d.Time.Year(), d.Time.Month()+3, d.Time.Day(), 0, 0, 0, 0, time.UTC).AddDate(0, 0, -1)
-	return types.NewDateFromTime(endDate), nil
-}
-
-// periodToDuration converts a period expression AST node to its duration in days.
-// Returns an error if the node is a point (today, next Friday) rather than a period.
-func (interp *Interpreter) periodToDuration(node ast.Node) (*types.Duration, error) {
-	rel, ok := node.(*ast.RelativeDateLiteral)
-	if !ok {
-		return nil, fmt.Errorf("cannot convert date to duration — use a period expression like 'this month', 'Q1', or 'FQ1'")
-	}
-
-	keyword := strings.ToLower(rel.Keyword)
-	if !isPeriodExpression(keyword) {
-		return nil, fmt.Errorf("cannot convert '%s' to duration — it is a point in time, not a period. Use a period like 'this month', 'Q1', or 'FQ1'",
-			rel.SourceText)
-	}
-
-	now := interp.now()
-
-	// Get start date
-	startResult, err := interp.evalRelativeDateLiteral(rel)
-	if err != nil {
-		return nil, err
-	}
-	startDate := startResult.(*types.Date)
-
-	// Get end date via evalEndOf
-	endResult, err := interp.evalEndOfForKeyword(keyword, now)
-	if err != nil {
-		return nil, err
-	}
-	endDate := endResult.(*types.Date)
-
-	// Duration = end - start + 1 day
-	days := endDate.DaysBetween(startDate) + 1
-	return &types.Duration{
-		Value: decimal.NewFromInt(int64(days)),
-		Unit:  "day",
-	}, nil
-}
-
-// isPeriodExpression returns true if the keyword represents a span (not a point).
-func isPeriodExpression(keyword string) bool {
-	// Periods: this/next/last week/month/year/quarter, fiscal quarter/year, named months, Q/FQ notation
-	switch keyword {
-	case "this week", "next week", "last week",
-		"this month", "next month", "last month",
-		"this year", "next year", "last year",
-		"this quarter", "next quarter", "last quarter",
-		"this fiscal quarter", "next fiscal quarter", "last fiscal quarter",
-		"this fiscal year", "next fiscal year", "last fiscal year":
-		return true
-	}
-	// Named months: "this april", "next dec", etc.
-	for _, prefix := range []string{"this ", "next ", "last "} {
-		if strings.HasPrefix(keyword, prefix) {
-			rest := keyword[len(prefix):]
-			if _, ok := canonicalMonths[rest]; ok {
-				return true
-			}
-		}
-	}
-	// Q/FQ notation
-	upper := strings.ToUpper(keyword)
-	if strings.HasPrefix(upper, "Q:") || strings.HasPrefix(upper, "FQ:") {
-		return true
-	}
-	return false
-}
-
-// evalEndOfForKeyword resolves the end date for a period keyword.
-// Delegates to evalEndOf for period expressions, and handles notation.
-func (interp *Interpreter) evalEndOfForKeyword(keyword string, now time.Time) (types.Type, error) {
-	// Handle notation (Q:1, FQ:3)
-	upper := strings.ToUpper(keyword)
-	if strings.HasPrefix(upper, "Q:") || strings.HasPrefix(upper, "FQ:") {
-		return interp.evalEndOfNotation(keyword, now)
-	}
-	// Handle period expressions
-	return interp.evalEndOf(keyword, now)
 }
 
 // calendarQuarterStart returns the first month of the calendar quarter containing m.
@@ -569,8 +352,11 @@ var canonicalMonths = map[string]time.Month{
 	"december": time.December, "dec": time.December,
 }
 
-// resolveMonthExpression handles "this april", "next april", "last april".
-func resolveMonthExpression(keyword string, now time.Time) (*types.Date, bool) {
+// resolveMonthExpression handles "this april", "next april", "last
+// april" forms. v2.0: returns *types.Period (the whole month).
+// Pre-v2.0 it returned the 1st-of-month Date; sites that need that
+// behavior call asDate on the result.
+func resolveMonthExpression(keyword string, now time.Time) (*types.Period, bool) {
 	modifier := ""
 	monthStr := keyword
 
@@ -590,29 +376,36 @@ func resolveMonthExpression(keyword string, now time.Time) (*types.Date, bool) {
 	currentYear := now.Year()
 	currentMonth := now.Month()
 
+	year := currentYear
 	switch modifier {
 	case "this":
-		// This <month> = the 1st of that month in the current year
-		return types.NewDateFromTime(time.Date(currentYear, target, 1, 0, 0, 0, 0, time.UTC)), true
-
+		// `this <month>` = the named month in the current year
+		// (existing behavior preserved).
 	case "next":
-		// Next <month> = the 1st of that month, next occurrence strictly after current month
-		year := currentYear
 		if target <= currentMonth {
-			year++ // target month is current or past — next year
+			year++
 		}
-		return types.NewDateFromTime(time.Date(year, target, 1, 0, 0, 0, 0, time.UTC)), true
-
 	case "last":
-		// Last <month> = the 1st of that month, most recent past occurrence
-		year := currentYear
 		if target >= currentMonth {
-			year-- // target month is current or future — last year
+			year--
 		}
-		return types.NewDateFromTime(time.Date(year, target, 1, 0, 0, 0, 0, time.UTC)), true
+	default:
+		return nil, false
 	}
 
-	return nil, false
+	p := types.NewCalendarMonth(year, target)
+	p.Kind = types.PeriodNamedMonth
+	// Direction reflects user-typed modifier so format / debug
+	// output can name the form.
+	switch modifier {
+	case "next":
+		p.Direction = +1
+	case "last":
+		p.Direction = -1
+	default:
+		p.Direction = 0
+	}
+	return p, true
 }
 
 // weekdayNames maps lowercase weekday names to Go's time.Weekday.
@@ -697,119 +490,48 @@ func parseUTCOffset(offset *ast.UTCOffset) (int, error) {
 	return totalMinutes, nil
 }
 
-// evalEndOfExpr evaluates `end of <period>`. The parser emits this
-// AST shape (ast.EndOfExpr) for any well-formed `end of X`
-// expression. Dispatch flow:
+// evalEndOfExpr evaluates `end of <period>`. v2.0 implementation:
+// eval the inner (which now returns *types.Period for period-bearing
+// keywords thanks to U10) and return Period.End directly.
 //
-//   1. Inspect the AST inner (NOT the evaluated value -- the inner's
-//      structure tells us which period kind it is, even when the
-//      same evaluated Date could correspond to multiple periods).
-//   2. For *ast.RelativeDateLiteral, dispatch via the existing
-//      keyword-keyed evalEndOf / evalEndOfNotation. The keyword is
-//      already in the canonical form the helpers understand
-//      ("Q:1" / "FQ:3" / "this month" / etc.).
-//   3. For *ast.Identifier, return a clear runtime error -- the
-//      variable holds a Date (today) and we can't recover which
-//      period kind produced it. R9 (variables-as-periods) is
-//      deferred to a future PR that introduces a Period value type
-//      and threads it through evalRelativeDateLiteral / Environment.
-//   4. For everything else (literals like 5 or "2026-01-01"),
-//      return a runtime error -- the type checker (U9) catches
-//      these statically too, but the runtime guard ensures
-//      correctness even when the type-check escape (e.g., a
-//      checker bug) lets one through.
+// Variable-bound case: when the inner is an Identifier and resolves
+// to a *types.Period at runtime, this works emergently — the Period
+// value flows through evalNode → here → Period.End. R9-deferred
+// path now opens up because U10 makes Period a real value type.
 //
-// Replaces the prior strings.HasPrefix(keyword, "end of ") dispatch
-// at evalRelativeDateLiteral and evalNotation -- both removed.
+// Pre-U10 the inner could resolve to *types.Date for period
+// keywords; that path is gone after U10. A defensive guard remains
+// for the rare case where an Identifier holds a Date (user wrote
+// `q = today; end of q`) — the semantic check accepts the
+// identifier and runtime catches the type mismatch here.
 func (interp *Interpreter) evalEndOfExpr(e *ast.EndOfExpr) (types.Type, error) {
 	if e.Period == nil {
 		return nil, fmt.Errorf("end of: missing inner expression")
 	}
-	now := interp.now()
-
-	switch inner := e.Period.(type) {
-	case *ast.RelativeDateLiteral:
-		// Existing helpers handle every period-bearing keyword
-		// (Q:N, FQ:N, FY:NNNN, CY:NNNN, this/next/last
-		// week/month/year/quarter/fiscal-quarter/fiscal-year, named
-		// months). evalEndOfForKeyword routes to the right helper.
-		// Lowercase the keyword to match the casing convention in
-		// the existing helpers' switch statements (e.g.
-		// resolveMonthExpression's canonicalMonths map is
-		// lowercase-keyed) -- evalRelativeDateLiteral lowercases
-		// at line 102 before its own switch, so dispatching here
-		// must do the same.
-		return interp.evalEndOfForKeyword(strings.ToLower(inner.Keyword), now)
-	case *ast.DateLiteral:
-		// Bare month names like `April` parse as DateLiteral with
-		// implicit Day=1, Year=nil and SourceText that contains no
-		// digits. Pre-PR-1b, `end of April` worked through the old
-		// string-prefix dispatch's resolveEndOfMonth fallback. The
-		// new AST-based dispatch initially rejected DateLiteral
-		// outright; this arm restores the bare-month-name path.
-		// Discriminator matches the semantic checker (see
-		// spec/semantic/end_of_check.go) -- accept iff SourceText
-		// has no digits.
-		//
-		// Transitional shim. The downstream brainstorm decided April
-		// should become a Period type entirely; once that migration
-		// lands, the parser will emit Period-bearing AST directly
-		// and this arm collapses.
-		if !sourceTextHasDigit(inner.SourceText) {
-			return interp.evalEndOfForKeyword("this "+strings.ToLower(inner.Month), now)
-		}
-		return nil, fmt.Errorf("end of: inner expression must be a period; got specific date %s", inner.SourceText)
-	case *ast.Identifier:
-		// R9 demoted -- the variable's bound value is a Date in the
-		// current value-type model, not a Period. Surfacing this as
-		// a clear runtime error keeps the user oriented; a future
-		// PR introducing *types.Period through evalRelativeDateLiteral
-		// + Environment binding will let this case work emergently.
-		return nil, fmt.Errorf("end of %s: variable-bound periods are not yet supported; use the period literal directly (e.g. `end of Q1`) until upstream Period value-type plumbing lands", inner.Name)
-	default:
-		return nil, fmt.Errorf("end of: inner expression must be a period (got %T); valid examples: `end of Q1`, `end of this month`, `end of FY2027`", e.Period)
+	inner, err := interp.evalNode(e.Period)
+	if err != nil {
+		return nil, err
 	}
+	p, err := asPeriod(inner)
+	if err != nil {
+		return nil, fmt.Errorf("end of: inner expression must be a period; got %T", inner)
+	}
+	return p.End, nil
 }
 
 // evalStartOfExpr evaluates `start of <period>`. Symmetric to
-// evalEndOfExpr but trivial -- start of a period is just the
-// period's start date, which is what evaluating the inner literal
-// already returns.
+// evalEndOfExpr — returns Period.Start directly.
 func (interp *Interpreter) evalStartOfExpr(s *ast.StartOfExpr) (types.Type, error) {
 	if s.Period == nil {
 		return nil, fmt.Errorf("start of: missing inner expression")
 	}
-	switch inner := s.Period.(type) {
-	case *ast.RelativeDateLiteral:
-		// Inner literal's evaluation IS the period start.
-		return interp.evalRelativeDateLiteral(inner)
-	case *ast.DateLiteral:
-		// Bare month name (no digits in SourceText) means "the first
-		// day of <month>". Same shim as evalEndOfExpr's DateLiteral
-		// arm; mirrors the semantic checker's accept rule.
-		if !sourceTextHasDigit(inner.SourceText) {
-			// `start of April` = `this April` start = April 1.
-			node := &ast.RelativeDateLiteral{Keyword: "this " + strings.ToLower(inner.Month)}
-			return interp.evalRelativeDateLiteral(node)
-		}
-		return nil, fmt.Errorf("start of: inner expression must be a period; got specific date %s", inner.SourceText)
-	case *ast.Identifier:
-		return nil, fmt.Errorf("start of %s: variable-bound periods are not yet supported; use the period literal directly (e.g. `start of Q1`) until upstream Period value-type plumbing lands", inner.Name)
-	default:
-		return nil, fmt.Errorf("start of: inner expression must be a period (got %T); valid examples: `start of Q1`, `start of this month`", s.Period)
+	inner, err := interp.evalNode(s.Period)
+	if err != nil {
+		return nil, err
 	}
-}
-
-// sourceTextHasDigit reports whether s contains any digit. Used to
-// distinguish bare month names (`April`) from specific dates
-// (`April 15`, `Apr 1 2026`); both produce *ast.DateLiteral but only
-// the former is period-bearing. Mirrors the semantic checker's
-// helper of the same name.
-func sourceTextHasDigit(s string) bool {
-	for _, r := range s {
-		if r >= '0' && r <= '9' {
-			return true
-		}
+	p, err := asPeriod(inner)
+	if err != nil {
+		return nil, fmt.Errorf("start of: inner expression must be a period; got %T", inner)
 	}
-	return false
+	return p.Start, nil
 }

--- a/impl/interpreter/end_of_runtime_test.go
+++ b/impl/interpreter/end_of_runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/spec/types"
 )
 
 // TestEndOfExpr_VariableBoundDeferredR9 — R9 (variables-as-periods)
@@ -41,5 +42,53 @@ func TestEndOfExpr_NumberInnerRuntimeError(t *testing.T) {
 	}
 	if _, err := interp.Eval(nodes); err == nil {
 		t.Fatal("expected runtime error from `end of 5`; got nil")
+	}
+}
+
+// TestEndOfExpr_BareMonthName — regression for PR-1b. Pre-PR-1b,
+// `end of April` worked through the old string-prefix dispatch. The
+// new AST-based dispatch sees `*ast.DateLiteral` (parser produces
+// that for bare month names with implicit Day=1, Year=nil) and
+// initially rejected it. The fix accepts bare month names (no
+// digits in SourceText) and routes them through the existing
+// keyword-keyed evalEndOf path.
+func TestEndOfExpr_BareMonthName(t *testing.T) {
+	cases := []struct {
+		name, input    string
+		wantMonth, wantDay int
+	}{
+		{"end of April", "x = end of April", 4, 30},
+		{"end of January", "x = end of January", 1, 31},
+		{"end of February (non-leap)", "x = end of February", 2, 28},
+		{"end of December", "x = end of December", 12, 31},
+		{"end of Apr (abbrev)", "x = end of Apr", 4, 30},
+		{"start of April", "x = start of April", 4, 1},
+		{"start of February", "x = start of February", 2, 1},
+	}
+	// Use a non-leap year for predictable Feb behavior.
+	clock := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			interp := newTestInterpreterWithClock(clock)
+			nodes, err := parser.Parse(tc.input)
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			results, err := interp.Eval(nodes)
+			if err != nil {
+				t.Fatalf("Eval(%q): %v", tc.input, err)
+			}
+			if len(results) != 1 {
+				t.Fatalf("expected 1 result, got %d", len(results))
+			}
+			date, ok := results[0].(*types.Date)
+			if !ok {
+				t.Fatalf("expected *types.Date, got %T", results[0])
+			}
+			if int(date.Time.Month()) != tc.wantMonth || date.Time.Day() != tc.wantDay {
+				t.Errorf("got %s, want month=%d day=%d",
+					date.Time.Format("2006-01-02"), tc.wantMonth, tc.wantDay)
+			}
+		})
 	}
 }

--- a/impl/interpreter/end_of_runtime_test.go
+++ b/impl/interpreter/end_of_runtime_test.go
@@ -1,7 +1,6 @@
 package interpreter
 
 import (
-	"strings"
 	"testing"
 	"time"
 
@@ -9,25 +8,34 @@ import (
 	"github.com/CalcMark/go-calcmark/spec/types"
 )
 
-// TestEndOfExpr_VariableBoundDeferredR9 — R9 (variables-as-periods)
-// is demoted to a future PR. Until the *types.Period value-type
-// plumbing lands, `q = Q1; e = end of q` returns a clear runtime
-// error directing users to use the literal directly.
-func TestEndOfExpr_VariableBoundDeferredR9(t *testing.T) {
+// TestEndOfExpr_VariableBoundWorks — v2.0 R9 (variables-as-periods).
+// Pre-v2: `q = Q1; e = end of q` errored because the variable held
+// a Date (Q1's start) and end-of couldn't recover the period kind.
+// v2: Q1 evaluates to *types.Period; the variable holds the Period
+// directly; `end of q` reads Period.End cleanly. The test now asserts
+// the working behavior — Q1 ends March 31 — and pins the v2.0 R9
+// emergent capability so it can't regress.
+func TestEndOfExpr_VariableBoundWorks(t *testing.T) {
 	interp := newTestInterpreterWithClock(time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC))
 	src := "q = Q1\ne = end of q"
 	nodes, err := parser.Parse(src)
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	_, err = interp.Eval(nodes)
-	if err == nil {
-		t.Fatal("expected runtime error from `e = end of q`; got nil")
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("expected `end of q` to evaluate cleanly with v2 Period plumbing; got error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "variable-bound") &&
-		!strings.Contains(err.Error(), "Period") &&
-		!strings.Contains(err.Error(), "period") {
-		t.Errorf("error %q should mention variable-bound or Period", err.Error())
+	// Two results: the assignment of q, then end of q.
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	d, ok := results[1].(*types.Date)
+	if !ok {
+		t.Fatalf("expected *types.Date for `end of q`, got %T", results[1])
+	}
+	if d.Time.Year() != 2026 || d.Time.Month() != time.March || d.Time.Day() != 31 {
+		t.Errorf("end of Q1 = %v, want 2026-03-31", d.Time.Format("2006-01-02"))
 	}
 }
 

--- a/impl/interpreter/end_of_runtime_test.go
+++ b/impl/interpreter/end_of_runtime_test.go
@@ -1,0 +1,45 @@
+package interpreter
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/CalcMark/go-calcmark/spec/parser"
+)
+
+// TestEndOfExpr_VariableBoundDeferredR9 — R9 (variables-as-periods)
+// is demoted to a future PR. Until the *types.Period value-type
+// plumbing lands, `q = Q1; e = end of q` returns a clear runtime
+// error directing users to use the literal directly.
+func TestEndOfExpr_VariableBoundDeferredR9(t *testing.T) {
+	interp := newTestInterpreterWithClock(time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC))
+	src := "q = Q1\ne = end of q"
+	nodes, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	_, err = interp.Eval(nodes)
+	if err == nil {
+		t.Fatal("expected runtime error from `e = end of q`; got nil")
+	}
+	if !strings.Contains(err.Error(), "variable-bound") &&
+		!strings.Contains(err.Error(), "Period") &&
+		!strings.Contains(err.Error(), "period") {
+		t.Errorf("error %q should mention variable-bound or Period", err.Error())
+	}
+}
+
+// TestEndOfExpr_NumberInnerRuntimeError — `end of 5` is rejected at
+// runtime even when the type-checker is bypassed. The interpreter
+// guard ensures correctness.
+func TestEndOfExpr_NumberInnerRuntimeError(t *testing.T) {
+	interp := newTestInterpreterWithClock(time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC))
+	nodes, err := parser.Parse("x = end of 5")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if _, err := interp.Eval(nodes); err == nil {
+		t.Fatal("expected runtime error from `end of 5`; got nil")
+	}
+}

--- a/impl/interpreter/interpreter.go
+++ b/impl/interpreter/interpreter.go
@@ -164,6 +164,10 @@ func (interp *Interpreter) evalNode(node ast.Node) (types.Type, error) {
 		return interp.evalEndOfExpr(n)
 	case *ast.StartOfExpr:
 		return interp.evalStartOfExpr(n)
+	case *ast.BetweenExpr:
+		return interp.evalBetweenExpr(n)
+	case *ast.LengthOfExpr:
+		return interp.evalLengthOfExpr(n)
 	case *ast.FractionLiteral:
 		return interp.evalFractionLiteral(n)
 	case *ast.QuantityLiteral:

--- a/impl/interpreter/interpreter.go
+++ b/impl/interpreter/interpreter.go
@@ -89,16 +89,31 @@ func (interp *Interpreter) SetMeasurement(mc *units.MeasurementConfig) {
 	interp.measurement = mc
 }
 
-// fiscalConfig holds the fiscal year start month and day.
+// fiscalConfig holds the fiscal year start month/day plus the FY-label
+// convention. labelMode defaults to FYLabelByEndYear (matches Australian
+// government year, US tax year, and most publicly traded companies);
+// documents can declare `calendar_year_offset: after` to switch to
+// FYLabelByStartYear.
 type fiscalConfig struct {
-	month int // 1-12
-	day   int // 1-31
+	month     int // 1-12
+	day       int // 1-31
+	labelMode types.FYLabelMode
 }
 
-// SetFiscalYearStarts configures the start of the fiscal year.
-// Month is 1-12 (January-December), day is the start day (1-31, typically 1).
+// SetFiscalYearStarts configures the start of the fiscal year using
+// the default FY-label convention (FYLabelByEndYear). Existing
+// callers stay on this entry point unchanged. Month is 1-12, day is
+// 1-31 (typically 1).
 func (interp *Interpreter) SetFiscalYearStarts(month, day int) {
-	interp.fiscalYearStarts = &fiscalConfig{month: month, day: day}
+	interp.SetFiscalCalendar(month, day, types.FYLabelByEndYear)
+}
+
+// SetFiscalCalendar configures the fiscal-year start month/day plus
+// the labeling convention. `mode` corresponds to the document's
+// `calendar_year_offset` frontmatter setting (`before` →
+// FYLabelByEndYear, `after` → FYLabelByStartYear).
+func (interp *Interpreter) SetFiscalCalendar(month, day int, mode types.FYLabelMode) {
+	interp.fiscalYearStarts = &fiscalConfig{month: month, day: day, labelMode: mode}
 }
 
 // resolveUnit maps a bare ambiguous unit name to its qualified form using

--- a/impl/interpreter/interpreter.go
+++ b/impl/interpreter/interpreter.go
@@ -160,6 +160,10 @@ func (interp *Interpreter) evalNode(node ast.Node) (types.Type, error) {
 		return interp.evalDurationLiteral(n)
 	case *ast.RelativeDateLiteral:
 		return interp.evalRelativeDateLiteral(n)
+	case *ast.EndOfExpr:
+		return interp.evalEndOfExpr(n)
+	case *ast.StartOfExpr:
+		return interp.evalStartOfExpr(n)
 	case *ast.FractionLiteral:
 		return interp.evalFractionLiteral(n)
 	case *ast.QuantityLiteral:

--- a/impl/interpreter/operators.go
+++ b/impl/interpreter/operators.go
@@ -275,13 +275,54 @@ func evalBinaryOperation(left, right types.Type, operator string) (types.Type, e
 		}
 	}
 
-	// Date operations
+	// Period arithmetic (v2.0): asymmetric — `+` extends from the
+	// period's END, `-` extends from its START. So `Q1 + 30 days` =
+	// Mar 31 + 30 days; `Q1 - 5 days` = Jan 1 - 5 days. Period ==
+	// Period is structural (start.Equal && end.Equal). Period ==
+	// Date is a type error and falls through to the generic
+	// type-mismatch error below.
+	if leftPeriod, ok := left.(*types.Period); ok {
+		if rightDur, ok := right.(*types.Duration); ok {
+			switch operator {
+			case "+":
+				// End + Duration → Date past the period's end.
+				return evalDateDurationOperation(leftPeriod.End, rightDur, "+")
+			case "-":
+				// Start - Duration → Date before the period's start.
+				return evalDateDurationOperation(leftPeriod.Start, rightDur, "-")
+			}
+		}
+		if rightPeriod, ok := right.(*types.Period); ok {
+			switch operator {
+			case "==":
+				eq := leftPeriod.Start.Time.Equal(rightPeriod.Start.Time) &&
+					leftPeriod.End.Time.Equal(rightPeriod.End.Time)
+				return &types.Boolean{Value: eq}, nil
+			case "!=":
+				eq := leftPeriod.Start.Time.Equal(rightPeriod.Start.Time) &&
+					leftPeriod.End.Time.Equal(rightPeriod.End.Time)
+				return &types.Boolean{Value: !eq}, nil
+			case "+", "-":
+				return nil, fmt.Errorf("cannot %s two periods; use 'length of' to get a duration", operator)
+			}
+		}
+	}
+
+	// Date operations. Periods masquerading as dates (e.g., when a
+	// Period flows through addition with a Duration on the right and
+	// the Period was the LHS — already handled above; this Date arm
+	// catches the case where a Period appears on the RHS of a Date
+	// operation, which is unusual but not impossible).
 	if leftDate, ok := left.(*types.Date); ok {
 		if rightDur, ok := right.(*types.Duration); ok {
 			return evalDateDurationOperation(leftDate, rightDur, operator)
 		}
 		if rightDate, ok := right.(*types.Date); ok {
 			return evalDateDateOperation(leftDate, rightDate, operator)
+		}
+		// Date - Period: treat Period as its Start (legacy unwrap).
+		if rightPeriod, ok := right.(*types.Period); ok && operator == "-" {
+			return evalDateDateOperation(leftDate, rightPeriod.Start, "-")
 		}
 	}
 
@@ -727,6 +768,27 @@ func evalComparison(left, right types.Type, operator string) (types.Type, error)
 				return types.NewBoolean(leftBool.Value != rightBool.Value), nil
 			default:
 				return nil, fmt.Errorf("unsupported boolean comparison: %s", operator)
+			}
+		}
+	}
+
+	// Period comparisons (v2.0): Period == Period is structural —
+	// matching Start.Time AND End.Time. Period vs Date is a type
+	// error (not in this branch — falls through to the generic
+	// unsupported-comparison error below).
+	if leftPeriod, ok := left.(*types.Period); ok {
+		if rightPeriod, ok := right.(*types.Period); ok {
+			switch operator {
+			case "==":
+				eq := leftPeriod.Start.Time.Equal(rightPeriod.Start.Time) &&
+					leftPeriod.End.Time.Equal(rightPeriod.End.Time)
+				return types.NewBoolean(eq), nil
+			case "!=":
+				eq := leftPeriod.Start.Time.Equal(rightPeriod.Start.Time) &&
+					leftPeriod.End.Time.Equal(rightPeriod.End.Time)
+				return types.NewBoolean(!eq), nil
+			default:
+				return nil, fmt.Errorf("unsupported period comparison: %s — periods only support == and !=", operator)
 			}
 		}
 	}

--- a/impl/interpreter/period_basis_conversion_test.go
+++ b/impl/interpreter/period_basis_conversion_test.go
@@ -1,0 +1,229 @@
+package interpreter
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/spec/types"
+)
+
+// Period basis conversion: `<period> as fiscal` / `<period> as
+// calendar`. Issue #146 (upstream go-calcmark). Midpoint-rule
+// implementation: returns the period of the requested basis whose
+// dates contain the input period's midpoint.
+
+// Year-level conversion: numeric label carries across. CY2026 ↔
+// FY2026 (NOT FY2027), even though the underlying date ranges differ.
+// Label-match preserves the user's "year 2026" mental model.
+
+func TestBasisConversion_CalendarYearAsFiscal(t *testing.T) {
+	interp := newTestInterpreterWithClock(testClock)
+	interp.SetFiscalYearStarts(7, 1) // July 1
+	nodes, err := parser.Parse("p = CY2026 as fiscal\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	p, ok := results[0].(*types.Period)
+	if !ok {
+		t.Fatalf("expected *types.Period, got %T", results[0])
+	}
+	if p.Kind != types.PeriodFiscalYear {
+		t.Errorf("Kind = %v, want PeriodFiscalYear", p.Kind)
+	}
+	if p.Year != 2026 {
+		t.Errorf("FY label = %d, want 2026 (label-match: CY2026 ↔ FY2026)", p.Year)
+	}
+}
+
+func TestBasisConversion_FiscalYearAsCalendar(t *testing.T) {
+	interp := newTestInterpreterWithClock(testClock)
+	interp.SetFiscalYearStarts(7, 1)
+	nodes, err := parser.Parse("p = FY2027 as calendar\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	p := results[0].(*types.Period)
+	if p.Kind != types.PeriodCalendarYear {
+		t.Errorf("Kind = %v, want PeriodCalendarYear", p.Kind)
+	}
+	if p.Year != 2027 {
+		t.Errorf("CY label = %d, want 2027 (label-match: FY2027 ↔ CY2027)", p.Year)
+	}
+}
+
+// TestBasisConversion_YearRoundTripIsIdentity — locks the
+// label-match contract via two-step round-trip (chained `as` not
+// supported by the existing UnitConversion parser).
+func TestBasisConversion_YearRoundTripIsIdentity(t *testing.T) {
+	interp := newTestInterpreterWithClock(testClock)
+	interp.SetFiscalYearStarts(7, 1)
+	nodes, err := parser.Parse("fy = CY2026 as fiscal\np = fy as calendar\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	p := results[1].(*types.Period)
+	if p.Kind != types.PeriodCalendarYear || p.Year != 2026 {
+		t.Errorf("round-trip CY2026 → FY → CY = (%v, %d), want (PeriodCalendarYear, 2026)",
+			p.Kind, p.Year)
+	}
+}
+
+func TestBasisConversion_QuarterAsFiscal(t *testing.T) {
+	interp := newTestInterpreterWithClock(testClock)
+	interp.SetFiscalYearStarts(7, 1)
+	// Q1 of CY2026 = Jan-Mar 2026. With Jul-start FY, FY2026 covers
+	// Jul 2025 - Jun 2026, and FQ3 of FY2026 = Jan-Mar 2026 (matches
+	// Q1 dates exactly).
+	nodes, err := parser.Parse("p = Q1 as fiscal\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	p := results[0].(*types.Period)
+	if p.Kind != types.PeriodFiscalQuarter {
+		t.Errorf("Kind = %v, want PeriodFiscalQuarter", p.Kind)
+	}
+	if p.QuarterIndex != 3 {
+		t.Errorf("FQ index = %d, want 3 (Q1=Jan-Mar matches FQ3 of FY2026 with Jul start)",
+			p.QuarterIndex)
+	}
+	wantStart := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2026, time.March, 31, 0, 0, 0, 0, time.UTC)
+	if !p.Start.Time.Equal(wantStart) {
+		t.Errorf("Start = %v, want %v", p.Start.Time, wantStart)
+	}
+	if !p.End.Time.Equal(wantEnd) {
+		t.Errorf("End = %v, want %v", p.End.Time, wantEnd)
+	}
+}
+
+func TestBasisConversion_FiscalQuarterAsCalendar(t *testing.T) {
+	clock := time.Date(2026, 8, 15, 0, 0, 0, 0, time.UTC) // Aug 2026 = FQ1 of FY2027
+	interp := newTestInterpreterWithClock(clock)
+	interp.SetFiscalYearStarts(7, 1)
+	// FQ1 of FY2027 = Jul-Sep 2026. Midpoint = mid-Aug.
+	// Calendar quarter containing mid-Aug = Q3 (Jul-Sep).
+	nodes, err := parser.Parse("p = FQ1 as calendar\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	p := results[0].(*types.Period)
+	if p.Kind != types.PeriodCalendarQuarter {
+		t.Errorf("Kind = %v, want PeriodCalendarQuarter", p.Kind)
+	}
+	if p.QuarterIndex != 3 {
+		t.Errorf("Q index = %d, want 3 (FQ1 with Jul start = Jul-Sep = Q3)",
+			p.QuarterIndex)
+	}
+}
+
+func TestBasisConversion_ThisYearAsFiscal(t *testing.T) {
+	clock := time.Date(2026, 8, 15, 0, 0, 0, 0, time.UTC)
+	interp := newTestInterpreterWithClock(clock)
+	interp.SetFiscalYearStarts(7, 1)
+	// `this year` resolves to CY2026 (Jan-Dec 2026). Label-match
+	// rule: → FY2026 (NOT FY2027). The user's mental model is
+	// "year 2026" — preserving the numeric year is more intuitive
+	// than picking the FY whose date-range happens to contain the
+	// midpoint.
+	nodes, err := parser.Parse("p = this year as fiscal\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	p := results[0].(*types.Period)
+	if p.Kind != types.PeriodFiscalYear {
+		t.Errorf("Kind = %v, want PeriodFiscalYear", p.Kind)
+	}
+	if p.Year != 2026 {
+		t.Errorf("FY label = %d, want 2026 (label-match)", p.Year)
+	}
+}
+
+func TestBasisConversion_AsFY_ShortAlias(t *testing.T) {
+	// `as fy` should behave like `as fiscal`.
+	interp := newTestInterpreterWithClock(testClock)
+	interp.SetFiscalYearStarts(7, 1)
+	nodes, _ := parser.Parse("p = CY2026 as fy\n")
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	if _, ok := results[0].(*types.Period); !ok {
+		t.Fatalf("expected *types.Period, got %T", results[0])
+	}
+}
+
+func TestBasisConversion_AsCY_ShortAlias(t *testing.T) {
+	interp := newTestInterpreterWithClock(testClock)
+	interp.SetFiscalYearStarts(7, 1)
+	nodes, _ := parser.Parse("p = FY2027 as cy\n")
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	p := results[0].(*types.Period)
+	if p.Kind != types.PeriodCalendarYear {
+		t.Errorf("Kind = %v, want PeriodCalendarYear", p.Kind)
+	}
+}
+
+func TestBasisConversion_FiscalRequiresConfig(t *testing.T) {
+	// `Q1 as fiscal` without fiscal_year_starts must error with a
+	// clear message.
+	interp := newTestInterpreterWithClock(testClock)
+	// NOT calling SetFiscalYearStarts.
+	nodes, err := parser.Parse("p = Q1 as fiscal\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	_, err = interp.Eval(nodes)
+	if err == nil {
+		t.Fatal("expected error for `as fiscal` without fiscal_year_starts; got nil")
+	}
+	if !strings.Contains(err.Error(), "fiscal_year_starts") {
+		t.Errorf("error %q should mention 'fiscal_year_starts'", err.Error())
+	}
+}
+
+func TestBasisConversion_CalendarSideAlwaysWorks(t *testing.T) {
+	// `as calendar` must work without fiscal_year_starts when the
+	// input doesn't depend on fiscal config (e.g., FY literal does
+	// require it to construct, but `as calendar` reads its dates
+	// from the input).
+	interp := newTestInterpreterWithClock(testClock)
+	// no SetFiscalYearStarts
+	nodes, err := parser.Parse("p = Q1 as calendar\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	_, err = interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Q1 as calendar should work without fiscal config; got: %v", err)
+	}
+}
+

--- a/impl/interpreter/period_eval.go
+++ b/impl/interpreter/period_eval.go
@@ -16,7 +16,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/CalcMark/go-calcmark/spec/ast"
 	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/shopspring/decimal"
 )
 
 // asDate unwraps a *types.Period to its Start date, returns
@@ -112,4 +114,75 @@ func namedMonthPeriod(month time.Month, now time.Time, direction int) *types.Per
 	p.Kind = types.PeriodNamedMonth
 	p.Direction = direction
 	return p
+}
+
+// evalBetweenExpr evaluates `between A and B` / `from A to B` to a
+// *types.Period (PeriodCustom kind). Both endpoints must evaluate
+// to a Date (or a Period that narrows to its Start). Errors when
+// end < start (NewCustomPeriod enforces).
+func (interp *Interpreter) evalBetweenExpr(b *ast.BetweenExpr) (types.Type, error) {
+	if b.Start == nil {
+		return nil, fmt.Errorf("between: missing start endpoint")
+	}
+	if b.End == nil {
+		return nil, fmt.Errorf("between: missing end endpoint")
+	}
+	startVal, err := interp.evalNode(b.Start)
+	if err != nil {
+		return nil, fmt.Errorf("between start: %w", err)
+	}
+	endVal, err := interp.evalNode(b.End)
+	if err != nil {
+		return nil, fmt.Errorf("between end: %w", err)
+	}
+	startDate, err := asDate(startVal)
+	if err != nil {
+		return nil, fmt.Errorf("between requires Date inputs; start: %w", err)
+	}
+	endDate, err := asDate(endVal)
+	if err != nil {
+		return nil, fmt.Errorf("between requires Date inputs; end: %w", err)
+	}
+	return types.NewCustomPeriod(startDate, endDate)
+}
+
+// evalLengthOfExpr evaluates `length of <P>` (returns Duration in
+// days) and `days in <P>` (returns Number — integer day count).
+// AsNumber discriminates the surface form. Both forms compute
+// (Period.End - Period.Start) + 1 day for closed-interval semantics.
+func (interp *Interpreter) evalLengthOfExpr(l *ast.LengthOfExpr) (types.Type, error) {
+	if l.Period == nil {
+		op := "length of"
+		if l.AsNumber {
+			op = "days in"
+		}
+		return nil, fmt.Errorf("%s: missing inner expression", op)
+	}
+	innerVal, err := interp.evalNode(l.Period)
+	if err != nil {
+		return nil, err
+	}
+	p, err := asPeriod(innerVal)
+	if err != nil {
+		op := "length of"
+		if l.AsNumber {
+			op = "days in"
+		}
+		return nil, fmt.Errorf("%s requires a period; got %T", op, innerVal)
+	}
+
+	// Closed interval, day precision: end - start + 1 day.
+	days := int(p.End.Time.Sub(p.Start.Time).Hours()/24) + 1
+
+	if l.AsNumber {
+		// `days in <P>` → Number (integer day count). Used in
+		// arithmetic like `cost = days in cycle * 1000`.
+		return &types.Number{Value: decimal.NewFromInt(int64(days))}, nil
+	}
+	// `length of <P>` → Duration in days. Composes with duration
+	// arithmetic (`length of Q1 + 5 days` = 95 days).
+	return &types.Duration{
+		Value: decimal.NewFromInt(int64(days)),
+		Unit:  "day",
+	}, nil
 }

--- a/impl/interpreter/period_eval.go
+++ b/impl/interpreter/period_eval.go
@@ -1,0 +1,115 @@
+// Period helpers for v2.0: asDate (unwraps Period.Start when a
+// site that historically expected *types.Date now receives a
+// *types.Period) and relative-kind factories (this/next/last
+// week/month/year) that depend on the interpreter's clock.
+//
+// Calendar / fiscal factories (NewCalendarQuarter, NewFiscalYear,
+// NewCalendarMonth, NewRelativeQuarter, NewRelativeFiscalQuarter)
+// live in spec/types/period.go because they take `now` as an
+// argument rather than reading interpreter state. Week / month /
+// year relative factories belong here so the spec/-never-imports-
+// impl/ boundary stays clean even when more interpreter state
+// (e.g., week-start configuration) eventually plugs in.
+package interpreter
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/CalcMark/go-calcmark/spec/types"
+)
+
+// asDate unwraps a *types.Period to its Start date, returns
+// *types.Date as-is, and errors otherwise. Used at every site that
+// historically type-asserted (*types.Date) and now also accepts a
+// Period — the legacy callers inherit the period-narrows-to-start
+// convention. New callers that need a Period's End should
+// type-assert *types.Period directly.
+func asDate(t types.Type) (*types.Date, error) {
+	switch v := t.(type) {
+	case *types.Date:
+		return v, nil
+	case *types.Period:
+		return v.Start, nil
+	default:
+		return nil, fmt.Errorf("expected Date or Period; got %T", t)
+	}
+}
+
+// asPeriod is the symmetric: returns *types.Period as-is, errors
+// otherwise. Sites that EXPECT a Period (length-of, days-in,
+// between operands) use this. Date is intentionally rejected — at
+// these call sites a Date is always a type error.
+func asPeriod(t types.Type) (*types.Period, error) {
+	if p, ok := t.(*types.Period); ok {
+		return p, nil
+	}
+	return nil, fmt.Errorf("expected Period; got %T", t)
+}
+
+// relativeWeekPeriod constructs the Period for `this/next/last
+// week` relative to `now`. Direction: -1 (last) / 0 (this) / +1
+// (next). Week starts Monday (CalcMark convention; matches the
+// existing Date-based eval at evalRelativeDateLiteral).
+func relativeWeekPeriod(now time.Time, direction int) *types.Period {
+	daysFromMonday := (int(now.Weekday()) - int(time.Monday) + 7) % 7
+	monday := now.AddDate(0, 0, -daysFromMonday+direction*7)
+	startT := time.Date(monday.Year(), monday.Month(), monday.Day(), 0, 0, 0, 0, time.UTC)
+	endT := startT.AddDate(0, 0, 6)
+	return &types.Period{
+		Start:     types.NewDateFromTime(startT),
+		End:       types.NewDateFromTime(endT),
+		Kind:      types.PeriodRelativeWeek,
+		Direction: direction,
+	}
+}
+
+// relativeMonthPeriod constructs the Period for `this/next/last
+// month` relative to `now`. Calendar-month aligned: start = 1st of
+// month, end = last day of month (handles February leap year via
+// time.Date normalization).
+func relativeMonthPeriod(now time.Time, direction int) *types.Period {
+	month := now.Month() + time.Month(direction)
+	year := now.Year()
+	for month < 1 {
+		month += 12
+		year--
+	}
+	for month > 12 {
+		month -= 12
+		year++
+	}
+	p := types.NewCalendarMonth(year, month)
+	p.Kind = types.PeriodRelativeMonth
+	p.Direction = direction
+	return p
+}
+
+// relativeYearPeriod constructs the Period for `this/next/last
+// year` relative to `now`. Calendar-year aligned.
+func relativeYearPeriod(now time.Time, direction int) *types.Period {
+	year := now.Year() + direction
+	p := types.NewCalendarYear(year)
+	p.Kind = types.PeriodRelativeYear
+	p.Direction = direction
+	return p
+}
+
+// namedMonthPeriod constructs the Period for a `this/next/last
+// <named-month>` form, resolved relative to `now`. Mirrors the
+// existing resolveMonthExpression Date-based logic. Direction
+// applies in years: `this April` = the April most natural relative
+// to now (the upcoming or past nearest one); `next April` = next
+// year's April; `last April` = previous year's April.
+//
+// The "this" rule matches resolveMonthExpression: when the named
+// month equals `now`'s month, return that month. Otherwise return
+// the month in `now`'s calendar year (e.g., `this April` from
+// July returns April of this year).
+func namedMonthPeriod(month time.Month, now time.Time, direction int) *types.Period {
+	year := now.Year() + direction
+	p := types.NewCalendarMonth(year, month)
+	p.Kind = types.PeriodNamedMonth
+	p.Direction = direction
+	return p
+}

--- a/impl/interpreter/period_eval.go
+++ b/impl/interpreter/period_eval.go
@@ -14,6 +14,7 @@ package interpreter
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/CalcMark/go-calcmark/spec/ast"
@@ -144,6 +145,121 @@ func (interp *Interpreter) evalBetweenExpr(b *ast.BetweenExpr) (types.Type, erro
 		return nil, fmt.Errorf("between requires Date inputs; end: %w", err)
 	}
 	return types.NewCustomPeriod(startDate, endDate)
+}
+
+// isPeriodBasisTarget reports whether the unit-conversion target
+// names a Period basis (fiscal / calendar). Triggers
+// convertPeriodBasis instead of the duration-conversion path in
+// evalUnitConversion.
+func isPeriodBasisTarget(unit string) bool {
+	switch strings.ToLower(unit) {
+	case "fiscal", "fy", "calendar", "cy":
+		return true
+	}
+	return false
+}
+
+// convertPeriodBasis converts a Period to the requested basis
+// (fiscal ↔ calendar). Two distinct rules apply depending on
+// granularity:
+//
+// Year-grain (CY ↔ FY): label-match. The numeric label carries
+// across — `CY2026 as fiscal` = FY2026, `FY2027 as calendar` =
+// CY2027. The dates differ (FY2027 with Jul start = Jul 2026 –
+// Jun 2027, CY2027 = Jan – Dec 2027) but the user's "year 2027"
+// mental model is preserved. Round-trip is identity.
+//
+// Quarter-grain (Q ↔ FQ): midpoint-contains. The dates are
+// preserved across the conversion — `Q1 as fiscal` with Jul-start
+// FY returns FQ3 of FY2026 (Jan–Mar 2026), the same date range
+// relabeled in fiscal terms. Useful for cross-referencing against
+// fiscal calendars without changing what dates the user means.
+//
+// Calendar-side targets always succeed (calendar boundaries don't
+// depend on configuration). Fiscal-side targets require
+// fiscal_year_starts in frontmatter.
+//
+// Other kinds (months, weeks, named-month, custom) error — they
+// don't have a canonical fiscal equivalent.
+func (interp *Interpreter) convertPeriodBasis(p *types.Period, target string) (*types.Period, error) {
+	target = strings.ToLower(target)
+	switch target {
+	case "fiscal", "fy":
+		return interp.toFiscalBasis(p)
+	case "calendar", "cy":
+		return interp.toCalendarBasis(p)
+	}
+	return nil, fmt.Errorf("unknown period basis: %q (use 'fiscal' or 'calendar')", target)
+}
+
+// toFiscalBasis converts a calendar-grain period to its fiscal
+// counterpart. Year inputs use label-match; quarter inputs use
+// midpoint-contains.
+func (interp *Interpreter) toFiscalBasis(p *types.Period) (*types.Period, error) {
+	if interp.fiscalYearStarts == nil {
+		return nil, fmt.Errorf("fiscal basis requires a 'fiscal_year_starts' frontmatter key")
+	}
+	fc := interp.fiscalYearStarts
+	fyStartMonth := time.Month(fc.month)
+	fyStartDay := fc.day
+
+	switch p.Kind {
+	case types.PeriodCalendarYear:
+		// CY<Y> → FY<Y>: numeric label carries across.
+		return types.NewFiscalYear(p.Year, fyStartMonth, fyStartDay), nil
+
+	case types.PeriodFiscalYear, types.PeriodRelativeYear, types.PeriodRelativeFiscalYear:
+		// CY<Y> seen via `this year` etc. → use the calendar year of
+		// the period's midpoint as the FY label. For PeriodFiscalYear
+		// it's already fiscal (no-op of sorts; reuse the same label).
+		span := p.End.Time.Sub(p.Start.Time)
+		midpoint := p.Start.Time.Add(span / 2)
+		return types.NewFiscalYear(midpoint.Year(), fyStartMonth, fyStartDay), nil
+
+	case types.PeriodCalendarQuarter, types.PeriodFiscalQuarter,
+		types.PeriodRelativeQuarter, types.PeriodRelativeFiscalQuarter:
+		// Quarter-grain: find the FQ whose dates contain the input's
+		// midpoint. Preserves the underlying date range when the
+		// quarters happen to align (e.g., Q1 ↔ FQ3 with Jul-start FY).
+		span := p.End.Time.Sub(p.Start.Time)
+		midpoint := p.Start.Time.Add(span / 2)
+		fyStartYear := fiscalYearWithDay(midpoint, fyStartMonth, fyStartDay)
+		fyStart := time.Date(fyStartYear, fyStartMonth, fyStartDay, 0, 0, 0, 0, time.UTC)
+		for q := 1; q <= 4; q++ {
+			fqStart := fyStart.AddDate(0, (q-1)*3, 0)
+			fqEnd := fqStart.AddDate(0, 3, -1)
+			if !midpoint.Before(fqStart) && !midpoint.After(fqEnd) {
+				return types.NewFiscalQuarter(fyStart, q)
+			}
+		}
+		return nil, fmt.Errorf("internal: midpoint %v not in any FQ of FY starting %v", midpoint, fyStart)
+	}
+	return nil, fmt.Errorf("`as fiscal` only supports year-grain and quarter-grain periods (got kind %v)", p.Kind)
+}
+
+// toCalendarBasis is the symmetric calendar-side converter.
+func (interp *Interpreter) toCalendarBasis(p *types.Period) (*types.Period, error) {
+	switch p.Kind {
+	case types.PeriodFiscalYear:
+		// FY<Y> → CY<Y>: numeric label carries across.
+		return types.NewCalendarYear(p.Year), nil
+
+	case types.PeriodCalendarYear, types.PeriodRelativeYear, types.PeriodRelativeFiscalYear:
+		// `this year` → CY of period's midpoint year. Relative fiscal
+		// year → CY whose label matches the FY's resolved year.
+		span := p.End.Time.Sub(p.Start.Time)
+		midpoint := p.Start.Time.Add(span / 2)
+		return types.NewCalendarYear(midpoint.Year()), nil
+
+	case types.PeriodCalendarQuarter, types.PeriodFiscalQuarter,
+		types.PeriodRelativeQuarter, types.PeriodRelativeFiscalQuarter:
+		// Calendar quarter containing midpoint: 1=Jan-Mar, ..., 4=Oct-Dec.
+		span := p.End.Time.Sub(p.Start.Time)
+		midpoint := p.Start.Time.Add(span / 2)
+		q := (int(midpoint.Month())-1)/3 + 1
+		return types.NewCalendarQuarter(midpoint.Year(), q)
+	}
+	return nil, fmt.Errorf("`as calendar` only supports year-grain and quarter-grain periods (got kind %v)", p.Kind)
 }
 
 // evalLengthOfExpr evaluates `length of <P>` (returns Duration in

--- a/impl/interpreter/period_eval.go
+++ b/impl/interpreter/period_eval.go
@@ -202,11 +202,12 @@ func (interp *Interpreter) toFiscalBasis(p *types.Period) (*types.Period, error)
 	fc := interp.fiscalYearStarts
 	fyStartMonth := time.Month(fc.month)
 	fyStartDay := fc.day
+	mode := fc.labelMode
 
 	switch p.Kind {
 	case types.PeriodCalendarYear:
 		// CY<Y> → FY<Y>: numeric label carries across.
-		return types.NewFiscalYear(p.Year, fyStartMonth, fyStartDay), nil
+		return types.NewFiscalYearWithMode(p.Year, fyStartMonth, fyStartDay, mode), nil
 
 	case types.PeriodFiscalYear, types.PeriodRelativeYear, types.PeriodRelativeFiscalYear:
 		// CY<Y> seen via `this year` etc. → use the calendar year of
@@ -214,7 +215,7 @@ func (interp *Interpreter) toFiscalBasis(p *types.Period) (*types.Period, error)
 		// it's already fiscal (no-op of sorts; reuse the same label).
 		span := p.End.Time.Sub(p.Start.Time)
 		midpoint := p.Start.Time.Add(span / 2)
-		return types.NewFiscalYear(midpoint.Year(), fyStartMonth, fyStartDay), nil
+		return types.NewFiscalYearWithMode(midpoint.Year(), fyStartMonth, fyStartDay, mode), nil
 
 	case types.PeriodCalendarQuarter, types.PeriodFiscalQuarter,
 		types.PeriodRelativeQuarter, types.PeriodRelativeFiscalQuarter:
@@ -229,7 +230,7 @@ func (interp *Interpreter) toFiscalBasis(p *types.Period) (*types.Period, error)
 			fqStart := fyStart.AddDate(0, (q-1)*3, 0)
 			fqEnd := fqStart.AddDate(0, 3, -1)
 			if !midpoint.Before(fqStart) && !midpoint.After(fqEnd) {
-				return types.NewFiscalQuarter(fyStart, q)
+				return types.NewFiscalQuarterWithMode(fyStart, q, mode)
 			}
 		}
 		return nil, fmt.Errorf("internal: midpoint %v not in any FQ of FY starting %v", midpoint, fyStart)

--- a/impl/interpreter/period_eval_test.go
+++ b/impl/interpreter/period_eval_test.go
@@ -114,7 +114,7 @@ func TestPeriodEval_FiscalYear(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *types.Period, got %T", results[0])
 	}
-	// FY2027 with July start = Jul 1 2026 - Jun 30 2027 (Microsoft).
+	// FY2027 with July start = Jul 1 2026 - Jun 30 2027 (default end-year labeling).
 	wantStart := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
 	wantEnd := time.Date(2027, time.June, 30, 0, 0, 0, 0, time.UTC)
 	if !p.Start.Time.Equal(wantStart) {

--- a/impl/interpreter/period_eval_test.go
+++ b/impl/interpreter/period_eval_test.go
@@ -1,0 +1,298 @@
+package interpreter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/spec/types"
+)
+
+// U10 — period-bearing keywords evaluate to *types.Period.
+//
+// Pre-v2: `Q1`, `this month`, `FY2027`, `next quarter`, etc., all
+// returned *types.Date — the START of the period — and end-of /
+// start-of operators synthesized the rest from kind+context.
+//
+// v2.0: those keywords return *types.Period with both Start and End
+// populated, enabling natural Period arithmetic, Period == Period
+// comparison, and variable-bound period operators (`q = Q1; e =
+// end of q` works without further plumbing).
+//
+// True date keywords (today, tomorrow, yesterday, now) continue to
+// return *types.Date — they're points, not spans.
+
+func TestPeriodEval_QuarterNotation(t *testing.T) {
+	clock := time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC)
+	cases := []struct {
+		input              string
+		wantStartMonth     time.Month
+		wantStartDay       int
+		wantEndMonth       time.Month
+		wantEndDay         int
+		wantQuarterIndex   int
+	}{
+		{"x = Q1\n", time.January, 1, time.March, 31, 1},
+		{"x = Q2\n", time.April, 1, time.June, 30, 2},
+		{"x = Q3\n", time.July, 1, time.September, 30, 3},
+		{"x = Q4\n", time.October, 1, time.December, 31, 4},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			interp := newTestInterpreterWithClock(clock)
+			nodes, err := parser.Parse(tc.input)
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			results, err := interp.Eval(nodes)
+			if err != nil {
+				t.Fatalf("Eval: %v", err)
+			}
+			p, ok := results[0].(*types.Period)
+			if !ok {
+				t.Fatalf("expected *types.Period, got %T (%v)", results[0], results[0])
+			}
+			if p.Kind != types.PeriodCalendarQuarter {
+				t.Errorf("Kind = %v, want PeriodCalendarQuarter", p.Kind)
+			}
+			if p.QuarterIndex != tc.wantQuarterIndex {
+				t.Errorf("QuarterIndex = %d, want %d", p.QuarterIndex, tc.wantQuarterIndex)
+			}
+			if p.Start == nil || p.End == nil {
+				t.Fatalf("Start or End is nil; both must be populated")
+			}
+			if p.Start.Time.Month() != tc.wantStartMonth || p.Start.Time.Day() != tc.wantStartDay {
+				t.Errorf("Start = %v, want %v %d", p.Start.Time, tc.wantStartMonth, tc.wantStartDay)
+			}
+			if p.End.Time.Month() != tc.wantEndMonth || p.End.Time.Day() != tc.wantEndDay {
+				t.Errorf("End = %v, want %v %d", p.End.Time, tc.wantEndMonth, tc.wantEndDay)
+			}
+		})
+	}
+}
+
+func TestPeriodEval_CalendarYear(t *testing.T) {
+	interp := newTestInterpreterWithClock(testClock)
+	nodes, err := parser.Parse("x = CY2026\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	p, ok := results[0].(*types.Period)
+	if !ok {
+		t.Fatalf("expected *types.Period, got %T", results[0])
+	}
+	if p.Kind != types.PeriodCalendarYear {
+		t.Errorf("Kind = %v, want PeriodCalendarYear", p.Kind)
+	}
+	if p.Year != 2026 {
+		t.Errorf("Year = %d, want 2026", p.Year)
+	}
+	if p.Start.Time.Month() != time.January || p.Start.Time.Day() != 1 {
+		t.Errorf("Start = %v, want Jan 1", p.Start.Time)
+	}
+	if p.End.Time.Month() != time.December || p.End.Time.Day() != 31 {
+		t.Errorf("End = %v, want Dec 31", p.End.Time)
+	}
+}
+
+func TestPeriodEval_FiscalYear(t *testing.T) {
+	interp := newTestInterpreterWithClock(testClock)
+	interp.SetFiscalYearStarts(7, 1) // July 1
+	nodes, err := parser.Parse("x = FY2027\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	p, ok := results[0].(*types.Period)
+	if !ok {
+		t.Fatalf("expected *types.Period, got %T", results[0])
+	}
+	// FY2027 with July start = Jul 1 2026 - Jun 30 2027 (Microsoft).
+	wantStart := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2027, time.June, 30, 0, 0, 0, 0, time.UTC)
+	if !p.Start.Time.Equal(wantStart) {
+		t.Errorf("Start = %v, want %v", p.Start.Time, wantStart)
+	}
+	if !p.End.Time.Equal(wantEnd) {
+		t.Errorf("End = %v, want %v", p.End.Time, wantEnd)
+	}
+}
+
+func TestPeriodEval_ThisMonth(t *testing.T) {
+	clock := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+	interp := newTestInterpreterWithClock(clock)
+	nodes, err := parser.Parse("x = this month\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	p, ok := results[0].(*types.Period)
+	if !ok {
+		t.Fatalf("expected *types.Period for `this month`, got %T", results[0])
+	}
+	if p.Start.Time.Month() != time.April || p.Start.Time.Day() != 1 {
+		t.Errorf("Start = %v, want April 1", p.Start.Time)
+	}
+	if p.End.Time.Month() != time.April || p.End.Time.Day() != 30 {
+		t.Errorf("End = %v, want April 30", p.End.Time)
+	}
+}
+
+func TestPeriodEval_BareMonthName(t *testing.T) {
+	// Bare month → RelativeDateLiteral{Keyword: "this April"} (U5)
+	// → resolveMonthExpression → Period (U10).
+	clock := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+	interp := newTestInterpreterWithClock(clock)
+	nodes, err := parser.Parse("x = April\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	p, ok := results[0].(*types.Period)
+	if !ok {
+		t.Fatalf("expected *types.Period for bare month `April`, got %T (%v)", results[0], results[0])
+	}
+	if p.Start.Time.Month() != time.April || p.Start.Time.Day() != 1 {
+		t.Errorf("Start = %v, want April 1", p.Start.Time)
+	}
+	if p.End.Time.Month() != time.April || p.End.Time.Day() != 30 {
+		t.Errorf("End = %v, want April 30", p.End.Time)
+	}
+}
+
+// TestPeriodEval_TodayStaysDate — point-in-time keywords retain
+// *types.Date semantics. A test failure here would indicate a regression
+// in the Date/Period split.
+func TestPeriodEval_TodayStaysDate(t *testing.T) {
+	for _, input := range []string{
+		"x = today\n",
+		"x = tomorrow\n",
+		"x = yesterday\n",
+	} {
+		t.Run(input, func(t *testing.T) {
+			interp := newTestInterpreterWithClock(testClock)
+			nodes, err := parser.Parse(input)
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			results, err := interp.Eval(nodes)
+			if err != nil {
+				t.Fatalf("Eval: %v", err)
+			}
+			if _, ok := results[0].(*types.Date); !ok {
+				t.Errorf("expected *types.Date for %q, got %T", input, results[0])
+			}
+		})
+	}
+}
+
+// TestPeriodArithmetic_PlusFromEnd — v2.0 asymmetric arithmetic:
+// Period + Duration extends from Period.End.
+func TestPeriodArithmetic_PlusFromEnd(t *testing.T) {
+	interp := newTestInterpreterWithClock(testClock)
+	nodes, err := parser.Parse("x = Q1 + 30 days\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	d, ok := results[0].(*types.Date)
+	if !ok {
+		t.Fatalf("expected *types.Date, got %T", results[0])
+	}
+	// Q1.End = Mar 31; + 30 days = April 30.
+	want := time.Date(2026, time.April, 30, 0, 0, 0, 0, time.UTC)
+	if !d.Time.Equal(want) {
+		t.Errorf("Q1 + 30 days = %v, want %v", d.Time.Format("2006-01-02"), want.Format("2006-01-02"))
+	}
+}
+
+// TestPeriodArithmetic_MinusFromStart — Period - Duration extends
+// from Period.Start.
+func TestPeriodArithmetic_MinusFromStart(t *testing.T) {
+	interp := newTestInterpreterWithClock(testClock)
+	nodes, err := parser.Parse("x = Q1 - 5 days\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	d, ok := results[0].(*types.Date)
+	if !ok {
+		t.Fatalf("expected *types.Date, got %T", results[0])
+	}
+	// Q1.Start = Jan 1; - 5 days = Dec 27, 2025.
+	want := time.Date(2025, time.December, 27, 0, 0, 0, 0, time.UTC)
+	if !d.Time.Equal(want) {
+		t.Errorf("Q1 - 5 days = %v, want %v", d.Time.Format("2006-01-02"), want.Format("2006-01-02"))
+	}
+}
+
+// TestPeriodArithmetic_StructuralEquality — Period == Period uses
+// structural comparison: Start.Equal && End.Equal.
+func TestPeriodArithmetic_StructuralEquality(t *testing.T) {
+	interp := newTestInterpreterWithClock(testClock)
+	// Q1 vs Q1 — same period, same year (clock=2026).
+	nodes, err := parser.Parse("x = Q1 == Q1\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	b, ok := results[0].(*types.Boolean)
+	if !ok {
+		t.Fatalf("expected *types.Boolean, got %T", results[0])
+	}
+	if !b.Value {
+		t.Error("Q1 == Q1 = false, want true")
+	}
+}
+
+// TestFromArith_PeriodIsNarrowed — the `from <X>` syntax preserves
+// pre-v2 date-arithmetic semantics: the period is narrowed to its
+// Start before the duration is added. So `2 weeks from next month`
+// (clock=April) = May 1 + 14 days = May 15, NOT May 31 + 14 days.
+//
+// This is parser-side narrowing (StartOfExpr wrapping in
+// parseFromTarget) so the semantic distinction between explicit
+// `+` arithmetic (extends from end) and `from` arithmetic (extends
+// from start) is preserved.
+func TestFromArith_PeriodIsNarrowed(t *testing.T) {
+	interp := newTestInterpreterWithClock(testClock)
+	nodes, err := parser.Parse("x = 2 weeks from next month\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	d, ok := results[0].(*types.Date)
+	if !ok {
+		t.Fatalf("expected *types.Date, got %T", results[0])
+	}
+	want := time.Date(2026, time.May, 15, 0, 0, 0, 0, time.UTC)
+	if !d.Time.Equal(want) {
+		t.Errorf("2 weeks from next month = %v, want %v",
+			d.Time.Format("2006-01-02"), want.Format("2006-01-02"))
+	}
+}

--- a/impl/interpreter/period_operators_eval_test.go
+++ b/impl/interpreter/period_operators_eval_test.go
@@ -1,0 +1,346 @@
+package interpreter
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/shopspring/decimal"
+)
+
+// U13 — runtime evaluation of v2.0 period operators:
+//   - BetweenExpr  → *types.Period (PeriodCustom kind)
+//   - LengthOfExpr → *types.Duration (length of) or *types.Number (days in)
+//
+// Semantic checks (U9) reject obvious type errors at parse time;
+// these tests exercise the runtime against the cases that pass
+// semantic and verify the evaluated values.
+
+// --- BetweenExpr ---
+
+func TestEvalBetween_DateLiterals(t *testing.T) {
+	interp := newTestInterpreterWithClock(testClock)
+	nodes, err := parser.Parse("p = between Apr 15 2026 and Jul 4 2026\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	p, ok := results[0].(*types.Period)
+	if !ok {
+		t.Fatalf("expected *types.Period, got %T (%v)", results[0], results[0])
+	}
+	if p.Kind != types.PeriodCustom {
+		t.Errorf("Kind = %v, want PeriodCustom", p.Kind)
+	}
+	wantStart := time.Date(2026, time.April, 15, 0, 0, 0, 0, time.UTC)
+	wantEnd := time.Date(2026, time.July, 4, 0, 0, 0, 0, time.UTC)
+	if !p.Start.Time.Equal(wantStart) {
+		t.Errorf("Start = %v, want %v", p.Start.Time, wantStart)
+	}
+	if !p.End.Time.Equal(wantEnd) {
+		t.Errorf("End = %v, want %v", p.End.Time, wantEnd)
+	}
+}
+
+func TestEvalBetween_FromToSynonym(t *testing.T) {
+	// `from A to B` and `between A and B` must produce structurally
+	// identical Period values.
+	interp1 := newTestInterpreterWithClock(testClock)
+	interp2 := newTestInterpreterWithClock(testClock)
+
+	src1 := "p = between Apr 15 2026 and Jul 4 2026\n"
+	src2 := "p = from Apr 15 2026 to Jul 4 2026\n"
+
+	nodes1, _ := parser.Parse(src1)
+	nodes2, _ := parser.Parse(src2)
+
+	r1, err := interp1.Eval(nodes1)
+	if err != nil {
+		t.Fatalf("between Eval: %v", err)
+	}
+	r2, err := interp2.Eval(nodes2)
+	if err != nil {
+		t.Fatalf("from-to Eval: %v", err)
+	}
+
+	p1 := r1[0].(*types.Period)
+	p2 := r2[0].(*types.Period)
+	if !p1.Start.Time.Equal(p2.Start.Time) {
+		t.Errorf("Start mismatch: between=%v from-to=%v", p1.Start.Time, p2.Start.Time)
+	}
+	if !p1.End.Time.Equal(p2.End.Time) {
+		t.Errorf("End mismatch: between=%v from-to=%v", p1.End.Time, p2.End.Time)
+	}
+}
+
+func TestEvalBetween_RelativeDates(t *testing.T) {
+	clock := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+	interp := newTestInterpreterWithClock(clock)
+	nodes, err := parser.Parse("p = between today and tomorrow\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	p, ok := results[0].(*types.Period)
+	if !ok {
+		t.Fatalf("expected *types.Period, got %T", results[0])
+	}
+	if !p.Start.Time.Equal(clock) {
+		t.Errorf("Start = %v, want %v", p.Start.Time, clock)
+	}
+	if !p.End.Time.Equal(clock.AddDate(0, 0, 1)) {
+		t.Errorf("End = %v, want %v", p.End.Time, clock.AddDate(0, 0, 1))
+	}
+}
+
+func TestEvalBetween_SingleDay(t *testing.T) {
+	// start == end is the minimal valid period.
+	interp := newTestInterpreterWithClock(testClock)
+	nodes, err := parser.Parse("p = between Apr 15 2026 and Apr 15 2026\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	p := results[0].(*types.Period)
+	if !p.Start.Time.Equal(p.End.Time) {
+		t.Errorf("single-day period Start (%v) != End (%v)", p.Start.Time, p.End.Time)
+	}
+}
+
+func TestEvalBetween_EndBeforeStart(t *testing.T) {
+	// Static-detect: end < start → runtime error from NewCustomPeriod.
+	interp := newTestInterpreterWithClock(testClock)
+	nodes, err := parser.Parse("p = between Jul 4 2026 and Apr 15 2026\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	_, err = interp.Eval(nodes)
+	if err == nil {
+		t.Fatal("expected runtime error for end-before-start; got nil")
+	}
+	if !strings.Contains(err.Error(), "before") && !strings.Contains(err.Error(), "end") {
+		t.Errorf("error %q should mention end-before-start", err.Error())
+	}
+}
+
+// TestEvalBetween_PeriodInputAcceptedAsDate — `between today and
+// next month` puts a Period (next month) on the End side. The
+// evaluator narrows the Period to its Start before constructing the
+// custom period — so `between today and next month` = today to
+// next-month-start. (Mirrors the parser-side narrowing for `from`.)
+func TestEvalBetween_PeriodInputAcceptedAsDate(t *testing.T) {
+	clock := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+	interp := newTestInterpreterWithClock(clock)
+	nodes, err := parser.Parse("p = between today and next month\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	p, ok := results[0].(*types.Period)
+	if !ok {
+		t.Fatalf("expected *types.Period, got %T", results[0])
+	}
+	if !p.Start.Time.Equal(clock) {
+		t.Errorf("Start = %v, want %v (today)", p.Start.Time, clock)
+	}
+	wantEnd := time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC)
+	if !p.End.Time.Equal(wantEnd) {
+		t.Errorf("End = %v, want %v (start of next month)", p.End.Time, wantEnd)
+	}
+}
+
+// --- LengthOfExpr (length of) ---
+
+func TestEvalLengthOf_Quarter(t *testing.T) {
+	// length of Q1 = 90 days (Jan 1 - Mar 31 = 90 days inclusive).
+	interp := newTestInterpreterWithClock(testClock)
+	nodes, err := parser.Parse("d = length of Q1\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	dur, ok := results[0].(*types.Duration)
+	if !ok {
+		t.Fatalf("expected *types.Duration, got %T (%v)", results[0], results[0])
+	}
+	if !dur.Value.Equal(decimal.NewFromInt(90)) {
+		t.Errorf("Q1 length = %v, want 90", dur.Value)
+	}
+	if dur.Unit != "day" {
+		t.Errorf("unit = %q, want %q", dur.Unit, "day")
+	}
+}
+
+func TestEvalLengthOf_Month(t *testing.T) {
+	// length of April = 30 days.
+	clock := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+	interp := newTestInterpreterWithClock(clock)
+	nodes, err := parser.Parse("d = length of April\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	dur := results[0].(*types.Duration)
+	if !dur.Value.Equal(decimal.NewFromInt(30)) {
+		t.Errorf("April length = %v, want 30", dur.Value)
+	}
+}
+
+func TestEvalLengthOf_Custom(t *testing.T) {
+	interp := newTestInterpreterWithClock(testClock)
+	nodes, err := parser.Parse("d = length of (between Apr 15 2026 and Jul 4 2026)\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	dur := results[0].(*types.Duration)
+	// Apr 15 to Jul 4 inclusive = 81 days (15→30 = 16, May = 31,
+	// Jun = 30, Jul 1-4 = 4 → 16+31+30+4 = 81).
+	if !dur.Value.Equal(decimal.NewFromInt(81)) {
+		t.Errorf("custom period length = %v, want 81", dur.Value)
+	}
+}
+
+// --- LengthOfExpr (days in) ---
+
+func TestEvalDaysIn_Quarter(t *testing.T) {
+	// `days in Q1` = Number(90), not Duration.
+	interp := newTestInterpreterWithClock(testClock)
+	nodes, err := parser.Parse("n = days in Q1\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	num, ok := results[0].(*types.Number)
+	if !ok {
+		t.Fatalf("expected *types.Number, got %T (%v)", results[0], results[0])
+	}
+	if !num.Value.Equal(decimal.NewFromInt(90)) {
+		t.Errorf("days in Q1 = %v, want 90", num.Value)
+	}
+}
+
+func TestEvalDaysIn_Month(t *testing.T) {
+	clock := time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)
+	interp := newTestInterpreterWithClock(clock)
+	nodes, err := parser.Parse("n = days in April\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	num := results[0].(*types.Number)
+	if !num.Value.Equal(decimal.NewFromInt(30)) {
+		t.Errorf("days in April = %v, want 30", num.Value)
+	}
+}
+
+func TestEvalDaysIn_LeapFebruary(t *testing.T) {
+	clock := time.Date(2024, 2, 15, 0, 0, 0, 0, time.UTC) // leap year
+	interp := newTestInterpreterWithClock(clock)
+	nodes, err := parser.Parse("n = days in this month\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	num := results[0].(*types.Number)
+	if !num.Value.Equal(decimal.NewFromInt(29)) {
+		t.Errorf("days in Feb 2024 = %v, want 29 (leap)", num.Value)
+	}
+}
+
+func TestEvalDaysIn_NonLeapFebruary(t *testing.T) {
+	clock := time.Date(2025, 2, 15, 0, 0, 0, 0, time.UTC)
+	interp := newTestInterpreterWithClock(clock)
+	nodes, err := parser.Parse("n = days in this month\n")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	num := results[0].(*types.Number)
+	if !num.Value.Equal(decimal.NewFromInt(28)) {
+		t.Errorf("days in Feb 2025 = %v, want 28 (non-leap)", num.Value)
+	}
+}
+
+// TestEvalDaysIn_UsedInArithmetic — `days in cycle * 1000` exercises
+// the Number return value flowing into ordinary arithmetic. Locks the
+// brainstorm's "days in returns Number not Duration" decision.
+func TestEvalDaysIn_UsedInArithmetic(t *testing.T) {
+	interp := newTestInterpreterWithClock(testClock)
+	src := "cycle = between Apr 15 2026 and Jul 4 2026\n" +
+		"cost = days in cycle * 1000\n"
+	nodes, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	num, ok := results[1].(*types.Number)
+	if !ok {
+		t.Fatalf("expected *types.Number for cost, got %T", results[1])
+	}
+	// 81 days × 1000 = 81000.
+	if !num.Value.Equal(decimal.NewFromInt(81000)) {
+		t.Errorf("days in cycle * 1000 = %v, want 81000", num.Value)
+	}
+}
+
+// TestEvalLengthOf_VariableBound — R9 emergent capability for the
+// new operators: `q = Q1; d = length of q` works because Q1
+// evaluates to *types.Period and the variable holds it directly.
+func TestEvalLengthOf_VariableBound(t *testing.T) {
+	interp := newTestInterpreterWithClock(testClock)
+	src := "q = Q1\nd = length of q\n"
+	nodes, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("Eval: %v", err)
+	}
+	dur := results[1].(*types.Duration)
+	if !dur.Value.Equal(decimal.NewFromInt(90)) {
+		t.Errorf("length of (variable-bound Q1) = %v, want 90", dur.Value)
+	}
+}

--- a/impl/interpreter/period_test_helpers_test.go
+++ b/impl/interpreter/period_test_helpers_test.go
@@ -1,0 +1,41 @@
+package interpreter
+
+import (
+	"testing"
+
+	"github.com/CalcMark/go-calcmark/spec/types"
+)
+
+// resultStartDate returns the start Date from a result that's
+// either a Date (legacy point) or a Period (v2.0 period-bearing
+// keyword). Used by the U18 test migration to adapt assertions
+// that historically expected (*types.Date) for `Q1`, `FY2026`,
+// `this month`, etc., which now evaluate to (*types.Period).
+//
+// Tests that specifically need to verify the Period contract
+// (Start AND End populated, Kind set correctly) should
+// type-assert (*types.Period) directly rather than using this
+// helper.
+func resultStartDate(t *testing.T, r types.Type) *types.Date {
+	t.Helper()
+	if d, ok := r.(*types.Date); ok {
+		return d
+	}
+	if p, ok := r.(*types.Period); ok {
+		return p.Start
+	}
+	t.Fatalf("expected *types.Date or *types.Period; got %T (%v)", r, r)
+	return nil
+}
+
+// resultIsDateOrPeriod reports whether r is either *types.Date or
+// *types.Period. Used by tests that just want to confirm the
+// expression produced "something date-like" without caring whether
+// the v2.0 routing returns a Date or a Period.
+func resultIsDateOrPeriod(r types.Type) bool {
+	switch r.(type) {
+	case *types.Date, *types.Period:
+		return true
+	}
+	return false
+}

--- a/impl/interpreter/unit_conversion_eval.go
+++ b/impl/interpreter/unit_conversion_eval.go
@@ -70,10 +70,17 @@ func (interp *Interpreter) evalUnitConversion(u *ast.UnitConversion) (types.Type
 		return converted, nil
 	}
 
-	// Period-to-duration conversion: "Q1 in days", "this month in weeks".
-	// v2.0: period expressions evaluate to *types.Period directly; the
-	// duration is End − Start + 1 day (closed-interval, day-precision).
 	if p, ok := result.(*types.Period); ok {
+		// Period basis conversion (v2.0): `Q1 as fiscal`, `this fiscal
+		// year as calendar`, etc. Returns a *types.Period of the target
+		// basis whose dates contain the input period's midpoint.
+		if isPeriodBasisTarget(targetUnit) {
+			return interp.convertPeriodBasis(p, targetUnit)
+		}
+		// Period-to-duration conversion: "Q1 in days", "this month
+		// in weeks". v2.0: period expressions evaluate to
+		// *types.Period directly; the duration is End − Start + 1
+		// day (closed-interval, day-precision).
 		days := int(p.End.Time.Sub(p.Start.Time).Hours()/24) + 1
 		dur := &types.Duration{Value: decimal.NewFromInt(int64(days)), Unit: "day"}
 		converted, err := dur.Convert(targetUnit)

--- a/impl/interpreter/unit_conversion_eval.go
+++ b/impl/interpreter/unit_conversion_eval.go
@@ -6,6 +6,7 @@ import (
 	"github.com/CalcMark/go-calcmark/spec/ast"
 	"github.com/CalcMark/go-calcmark/spec/types"
 	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/shopspring/decimal"
 )
 
 // evalUnitConversion evaluates explicit unit conversion: "10 meters in feet"
@@ -69,13 +70,12 @@ func (interp *Interpreter) evalUnitConversion(u *ast.UnitConversion) (types.Type
 		return converted, nil
 	}
 
-	// Period-to-duration conversion: "Q1 in days", "this month in weeks"
-	// When a Date comes from a period expression, compute its duration and convert.
-	if _, ok := result.(*types.Date); ok {
-		dur, err := interp.periodToDuration(u.Quantity)
-		if err != nil {
-			return nil, err
-		}
+	// Period-to-duration conversion: "Q1 in days", "this month in weeks".
+	// v2.0: period expressions evaluate to *types.Period directly; the
+	// duration is End − Start + 1 day (closed-interval, day-precision).
+	if p, ok := result.(*types.Period); ok {
+		days := int(p.End.Time.Sub(p.Start.Time).Hours()/24) + 1
+		dur := &types.Duration{Value: decimal.NewFromInt(int64(days)), Unit: "day"}
 		converted, err := dur.Convert(targetUnit)
 		if err != nil {
 			return nil, fmt.Errorf("cannot convert period duration: %w", err)
@@ -102,6 +102,12 @@ func (interp *Interpreter) evalUnitConversion(u *ast.UnitConversion) (types.Type
 	// Standard quantity conversion
 	qty, ok := result.(*types.Quantity)
 	if !ok {
+		// Date inputs need a period to be convertible to a duration.
+		// The pre-v2 error message named "period" explicitly so users
+		// know how to fix it; preserve that wording.
+		if _, isDate := result.(*types.Date); isDate {
+			return nil, fmt.Errorf("'in' conversion requires a period (got Date — use a period like 'this month', 'Q1', or 'FQ1')")
+		}
 		return nil, fmt.Errorf("'in' conversion requires a quantity or duration, got %T", result)
 	}
 

--- a/lsp/acceptance_test.go
+++ b/lsp/acceptance_test.go
@@ -554,10 +554,14 @@ func TestFrontmatter_Unit9_ConsolidatedSession(t *testing.T) {
 	s, uri := prepareServerDoc(t, source)
 
 	// R1 — Registry shape and membership.
-	if got := len(document.Registry); got != 6 {
-		t.Errorf("R1: Registry has %d entries, want 6", got)
+	// Bumped from 6 to 7 when calendar_year_offset was added (2026-04-30).
+	if got := len(document.Registry); got != 7 {
+		t.Errorf("R1: Registry has %d entries, want 7", got)
 	}
-	for _, name := range []string{"exchange", "globals", "scale", "convert_to", "measurement", "fiscal_year_starts"} {
+	for _, name := range []string{
+		"exchange", "globals", "scale", "convert_to", "measurement",
+		"fiscal_year_starts", "calendar_year_offset",
+	} {
 		if !document.IsRegisteredKey(name) {
 			t.Errorf("R1: IsRegisteredKey(%q) = false, want true", name)
 		}

--- a/lsp/frontmatter_completion_test.go
+++ b/lsp/frontmatter_completion_test.go
@@ -12,6 +12,7 @@ import (
 // frontmatter key names. Kept inline so the test fails loudly if Registry
 // changes unexpectedly.
 var registryKeyNames = []string{
+	"calendar_year_offset",
 	"convert_to",
 	"exchange",
 	"fiscal_year_starts",

--- a/lsp/frontmatter_region_test.go
+++ b/lsp/frontmatter_region_test.go
@@ -9,12 +9,12 @@ import (
 
 func TestDetectRegion(t *testing.T) {
 	cases := []struct {
-		name       string
-		source     string
-		wantOK     bool
-		wantStart  int
-		wantEnd    int
-		wantKeys   map[int]string
+		name      string
+		source    string
+		wantOK    bool
+		wantStart int
+		wantEnd   int
+		wantKeys  map[int]string
 	}{
 		{
 			name:      "well-formed single key",
@@ -105,12 +105,12 @@ func TestClassifyCursor(t *testing.T) {
 	}
 
 	cases := []struct {
-		name     string
-		region   FrontmatterRegion
-		pos      protocol.Position
-		wantIn   bool
-		wantPos  CursorPosition
-		wantKey  string
+		name    string
+		region  FrontmatterRegion
+		pos     protocol.Position
+		wantIn  bool
+		wantPos CursorPosition
+		wantKey string
 	}{
 		{
 			name:    "outside region (after end fence)",

--- a/lsp/lexicon.go
+++ b/lsp/lexicon.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 
 	"github.com/CalcMark/go-calcmark/spec/features"
+	"github.com/CalcMark/go-calcmark/spec/lexer"
 	"github.com/CalcMark/go-calcmark/spec/types"
 	"github.com/CalcMark/go-calcmark/spec/units"
 )
@@ -37,6 +38,26 @@ type LexiconResult struct {
 	// `spec/units` automatically lights it up in the UI without a
 	// client-side mirror needing to follow.
 	UnitCategories []string `json:"unitCategories"`
+	// KeywordPhrases is the full set of keyword phrases the lexer
+	// recognizes — single-word AND multi-word — so the client
+	// tokenizer can render each as a single highlighted pill rather
+	// than splitting `this fiscal quarter` across three segments. The
+	// list is sorted longest-first so the client matches greedy
+	// without ambiguity at the front of an identifier sequence.
+	//
+	// Sources: spec/lexer DateKeywords (today, tomorrow, weekdays),
+	// RelativeDateKeywords (`this week`, `next month`, `end of`,
+	// `length of`, `between`, …), ThreeWordDateKeywords
+	// (`this fiscal quarter`, `last fiscal year`, …), plus the
+	// hand-curated ConversionKeywords list above (the single-word
+	// vocabulary like `as`, `in`, `napkin`).
+	//
+	// Synthetic parser phrases like `as a % of` are NOT in this list —
+	// they're stitched from individual keyword tokens (`as`, `%`,
+	// `of`) which each already appear here. Frontend rendering can
+	// merge adjacent keyword spans visually if the styling calls for
+	// it.
+	KeywordPhrases []string `json:"keywordPhrases"`
 }
 
 // computeLexicon returns the static lexicon. Pure: no I/O, no document
@@ -74,6 +95,7 @@ func computeLexicon() LexiconResult {
 		"and",
 		"as",
 		"at",
+		"between", // v2.0 — `between A and B`
 		"by",
 		"compounded",
 		"from",
@@ -96,9 +118,39 @@ func computeLexicon() LexiconResult {
 	unitCategories := append([]string(nil), units.Categories()...)
 	sort.Strings(unitCategories)
 
+	// Keyword phrases: union of all lexer keyword maps + the hand-
+	// curated single-word ConversionKeywords list. Sorted longest-
+	// first so the client can match greedy without ambiguity (e.g.
+	// `this fiscal quarter` matches before `this fiscal`).
+	keywordSet := make(map[string]struct{})
+	for k := range lexer.DateKeywords {
+		keywordSet[k] = struct{}{}
+	}
+	for k := range lexer.RelativeDateKeywords {
+		keywordSet[k] = struct{}{}
+	}
+	for k := range lexer.ThreeWordDateKeywords {
+		keywordSet[k] = struct{}{}
+	}
+	for _, kw := range conversionKeywords {
+		keywordSet[kw] = struct{}{}
+	}
+	keywordPhrases := make([]string, 0, len(keywordSet))
+	for k := range keywordSet {
+		keywordPhrases = append(keywordPhrases, k)
+	}
+	sort.Slice(keywordPhrases, func(i, j int) bool {
+		// Longest first; tiebreak alphabetical for stable output.
+		if len(keywordPhrases[i]) != len(keywordPhrases[j]) {
+			return len(keywordPhrases[i]) > len(keywordPhrases[j])
+		}
+		return keywordPhrases[i] < keywordPhrases[j]
+	})
+
 	return LexiconResult{
 		Functions:          functions,
 		ConversionKeywords: conversionKeywords,
 		UnitCategories:     unitCategories,
+		KeywordPhrases:     keywordPhrases,
 	}
 }

--- a/lsp/lexicon_test.go
+++ b/lsp/lexicon_test.go
@@ -83,3 +83,44 @@ func TestComputeLexicon_ExcludesControlFlowKeywords(t *testing.T) {
 		}
 	}
 }
+
+// TestComputeLexicon_KeywordPhrasesIncludesMultiWord — pins the
+// contract that the LSP exposes multi-word date / period operator
+// phrases so the client tokenizer can render each as a single
+// highlighted pill.
+func TestComputeLexicon_KeywordPhrasesIncludesMultiWord(t *testing.T) {
+	lex := computeLexicon()
+	wantSubset := []string{
+		// Multi-word date keywords
+		"this year", "next month", "last quarter",
+		"this fiscal quarter", "next fiscal year", "last fiscal quarter",
+		// Period operators
+		"end of", "start of", "length of", "days in", "between",
+		// Single-word vocabulary
+		"as", "in", "by", "of", "per", "and",
+		// Date keyword aliases
+		"fiscal quarter", "fiscal year",
+		// Single-word date keywords
+		"today", "tomorrow", "yesterday",
+	}
+	for _, kw := range wantSubset {
+		if !slices.Contains(lex.KeywordPhrases, kw) {
+			t.Errorf("KeywordPhrases missing expected entry %q", kw)
+		}
+	}
+}
+
+// TestComputeLexicon_KeywordPhrasesSortedLongestFirst — the client
+// matches greedy-longest, so ordering matters: `this fiscal quarter`
+// must precede `this fiscal` (and `this`, etc.) in the wire output.
+func TestComputeLexicon_KeywordPhrasesSortedLongestFirst(t *testing.T) {
+	lex := computeLexicon()
+	for i := 1; i < len(lex.KeywordPhrases); i++ {
+		prev, curr := lex.KeywordPhrases[i-1], lex.KeywordPhrases[i]
+		if len(prev) < len(curr) {
+			t.Errorf("KeywordPhrases not longest-first: %q (len %d) before %q (len %d)",
+				prev, len(prev), curr, len(curr))
+			break
+		}
+	}
+}

--- a/site/content/docs/language-reference.md
+++ b/site/content/docs/language-reference.md
@@ -470,6 +470,7 @@ From **highest** to **lowest**:
 | **Duration** | `5 days`, `2 weeks`, `1 year` | Value + time unit |
 | **Rate** | `100 MB/s`, `$50/hour`, `1000 req/s` | Numerator / time unit |
 | **Date** | `Jan 15 2025`, `today` | Calendar date |
+| **Period** | `Q1`, `FQ2`, `this month`, `this fiscal quarter` | Calendar / fiscal span. **Structural type — full type-system integration is forthcoming.** Today, period-bearing keywords evaluate to `Date` (the period's start day). The `Period` type is defined in `spec/types/period.go` for a future PR that will plumb it through the interpreter. Period vs Duration distinction in function arguments and Period arithmetic semantics (`Period − Period`, `Period + Duration`, equality) are tracked as open design questions — see issues against [`go-calcmark`](https://github.com/CalcMark/go-calcmark/issues). |
 
 ### Type Compatibility
 

--- a/site/content/docs/user-guide/dates.md
+++ b/site/content/docs/user-guide/dates.md
@@ -205,6 +205,26 @@ fy_end = end of this fiscal year
 
 Fiscal quarter numbering: FQ1 begins at the configured start month. With `fiscal_year_starts: july`: FQ1 = Jul-Sep, FQ2 = Oct-Dec, FQ3 = Jan-Mar, FQ4 = Apr-Jun.
 
+#### Choosing how an FY label maps to a calendar year {#calendar-year-offset}
+
+When the fiscal year does not start in January it straddles two calendar years, and different organisations label that span differently. CalcMark exposes the choice as a single frontmatter key:
+
+```yaml
+---
+fiscal_year_starts: february 2
+calendar_year_offset: before   # default — can be omitted
+---
+```
+
+The two values:
+
+- `calendar_year_offset: before` (the default). The FY label is the calendar year the FY **ends** in. Used by the Australian government year (`FY2026` = Jul 1, 2025 → Jun 30, 2026), the US tax year for non-calendar fiscal periods, and most publicly traded companies. With `fiscal_year_starts: february 2`, `FY2026` resolves to Feb 2, 2025 → Feb 1, 2026.
+- `calendar_year_offset: after`. The FY label is the calendar year the FY **starts** in. Some organisations label by the starting year — `FY2026` = Feb 2, 2026 → Feb 1, 2027 under this convention.
+
+The setting only affects labeling — the duration and quarter shape of the fiscal year are unchanged. It also has no effect when `fiscal_year_starts: january` (start year and end year are the same).
+
+If your team's CFO or finance system uses a different label than CalcMark gives you by default, set `calendar_year_offset: after` once in frontmatter and `FY2026`, `FQ1`, `this fiscal year`, etc. will all line up with what they expect.
+
 ### Quarter and Year Shorthand {#notation}
 
 CalcMark supports compact notation for quarters and years:
@@ -227,7 +247,7 @@ cy_start = CY2026
 ```
 
 - `FQ1`-`FQ4` — fiscal quarters (requires `fiscal_year_starts`)
-- `FY27` or `FY2027` — first day of fiscal year 2027. **FY is labeled by the year it ends in** (Microsoft/Australian convention). With `fiscal_year_starts: july`, FY2027 = July 1, 2026 through June 30, 2027
+- `FY27` or `FY2027` — first day of fiscal year 2027. By default the FY label is the year it **ends** in (matches the Australian government year, the US tax year, and most publicly traded companies). With `fiscal_year_starts: july`, FY2027 = July 1, 2026 through June 30, 2027. Set [`calendar_year_offset: after`](#calendar-year-offset) to label by the **starting** year instead.
 - `CY26` or `CY2026` — January 1 of calendar year 2026. Disambiguates a year from a bare number (`2026` is the number 2,026; `CY2026` is January 1, 2026)
 
 All notation is case-insensitive: `q1`, `fq3`, `fy27`, `cy2026` all work.

--- a/site/content/docs/user-guide/dates.md
+++ b/site/content/docs/user-guide/dates.md
@@ -49,9 +49,8 @@ These common patterns do **not** create dates in CalcMark:
 | `2019` | The number 2,019 | Bare numbers are never dates |
 | `Apr 1 2019 12:30PM` | Plain text (markdown) | Date + time in a single literal is not supported |
 | `10:30 AM` | Plain text (markdown) | Standalone time literals are not recognized as calculations |
-| `CY2019` | Error: undefined variable | CY/FY/Q notation is planned but not yet implemented |
 
-**To express a year as a date**, use a month name: `Jan 1 2019`.
+**To express a year as a date**, use a month name: `Jan 1 2019`, or the calendar-year shorthand: `CY2019` (resolves to January 1 — see [Quarter and Year Shorthand](#notation)).
 
 **To express a date with a time offset**, use arithmetic: `Apr 1 2019 + 12 hours + 30 minutes`. The result carries time precision internally.
 
@@ -163,6 +162,16 @@ board_deck = end of this quarter - 2 weeks
 
 `end of` resolves to the **last day** of the period. `start of` is the explicit form of the default (first day). These compose with all period types: weeks, months, years, quarters, named months, and fiscal periods.
 
+`start of` and `end of` are first-class language operators (not string-prefix sugar). The inner expression must be a **period** — a span of time the calendar can take the start or end of. Things that are NOT periods produce a clear diagnostic at type-check time:
+
+- `end of today` — `today` is a single Date, not a period. The intent is usually `end of this month` or `end of this week`.
+- `end of 5` — Numbers aren't periods.
+- `end of "Jan 15 2026"` — Date literals are points, not periods.
+
+The same rule applies to `start of`. Variable-bound forms (`q = Q1; e = end of q`) are deferred to a future release; until then, use the period literal directly: `e = end of Q1`.
+
+Period values type-check at editing time, so the LSP completion dropdown and the cmw editor's diagnostic markers surface these errors as you type.
+
 ### Fiscal Periods {#fiscal}
 
 CalcMark supports fiscal year and quarter calculations when configured via frontmatter:
@@ -222,6 +231,8 @@ cy_start = CY2026
 - `CY26` or `CY2026` — January 1 of calendar year 2026. Disambiguates a year from a bare number (`2026` is the number 2,026; `CY2026` is January 1, 2026)
 
 All notation is case-insensitive: `q1`, `fq3`, `fy27`, `cy2026` all work.
+
+In editors that integrate the CalcMark LSP, typing `Q`, `FQ`, `FY`, `CY`, `end`, `end of`, `start`, or `start of` surfaces the corresponding completions in the dropdown — including snippet-form `FY${1:NNNN}` and `CY${1:NNNN}` for the year-bearing forms, and synthesized `end of <period>` / `start of <period>` items for every parseable period kind. New period kinds added to the registry automatically light up in the completion dropdown without further wiring.
 
 `FQ1` always refers to **the current fiscal year** you are in. If you need a future fiscal quarter, use `next fiscal quarter`. The distinction:
 

--- a/site/content/docs/user-guide/frontmatter.md
+++ b/site/content/docs/user-guide/frontmatter.md
@@ -197,3 +197,25 @@ The editor results pane shows symbols next to values that have been transformed:
 | _(none)_ | Untransformed | `10 m` -- no transforms applied |
 
 For details on measurement conventions that interact with scaling and conversion, see [Units & Measurement: Measurement Conventions](../units/#measurement-conventions).
+
+### Fiscal Calendar {#fiscal-calendar}
+
+Two keys configure how `FQ1`–`FQ4`, `FYxxxx`, `this fiscal quarter`, and `this fiscal year` resolve:
+
+```yaml
+---
+fiscal_year_starts: february 2     # required for any fiscal expression
+calendar_year_offset: before       # optional — `before` (default) or `after`
+---
+```
+
+`fiscal_year_starts` accepts a month name (`july`, `oct`) or a month + day (`July 15`, `April 1`).
+
+`calendar_year_offset` controls how an FY label maps to a calendar year when the fiscal year does not start in January:
+
+- `before` (default) — FY label = year FY ends in. Matches the Australian government year, the US tax year for non-calendar fiscal periods, and most publicly traded companies. With `fiscal_year_starts: february 2`, `FY2026` = Feb 2 2025 → Feb 1 2026.
+- `after` — FY label = year FY starts in. With the same start, `FY2026` = Feb 2 2026 → Feb 1 2027.
+
+The setting only affects labeling; the duration and quarter shape of the fiscal year are unchanged. It has no effect when `fiscal_year_starts: january`.
+
+See [Dates & Time → Fiscal Periods](../dates/#fiscal) for fiscal expressions and worked examples.

--- a/spec/ast/contains_scale_ref_test.go
+++ b/spec/ast/contains_scale_ref_test.go
@@ -186,3 +186,48 @@ func TestContainsScaleRef_PreciseConversion(t *testing.T) {
 		t.Error("precise conversion with @scale should return true")
 	}
 }
+
+// EndOfExpr / StartOfExpr — composite operator nodes whose inner
+// can carry a scale reference. The transform pipeline (used for
+// `@scale` propagation) must descend through these or the scale
+// reference becomes invisible to scaling logic.
+//
+// Per the cross-layer checklist (docs/solutions/logic-errors/
+// adding-new-type-fraction-cross-layer-checklist.md): every new
+// composite AST node needs an explicit ContainsScaleRef arm even
+// if the wrapped expression rarely contains @scale in practice.
+
+func TestContainsScaleRef_EndOfExpr_InnerHasScale(t *testing.T) {
+	node := &EndOfExpr{
+		Period: &BinaryOp{
+			Operator: "*",
+			Left:     &RelativeDateLiteral{Keyword: "this quarter"},
+			Right:    &DirectiveRef{Directive: "scale"},
+		},
+	}
+	if !ContainsScaleRef(node) {
+		t.Error("EndOfExpr with @scale in inner should return true")
+	}
+}
+
+func TestContainsScaleRef_EndOfExpr_InnerNoScale(t *testing.T) {
+	node := &EndOfExpr{
+		Period: &RelativeDateLiteral{Keyword: "this quarter"},
+	}
+	if ContainsScaleRef(node) {
+		t.Error("EndOfExpr without @scale should return false")
+	}
+}
+
+func TestContainsScaleRef_StartOfExpr_InnerHasScale(t *testing.T) {
+	node := &StartOfExpr{
+		Period: &BinaryOp{
+			Operator: "+",
+			Left:     &RelativeDateLiteral{Keyword: "Q:1"},
+			Right:    &DirectiveRef{Directive: "scale"},
+		},
+	}
+	if !ContainsScaleRef(node) {
+		t.Error("StartOfExpr with @scale in inner should return true")
+	}
+}

--- a/spec/ast/nodes.go
+++ b/spec/ast/nodes.go
@@ -263,6 +263,69 @@ func (r *RelativeDateLiteral) GetRange() *Range {
 	return r.Range
 }
 
+// EndOfExpr represents `end of <period>` -- the operator that
+// resolves a Period-typed inner expression to its last day. The
+// inner is a generic Node so any expression that types as Period
+// (literal, identifier-bound period, parenthesized period
+// expression) parses uniformly. Type-check enforcement of "must be
+// a Period" lives in spec/semantic; at the AST layer the constraint
+// is unenforced -- a NumberLiteral here is well-formed but
+// semantically rejected.
+//
+// Replaces the previous string-flatten in spec/parser/primary.go
+// which produced ast.RelativeDateLiteral{Keyword: "end of " +
+// innerKeyword} -- losing the inner's structure, bounding the
+// inner-token set to an enumeration, and forcing string-prefix
+// dispatch in the interpreter.
+type EndOfExpr struct {
+	// Period is the inner expression. Must type as Period at semantic
+	// check time; runtime panics if non-Period flows through. Parser
+	// uses parsePrimary() so precedence is preserved
+	// (`end of Q1 + 1 day` parses as `(end of Q1) + 1 day`).
+	Period Node
+
+	// SourceText is the original source slice ("end of Q1") for
+	// diagnostics + AST round-tripping.
+	SourceText string
+
+	Range *Range
+}
+
+func (e *EndOfExpr) String() string {
+	if e.Period == nil {
+		return "EndOfExpr(<nil>)"
+	}
+	return fmt.Sprintf("EndOfExpr(%s)", e.Period.String())
+}
+
+func (e *EndOfExpr) GetRange() *Range {
+	return e.Range
+}
+
+// StartOfExpr is the symmetric partner of EndOfExpr -- resolves a
+// Period to its first day. Parser-level identical to EndOfExpr;
+// interpreter just returns Period.Start unchanged. Useful in
+// expressions where intent matters (e.g.
+// `forecast = start of next fiscal quarter` reads better than the
+// implicit `next fiscal quarter` even though they evaluate the
+// same).
+type StartOfExpr struct {
+	Period     Node
+	SourceText string
+	Range      *Range
+}
+
+func (s *StartOfExpr) String() string {
+	if s.Period == nil {
+		return "StartOfExpr(<nil>)"
+	}
+	return fmt.Sprintf("StartOfExpr(%s)", s.Period.String())
+}
+
+func (s *StartOfExpr) GetRange() *Range {
+	return s.Range
+}
+
 // DurationLiteral represents a duration literal: "5 days", "3 hours"
 type DurationLiteral struct {
 	Value      string // Numeric value ("5", "3.5", etc.)

--- a/spec/ast/nodes.go
+++ b/spec/ast/nodes.go
@@ -181,9 +181,21 @@ func (r *RateLiteral) GetRange() *Range {
 
 // DateLiteral represents a date literal: "Dec 25" or "Dec 25 2024"
 type DateLiteral struct {
-	Month      string  // "Dec", "December"
-	Day        string  // "25"
-	Year       *string // nil if not provided, "2024" if provided
+	Month string  // "Dec", "December"
+	Day   string  // "25" — the literal day. When the user wrote no
+	// day number in source, Day is "1" (lexer default) AND
+	// HasExplicitDay is false.
+	Year *string // nil if not provided, "2024" if provided
+
+	// HasExplicitDay reports whether a day number was scanned from
+	// the source. Discriminates `April 1` (true: specific date) from
+	// `April` (false: bare month, semantically a Period). The parser
+	// uses this flag to route bare-month forms to RelativeDateLiteral
+	// instead of DateLiteral. Lexer-driven so the discriminator
+	// doesn't depend on substring inspection of SourceText (which
+	// drifts with whitespace / future lexer changes).
+	HasExplicitDay bool
+
 	SourceText string
 	Range      *Range
 }

--- a/spec/ast/nodes.go
+++ b/spec/ast/nodes.go
@@ -515,6 +515,10 @@ func ContainsScaleRef(node Node) bool {
 		return ContainsScaleRef(n.Amount)
 	case *QuantityLiteral:
 		return ContainsScaleRef(n.Expr)
+	case *EndOfExpr:
+		return ContainsScaleRef(n.Period)
+	case *StartOfExpr:
+		return ContainsScaleRef(n.Period)
 	default:
 		// Leaf nodes: NumberLiteral, FractionLiteral, CurrencyLiteral,
 		// DateLiteral, TimeLiteral, DurationLiteral,

--- a/spec/ast/nodes.go
+++ b/spec/ast/nodes.go
@@ -326,6 +326,82 @@ func (s *StartOfExpr) GetRange() *Range {
 	return s.Range
 }
 
+// BetweenExpr represents `between A and B` / `from A to B` -- a
+// user-defined custom Period spanning two Date endpoints. Both
+// endpoints are generic Node so any expression typing as Date is
+// well-formed at the AST layer; semantic check (spec/semantic) is
+// where Date typing + start <= end constraints are enforced. The
+// runtime constructs a *types.Period (PeriodCustom kind) from the
+// evaluated endpoints.
+type BetweenExpr struct {
+	// Start is the period's first day; End is its last (closed
+	// interval, day precision -- mirrors *types.Period).
+	Start Node
+	End   Node
+
+	// SourceText is the original source slice for diagnostics +
+	// AST round-tripping.
+	SourceText string
+
+	Range *Range
+}
+
+func (b *BetweenExpr) String() string {
+	startStr := "<nil>"
+	endStr := "<nil>"
+	if b.Start != nil {
+		startStr = b.Start.String()
+	}
+	if b.End != nil {
+		endStr = b.End.String()
+	}
+	return fmt.Sprintf("BetweenExpr(%s, %s)", startStr, endStr)
+}
+
+func (b *BetweenExpr) GetRange() *Range {
+	return b.Range
+}
+
+// LengthOfExpr represents `length of <Period>` (returns Duration)
+// and `days in <Period>` (returns Number). Both forms desugar to
+// the same node; AsNumber discriminates the return shape.
+//
+// AST layer doesn't enforce that Period types as Period -- semantic
+// (spec/semantic) does. Period field is generic Node so any
+// expression typing as Period (literal, variable-bound,
+// parenthesized) parses uniformly.
+type LengthOfExpr struct {
+	// Period is the inner expression. Must type as Period at
+	// semantic check time. Parser uses parsePrimary() so precedence
+	// is preserved.
+	Period Node
+
+	// AsNumber discriminates the surface form: false = `length of`
+	// (returns Duration); true = `days in` (returns Number, integer
+	// day count).
+	AsNumber bool
+
+	// SourceText is the original source slice.
+	SourceText string
+
+	Range *Range
+}
+
+func (l *LengthOfExpr) String() string {
+	form := "length of"
+	if l.AsNumber {
+		form = "days in"
+	}
+	if l.Period == nil {
+		return fmt.Sprintf("LengthOfExpr(%s <nil>)", form)
+	}
+	return fmt.Sprintf("LengthOfExpr(%s %s)", form, l.Period.String())
+}
+
+func (l *LengthOfExpr) GetRange() *Range {
+	return l.Range
+}
+
 // DurationLiteral represents a duration literal: "5 days", "3 hours"
 type DurationLiteral struct {
 	Value      string // Numeric value ("5", "3.5", etc.)
@@ -518,6 +594,10 @@ func ContainsScaleRef(node Node) bool {
 	case *EndOfExpr:
 		return ContainsScaleRef(n.Period)
 	case *StartOfExpr:
+		return ContainsScaleRef(n.Period)
+	case *BetweenExpr:
+		return ContainsScaleRef(n.Start) || ContainsScaleRef(n.End)
+	case *LengthOfExpr:
 		return ContainsScaleRef(n.Period)
 	default:
 		// Leaf nodes: NumberLiteral, FractionLiteral, CurrencyLiteral,

--- a/spec/ast/nodes_new_test.go
+++ b/spec/ast/nodes_new_test.go
@@ -240,3 +240,66 @@ func TestDurationLiteralUnits(t *testing.T) {
 		})
 	}
 }
+
+// TestEndOfExpr_StringIncludesInner verifies the AST debug shape.
+// String() output is used in interpreter trace logs; nesting must
+// be visible.
+func TestEndOfExpr_StringIncludesInner(t *testing.T) {
+	inner := &RelativeDateLiteral{Keyword: "Q:1", SourceText: "Q1"}
+	node := &EndOfExpr{
+		Period:     inner,
+		SourceText: "end of Q1",
+		Range:      &Range{Start: Position{Line: 5, Column: 1}, End: Position{Line: 5, Column: 10}},
+	}
+	got := node.String()
+	if got == "" {
+		t.Fatal("EndOfExpr.String() should not be empty")
+	}
+	// Sanity: must mention the inner node so trace logs are useful.
+	if !contains(got, "Q") {
+		t.Errorf("EndOfExpr.String() = %q should mention inner; expected to contain %q", got, "Q")
+	}
+}
+
+// TestEndOfExpr_GetRangeReturnsStored — pin the Range pass-through.
+func TestEndOfExpr_GetRangeReturnsStored(t *testing.T) {
+	r := &Range{Start: Position{Line: 7, Column: 3}, End: Position{Line: 7, Column: 12}}
+	node := &EndOfExpr{Range: r}
+	if node.GetRange() != r {
+		t.Errorf("GetRange() should return the stored Range pointer")
+	}
+}
+
+// TestStartOfExpr_String — symmetric to EndOf.
+func TestStartOfExpr_String(t *testing.T) {
+	inner := &RelativeDateLiteral{Keyword: "FQ:1", SourceText: "FQ1"}
+	node := &StartOfExpr{Period: inner, SourceText: "start of FQ1"}
+	if got := node.String(); got == "" {
+		t.Errorf("StartOfExpr.String() should not be empty")
+	}
+}
+
+// TestEndOfExpr_PeriodFieldAcceptsAnyNode — the inner is `Node`,
+// not a constrained interface. Identifier / RelativeDateLiteral /
+// any expression-producing node must work. Type-check happens in
+// spec/semantic; at the AST layer this is unconstrained.
+func TestEndOfExpr_PeriodFieldAcceptsAnyNode(t *testing.T) {
+	cases := []Node{
+		&RelativeDateLiteral{Keyword: "Q:1"},
+		&Identifier{Name: "q"},
+		&NumberLiteral{Value: "5"}, // semantic checker rejects this; AST allows it
+	}
+	for _, inner := range cases {
+		_ = &EndOfExpr{Period: inner, SourceText: "end of <expr>"}
+	}
+}
+
+// contains is a tiny helper to avoid importing strings just for this file.
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/spec/ast/nodes_new_test.go
+++ b/spec/ast/nodes_new_test.go
@@ -303,3 +303,157 @@ func contains(s, sub string) bool {
 	}
 	return false
 }
+
+// --- U3: BetweenExpr ---
+//
+// `between A and B` / `from A to B` — user-defined custom periods.
+// AST shape mirrors EndOfExpr: Start and End are generic Node so any
+// expression types as Date at semantic check time. Variable-bound
+// (`between start_dt and end_dt`) typechecks at semantic; runtime
+// validates Date.
+
+func TestBetweenExpr_StringIncludesEndpoints(t *testing.T) {
+	start := &DateLiteral{Month: "April", Day: "1", SourceText: "April 1"}
+	end := &DateLiteral{Month: "June", Day: "30", SourceText: "June 30"}
+	node := &BetweenExpr{
+		Start:      start,
+		End:        end,
+		SourceText: "between April 1 and June 30",
+		Range:      &Range{Start: Position{Line: 3, Column: 5}, End: Position{Line: 3, Column: 30}},
+	}
+	got := node.String()
+	if got == "" {
+		t.Fatal("BetweenExpr.String() should not be empty")
+	}
+	if !contains(got, "April") {
+		t.Errorf("BetweenExpr.String() = %q should reference Start child", got)
+	}
+	if !contains(got, "June") {
+		t.Errorf("BetweenExpr.String() = %q should reference End child", got)
+	}
+}
+
+func TestBetweenExpr_GetRangeReturnsStored(t *testing.T) {
+	r := &Range{Start: Position{Line: 1, Column: 1}, End: Position{Line: 1, Column: 25}}
+	node := &BetweenExpr{Range: r}
+	if node.GetRange() != r {
+		t.Errorf("GetRange() should return the stored Range pointer")
+	}
+}
+
+// TestBetweenExpr_FieldsAcceptAnyNode — Start and End are typed
+// `Node`, not constrained at the AST layer. Semantic checks (U7)
+// enforce both endpoints type as Date.
+func TestBetweenExpr_FieldsAcceptAnyNode(t *testing.T) {
+	cases := []struct{ start, end Node }{
+		{&DateLiteral{Month: "April", Day: "1"}, &DateLiteral{Month: "June", Day: "30"}},
+		{&Identifier{Name: "start_dt"}, &Identifier{Name: "end_dt"}},
+		{&NumberLiteral{Value: "5"}, &NumberLiteral{Value: "10"}}, // semantic rejects; AST allows
+	}
+	for _, c := range cases {
+		_ = &BetweenExpr{Start: c.start, End: c.end, SourceText: "between <a> and <b>"}
+	}
+}
+
+// TestContainsScaleRef_BetweenExpr — the new arm in
+// ContainsScaleRef. Recurses into both endpoints.
+func TestContainsScaleRef_BetweenExpr(t *testing.T) {
+	scaleNode := &DirectiveRef{Directive: "scale"}
+	plain := &DateLiteral{Month: "April", Day: "1"}
+
+	// Scale on Start
+	n1 := &BetweenExpr{Start: scaleNode, End: plain}
+	if !ContainsScaleRef(n1) {
+		t.Error("BetweenExpr with @scale on Start should return true")
+	}
+	// Scale on End
+	n2 := &BetweenExpr{Start: plain, End: scaleNode}
+	if !ContainsScaleRef(n2) {
+		t.Error("BetweenExpr with @scale on End should return true")
+	}
+	// Neither
+	n3 := &BetweenExpr{Start: plain, End: plain}
+	if ContainsScaleRef(n3) {
+		t.Error("BetweenExpr without @scale should return false")
+	}
+}
+
+// --- U4: LengthOfExpr ---
+//
+// `length of <Period>` returns Duration; `days in <Period>` returns
+// Number. Both desugar to LengthOfExpr; AsNumber discriminates.
+
+func TestLengthOfExpr_StringDistinguishesForms(t *testing.T) {
+	inner := &RelativeDateLiteral{Keyword: "Q:1", SourceText: "Q1"}
+
+	asDuration := &LengthOfExpr{
+		Period:     inner,
+		AsNumber:   false,
+		SourceText: "length of Q1",
+	}
+	asNumber := &LengthOfExpr{
+		Period:     inner,
+		AsNumber:   true,
+		SourceText: "days in Q1",
+	}
+
+	got1 := asDuration.String()
+	got2 := asNumber.String()
+	if got1 == "" || got2 == "" {
+		t.Fatal("LengthOfExpr.String() should not be empty")
+	}
+	if got1 == got2 {
+		t.Errorf("LengthOfExpr.String() should distinguish AsNumber forms; got %q for both", got1)
+	}
+	// Each form must surface the inner.
+	if !contains(got1, "Q") || !contains(got2, "Q") {
+		t.Errorf("String() should reference inner Period child; got %q / %q", got1, got2)
+	}
+}
+
+func TestLengthOfExpr_GetRangeReturnsStored(t *testing.T) {
+	r := &Range{Start: Position{Line: 2, Column: 1}, End: Position{Line: 2, Column: 14}}
+	node := &LengthOfExpr{Range: r}
+	if node.GetRange() != r {
+		t.Errorf("GetRange() should return the stored Range pointer")
+	}
+}
+
+// TestLengthOfExpr_AsNumberRoundtrip — pin the discriminator field.
+func TestLengthOfExpr_AsNumberRoundtrip(t *testing.T) {
+	inner := &RelativeDateLiteral{Keyword: "Q:1"}
+	asDuration := &LengthOfExpr{Period: inner, AsNumber: false}
+	asNumber := &LengthOfExpr{Period: inner, AsNumber: true}
+	if asDuration.AsNumber {
+		t.Error("AsNumber should be false for `length of` form")
+	}
+	if !asNumber.AsNumber {
+		t.Error("AsNumber should be true for `days in` form")
+	}
+}
+
+func TestLengthOfExpr_PeriodAcceptsAnyNode(t *testing.T) {
+	cases := []Node{
+		&RelativeDateLiteral{Keyword: "Q:1"},
+		&Identifier{Name: "p"},
+		&NumberLiteral{Value: "5"}, // semantic rejects; AST allows
+	}
+	for _, inner := range cases {
+		_ = &LengthOfExpr{Period: inner, SourceText: "length of <expr>"}
+	}
+}
+
+// TestContainsScaleRef_LengthOfExpr — recurses into Period child.
+func TestContainsScaleRef_LengthOfExpr(t *testing.T) {
+	scaleNode := &DirectiveRef{Directive: "scale"}
+	plain := &RelativeDateLiteral{Keyword: "Q:1"}
+
+	n1 := &LengthOfExpr{Period: scaleNode}
+	if !ContainsScaleRef(n1) {
+		t.Error("LengthOfExpr with @scale on Period should return true")
+	}
+	n2 := &LengthOfExpr{Period: plain}
+	if ContainsScaleRef(n2) {
+		t.Error("LengthOfExpr without @scale should return false")
+	}
+}

--- a/spec/document/detector.go
+++ b/spec/document/detector.go
@@ -329,6 +329,14 @@ func (d *Detector) looksLikeCalculation(tokens []lexer.Token) bool {
 		return true
 	}
 
+	// Period-bearing operator (end of / start of) followed by a
+	// literal period-bearing token. The look-ahead is required —
+	// `end of the day` is common English prose (END_OF + IDENTIFIER)
+	// and must not classify as a calculation.
+	if isPeriodOperatorToken(first.Type) {
+		return looksLikePeriodOperator(tokens)
+	}
+
 	// Identifier alone or followed by operator/function call = calculation
 	// But multiple consecutive identifiers = prose (like "More text")
 	// Single identifier = ambiguous, treat as prose in document context
@@ -427,6 +435,42 @@ func isFunctionToken(t lexer.TokenType) bool {
 		return true
 	}
 	return false
+}
+
+// isPeriodOperatorToken reports whether t is a period-bearing
+// operator that takes a period inner expression (e.g., `end of <P>`,
+// `start of <P>`). Pure function.
+//
+// New tokens added in v2.0 (LENGTH_OF, DAYS_IN, BETWEEN) plug in
+// here as they land — the classifier dispatch in
+// looksLikeCalculation already routes through this helper.
+func isPeriodOperatorToken(t lexer.TokenType) bool {
+	switch t {
+	case lexer.END_OF, lexer.START_OF:
+		return true
+	}
+	return false
+}
+
+// looksLikePeriodOperator reports whether a token stream beginning
+// with a period-bearing operator (END_OF / START_OF / ...) is a
+// calculation. Pure function. The decision rule is look-ahead on
+// tokens[1]: literal period-bearing tokens → calc; anything else
+// (notably IDENTIFIER) → prose. This keeps `end of the day` (common
+// English) out of calc classification while admitting `end of Q1`,
+// `end of this fiscal year`, `end of April`, etc.
+//
+// IDENTIFIER is rejected even though it would unlock the R9
+// variable-bound path (`q = Q1; e = end of q`). R9 is deferred to a
+// later PR; bare-line variable-bound forms revisit when R9 lands.
+// Assignment forms (`x = end of q`) classify via the assignment
+// shape, so the deferred path isn't blocked for users who write the
+// natural `x = ...` form.
+func looksLikePeriodOperator(tokens []lexer.Token) bool {
+	if len(tokens) < 2 {
+		return false
+	}
+	return isDateToken(tokens[1].Type)
 }
 
 // hasIndentedCodePrefix checks if a line starts with 4+ spaces or a tab,

--- a/spec/document/detector.go
+++ b/spec/document/detector.go
@@ -439,14 +439,17 @@ func isFunctionToken(t lexer.TokenType) bool {
 
 // isPeriodOperatorToken reports whether t is a period-bearing
 // operator that takes a period inner expression (e.g., `end of <P>`,
-// `start of <P>`). Pure function.
+// `start of <P>`, `length of <P>`, `days in <P>`) or a custom-period
+// constructor (`between A and B`, `from A to B`). Pure function.
 //
-// New tokens added in v2.0 (LENGTH_OF, DAYS_IN, BETWEEN) plug in
-// here as they land — the classifier dispatch in
-// looksLikeCalculation already routes through this helper.
+// LENGTH_OF / DAYS_IN take Period inner — same look-ahead rule as
+// END_OF (next token must be period-bearing). BETWEEN / FROM take
+// arbitrary expressions; their first operand can be any date-bearing
+// or period-bearing token, so the same look-ahead admits them.
 func isPeriodOperatorToken(t lexer.TokenType) bool {
 	switch t {
-	case lexer.END_OF, lexer.START_OF:
+	case lexer.END_OF, lexer.START_OF, lexer.LENGTH_OF, lexer.DAYS_IN,
+		lexer.BETWEEN, lexer.FROM:
 		return true
 	}
 	return false

--- a/spec/document/detector_test.go
+++ b/spec/document/detector_test.go
@@ -774,3 +774,60 @@ func TestDetectorRegressionAllCMFiles(t *testing.T) {
 		}
 	}
 }
+
+// TestPeriodOperatorClassification — U2.5 Layer-5 gap fix.
+// Pre-v2.0, bare-line `end of Q1` and `start of Q1` were silently
+// classified as prose because END_OF / START_OF tokens were never
+// added to the calc-line classifier. These tests pin the look-ahead
+// rule: END_OF / START_OF + literal period-bearing token → calc;
+// END_OF / START_OF + IDENTIFIER → prose (so common English like
+// `end of the day` stays prose).
+func TestPeriodOperatorClassification(t *testing.T) {
+	detector := NewDetector()
+	tests := []struct {
+		name   string
+		line   string
+		isCalc bool
+	}{
+		// Calc — END_OF / START_OF followed by a period-bearing literal.
+		{"end of Q1", "end of Q1", true},
+		{"start of Q1", "start of Q1", true},
+		{"end of Q4", "end of Q4", true},
+		{"end of FQ1", "end of FQ1", true},
+		{"end of FY2027", "end of FY2027", true},
+		{"end of CY2026", "end of CY2026", true},
+		{"end of this quarter", "end of this quarter", true},
+		{"start of this quarter", "start of this quarter", true},
+		{"end of next quarter", "end of next quarter", true},
+		{"end of last fiscal year", "end of last fiscal year", true},
+		{"end of this fiscal year", "end of this fiscal year", true},
+		{"end of this fiscal quarter", "end of this fiscal quarter", true},
+		{"end of next fiscal quarter", "end of next fiscal quarter", true},
+		{"end of this month", "end of this month", true},
+		{"end of this year", "end of this year", true},
+		{"end of April", "end of April", true},     // bare month → DATE_LITERAL
+		{"start of April", "start of April", true}, // bare month → DATE_LITERAL
+
+		// Prose — END_OF / START_OF followed by IDENTIFIER (not period-bearing).
+		// This is the critical regression guard: `end of the day` is common
+		// English and must NOT be classified as a calculation.
+		{"end of the day", "end of the day", false},
+		{"start of the year", "start of the year", false},
+		{"by the end of the day", "by the end of the day", false},
+
+		// Existing assignment paths must still work (regression guard).
+		{"x = end of Q1", "x = end of Q1", true},
+		{"y = start of this fiscal year", "y = start of this fiscal year", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := detector.IsCalculation(tt.line)
+			if err != nil {
+				t.Fatalf("IsCalculation(%q): %v", tt.line, err)
+			}
+			if got != tt.isCalc {
+				t.Errorf("IsCalculation(%q) = %v, want %v", tt.line, got, tt.isCalc)
+			}
+		})
+	}
+}

--- a/spec/document/frontmatter.go
+++ b/spec/document/frontmatter.go
@@ -102,6 +102,15 @@ type Frontmatter struct {
 	// to this configuration. When nil, fiscal expressions produce an error diagnostic.
 	FiscalYearStarts *FiscalYearConfig
 
+	// CalendarYearOffset selects which calendar year an FY label refers
+	// to. CalendarYearOffsetBefore (default) labels by the calendar
+	// year the FY ENDS in (matches the Australian government year,
+	// the US tax year, and most companies). CalendarYearOffsetAfter
+	// labels by the calendar year the FY STARTS in. Only has effect
+	// when FiscalYearStarts is non-nil and the start month is not
+	// January.
+	CalendarYearOffset CalendarYearOffset
+
 	// exchangeKeys preserves insertion order of exchange rate keys.
 	// Go maps have non-deterministic iteration order; frontmatter variables
 	// must be processed in document order (they are *front* matter).
@@ -339,13 +348,27 @@ func (f *Frontmatter) HasExchangeRate(key string) bool {
 // frontmatterYAML is the intermediate struct for YAML unmarshaling.
 // This keeps the YAML structure separate from the normalized Frontmatter type.
 type frontmatterYAML struct {
-	Exchange         map[string]float64 `yaml:"exchange"`
-	Globals          map[string]string  `yaml:"globals"`
-	Scale            any                `yaml:"scale"`
-	ConvertTo        any                `yaml:"convert_to"`
-	Measurement      any                `yaml:"measurement"`
-	FiscalYearStarts string             `yaml:"fiscal_year_starts"`
+	Exchange           map[string]float64 `yaml:"exchange"`
+	Globals            map[string]string  `yaml:"globals"`
+	Scale              any                `yaml:"scale"`
+	ConvertTo          any                `yaml:"convert_to"`
+	Measurement        any                `yaml:"measurement"`
+	FiscalYearStarts   string             `yaml:"fiscal_year_starts"`
+	CalendarYearOffset string             `yaml:"calendar_year_offset"`
 }
+
+// CalendarYearOffset enumerates the FY-label conventions a document
+// can declare via the `calendar_year_offset` frontmatter key.
+type CalendarYearOffset int
+
+const (
+	// CalendarYearOffsetBefore is the default. The FY label corresponds
+	// to the calendar year the FY ENDS in.
+	CalendarYearOffsetBefore CalendarYearOffset = iota
+	// CalendarYearOffsetAfter labels by the calendar year the FY
+	// STARTS in.
+	CalendarYearOffsetAfter
+)
 
 // parseScaleConfig parses the scale field which can be a scalar number or a map
 // with factor and unit_categories keys.
@@ -726,6 +749,15 @@ func ParseFrontmatter(source string) (*Frontmatter, string, error) {
 		fm.FiscalYearStarts = fc
 	}
 
+	// Parse calendar_year_offset directive (defaults to "before").
+	if raw.CalendarYearOffset != "" {
+		off, err := parseCalendarYearOffset(raw.CalendarYearOffset)
+		if err != nil {
+			return nil, "", fmt.Errorf("frontmatter: %w", err)
+		}
+		fm.CalendarYearOffset = off
+	}
+
 	// Capture per-key source ranges for every top-level key (registered + Extra).
 	// Lines are document-relative (1-based); the YAML body starts on line 2
 	// because line 1 is the opening "---" fence, hence yamlLineOffset = 1.
@@ -798,6 +830,23 @@ func parseFiscalYearStarts(value string) (*FiscalYearConfig, error) {
 	}
 
 	return &FiscalYearConfig{Month: month, Day: day}, nil
+}
+
+// parseCalendarYearOffset parses the `calendar_year_offset` value.
+// Accepts the strings "before" (default — FY label = year FY ends in)
+// and "after" (FY label = year FY starts in). Comparison is
+// case-insensitive; surrounding whitespace is tolerated. Any other
+// value returns an error.
+func parseCalendarYearOffset(value string) (CalendarYearOffset, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "before":
+		return CalendarYearOffsetBefore, nil
+	case "after":
+		return CalendarYearOffsetAfter, nil
+	default:
+		return CalendarYearOffsetBefore, fmt.Errorf(
+			"calendar_year_offset: invalid value %q (expected 'before' or 'after')", value)
+	}
 }
 
 // parseYAMLMapping parses YAML content and returns the root mapping node.

--- a/spec/document/frontmatter_registry.go
+++ b/spec/document/frontmatter_registry.go
@@ -102,6 +102,12 @@ var Registry = []RegisteredKey{
 		Type: FrontmatterKeyStruct,
 		Doc:  "Anchors fiscal-period expressions (FQ1, FY26, 'this fiscal quarter') to a calendar start. String value naming a month, optionally with a day (e.g., 'July', 'October 1').",
 	},
+	{
+		Name:       "calendar_year_offset",
+		Type:       FrontmatterKeyEnumString,
+		Doc:        "Selects which calendar year a fiscal-year label refers to. 'before' (default) — FY label = year FY ends in (Australian government year, US tax year, most companies). 'after' — FY label = year FY starts in (some companies). Has no effect when fiscal_year_starts is January.",
+		EnumValues: []string{"before", "after"},
+	},
 }
 
 // IsRegisteredKey reports whether name is a CalcMark-grammar frontmatter key.

--- a/spec/document/frontmatter_registry_test.go
+++ b/spec/document/frontmatter_registry_test.go
@@ -133,8 +133,10 @@ func TestRegistry_IsRegisteredKey(t *testing.T) {
 	}
 }
 
-func TestRegistry_HasAllSixKnownKeys(t *testing.T) {
-	if len(Registry) != 6 {
-		t.Errorf("expected 6 registered keys, got %d", len(Registry))
+func TestRegistry_HasAllKnownKeys(t *testing.T) {
+	// Bumped from 6 to 7 when calendar_year_offset was added (2026-04-30)
+	// to support `before` (default) / `after` FY-label conventions.
+	if len(Registry) != 7 {
+		t.Errorf("expected 7 registered keys, got %d", len(Registry))
 	}
 }

--- a/spec/document/frontmatter_test.go
+++ b/spec/document/frontmatter_test.go
@@ -1700,6 +1700,64 @@ func TestFiscalYearStartsParsing(t *testing.T) {
 	}
 }
 
+// TestCalendarYearOffsetParsing pins the parse of the
+// `calendar_year_offset` frontmatter key. Default = before; explicit
+// `before` and `after` round-trip to the matching enum value;
+// invalid values error out; absent key leaves the field at its zero
+// value (CalendarYearOffsetBefore).
+func TestCalendarYearOffsetParsing(t *testing.T) {
+	tests := []struct {
+		name    string
+		source  string
+		want    CalendarYearOffset
+		wantErr bool
+	}{
+		{
+			name:   "absent → default before",
+			source: "---\nfiscal_year_starts: february 2\n---\n",
+			want:   CalendarYearOffsetBefore,
+		},
+		{
+			name:   "explicit before",
+			source: "---\nfiscal_year_starts: february 2\ncalendar_year_offset: before\n---\n",
+			want:   CalendarYearOffsetBefore,
+		},
+		{
+			name:   "explicit after",
+			source: "---\nfiscal_year_starts: february 2\ncalendar_year_offset: after\n---\n",
+			want:   CalendarYearOffsetAfter,
+		},
+		{
+			name:   "case-insensitive AFTER",
+			source: "---\nfiscal_year_starts: february 2\ncalendar_year_offset: AFTER\n---\n",
+			want:   CalendarYearOffsetAfter,
+		},
+		{
+			name:    "invalid value rejected",
+			source:  "---\nfiscal_year_starts: february 2\ncalendar_year_offset: middle\n---\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fm, _, err := ParseFrontmatter(tt.source)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if fm.CalendarYearOffset != tt.want {
+				t.Errorf("CalendarYearOffset = %v, want %v", fm.CalendarYearOffset, tt.want)
+			}
+		})
+	}
+}
+
 // TestParseFrontmatter_RegistryDrivesKnownKeyRouting pins the architectural
 // property that the Registry — not an inline allowlist — decides which
 // frontmatter keys are CalcMark-known. Every Registry entry must be routed

--- a/spec/features/completion.go
+++ b/spec/features/completion.go
@@ -250,22 +250,62 @@ var templateDateNames = map[string]bool{
 	"last month name": true,
 }
 
+// nonPeriodDateNames identifies CategoryDate features that are NOT
+// period-bearing -- they resolve to a single date or a duration, not
+// to a period the user can take the start/end of. The
+// `end of <period>` / `start of <period>` synthesis handler skips
+// these so it does not offer nonsensical combinations like
+// `end of today` or `end of days`.
+//
+// Adding a new CategoryDate feature: if it produces a Period (a
+// span the user can ask for the start or end of), do nothing -- it
+// flows through synthesis automatically. If it produces a Date
+// (point in time) or Duration (length), add it here.
+var nonPeriodDateNames = map[string]bool{
+	"today":     true,
+	"tomorrow":  true,
+	"yesterday": true,
+	"now":       true,
+	"days":      true,
+	"weeks":     true,
+	"months":    true,
+	"years":     true,
+	"from":      true,
+	"ago":       true,
+}
+
 // DateSuggestions returns date keyword suggestions matching prefix.
 // Surfaces date-related features like "today", "next Friday", "this quarter", "ago", "end of".
 func DateSuggestions(prefix string) []Suggestion {
 	prefix = strings.ToLower(prefix)
 	var suggestions []Suggestion
 
+	// `end[ of]?` / `start[ of]?` prefix triggers the synthesis
+	// handler, which prefixes the registered period set with
+	// `end of ` / `start of `. Stays in sync with the registry --
+	// new period kinds light up automatically.
+	if op, isOp, opPrefix := detectEndStartOfPrefix(prefix); isOp {
+		return synthesizeEndStartOfPeriods(op, opPrefix)
+	}
+
 	registry := DefaultRegistry()
 
 	for _, f := range registry.ByCategory(CategoryDate) {
 		if !templateDateNames[f.Name] && MatchesPrefix(f.Name, prefix) {
+			// Snippet-form entries (e.g., year-bearing literals like
+			// `FY${1:NNNN}`) carry their own InsertText. Plain literals
+			// fall back to Name. Downstream LSP layers detect the
+			// `${...}` placeholder and flag InsertTextFormat: Snippet.
+			insertText := f.InsertText
+			if insertText == "" {
+				insertText = f.Name
+			}
 			suggestions = append(suggestions, Suggestion{
 				Name:        f.Name,
 				Category:    "Date",
 				Description: f.Description,
 				Syntax:      f.Syntax,
-				InsertText:  f.Name,
+				InsertText:  insertText,
 			})
 		}
 		// Also check aliases for parseable date expressions
@@ -352,4 +392,69 @@ func firstWord(name string) string {
 		return before
 	}
 	return name
+}
+
+// detectEndStartOfPrefix recognizes the `end[ of]?` / `start[ of]?`
+// prefix shapes that trigger synthesis. Returns:
+//   - op: the operator string ("end of " or "start of ")
+//   - isOp: true when the prefix matches one of these shapes
+//   - opPrefix: the period-name prefix the user has typed beyond
+//     the operator (e.g., "Q" from "end of Q", or "" from "end")
+//
+// Word-boundary check: the prefix must be exactly `end`, `end `,
+// `end of`, `end of `, `end of <text>`, or the `start` equivalents.
+// `ending`, `endorse`, `started` etc. don't match -- the input
+// has to *be* the operator, not just begin with it.
+func detectEndStartOfPrefix(prefix string) (op string, isOp bool, opPrefix string) {
+	for _, candidate := range []string{"end", "start"} {
+		full := candidate + " of"
+		switch {
+		case prefix == candidate:
+			return candidate + " of ", true, ""
+		case strings.HasPrefix(prefix, candidate+" ") && (prefix == candidate+" " || strings.HasPrefix(prefix, full)):
+			// Either "end " (still typing) or "end of..." (typing the period).
+			rest := strings.TrimPrefix(prefix, candidate+" ")
+			rest = strings.TrimPrefix(rest, "of")
+			rest = strings.TrimPrefix(rest, " ")
+			return candidate + " of ", true, rest
+		}
+	}
+	return "", false, ""
+}
+
+// synthesizeEndStartOfPeriods emits `op + <period-name>` items for
+// every registered period-bearing CategoryDate feature whose name
+// matches `opPrefix`. The `nonPeriodDateNames` skip-list filters out
+// non-period entries (today, tomorrow, days, etc.).
+//
+// Snippet propagation: when a period entry has its own InsertText
+// (e.g., FY/CY year-bearing snippets `FY${1:2026}`), the synthesized
+// item carries `op + that-snippet` so editors still treat the year
+// as a placeholder.
+func synthesizeEndStartOfPeriods(op string, opPrefix string) []Suggestion {
+	var out []Suggestion
+	registry := DefaultRegistry()
+
+	opPrefixLower := strings.ToLower(opPrefix)
+
+	for _, f := range registry.ByCategory(CategoryDate) {
+		if templateDateNames[f.Name] || nonPeriodDateNames[f.Name] {
+			continue
+		}
+		if opPrefix != "" && !MatchesPrefix(f.Name, opPrefixLower) {
+			continue
+		}
+		insertBase := f.InsertText
+		if insertBase == "" {
+			insertBase = f.Name
+		}
+		out = append(out, Suggestion{
+			Name:        op + f.Name,
+			Category:    "Date",
+			Description: f.Description,
+			Syntax:      op + f.Syntax,
+			InsertText:  op + insertBase,
+		})
+	}
+	return out
 }

--- a/spec/features/completion.go
+++ b/spec/features/completion.go
@@ -308,12 +308,29 @@ func DateSuggestions(prefix string) []Suggestion {
 				InsertText:  insertText,
 			})
 		}
-		// Also check aliases for parseable date expressions
+		// Also check aliases for parseable date expressions.
+		//
+		// Suffix matching for relative-period aliases: when an alias
+		// starts with `this `, `next `, or `last ` followed by an
+		// abbreviation like `FQ` / `CQ` / `FY` / `CY`, also match the
+		// abbreviation prefix on its own. The lexer rejects bare `FQ`
+		// (it collides with `FQ1` notation parsing — see
+		// spec/lexer/date_keywords.go), so the user types `FQ` to
+		// search but the dropdown surfaces `this FQ` (which lexes
+		// correctly). Inserting `this FQ` rather than `FQ` keeps the
+		// completion always parseable.
 		for _, alias := range f.Aliases {
 			if templateDateNames[alias.Name] {
 				continue
 			}
-			if alias.Parseable && MatchesPrefix(alias.Name, prefix) {
+			matched := alias.Parseable && MatchesPrefix(alias.Name, prefix)
+			if !matched && alias.Parseable {
+				// Try matching the period-abbreviation suffix.
+				if suffix, ok := relativePeriodSuffix(alias.Name); ok && MatchesPrefix(suffix, prefix) {
+					matched = true
+				}
+			}
+			if matched {
 				suggestions = append(suggestions, Suggestion{
 					Name:        alias.Name,
 					Category:    "Date",
@@ -457,4 +474,29 @@ func synthesizeEndStartOfPeriods(op string, opPrefix string) []Suggestion {
 		})
 	}
 	return out
+}
+
+// relativePeriodSuffix returns the trailing abbreviation of a
+// relative-period alias name. Given `"this FQ"` returns `"FQ"`,
+// `true`. Given anything that doesn't start with a relative
+// modifier OR whose suffix is a multi-word phrase rather than a
+// short abbreviation, returns `"", false`.
+//
+// Used by DateSuggestions to surface aliases like `this FQ` when
+// the user types just `FQ`. Only matches the recognized
+// abbreviations (FQ / CQ / FY / CY) so we don't accidentally let
+// `this fiscal quarter` match the prefix `fiscal` (that already
+// matches via the alias name itself).
+func relativePeriodSuffix(aliasName string) (string, bool) {
+	for _, modifier := range []string{"this ", "next ", "last "} {
+		if !strings.HasPrefix(aliasName, modifier) {
+			continue
+		}
+		rest := aliasName[len(modifier):]
+		switch rest {
+		case "FQ", "CQ", "FY", "CY":
+			return rest, true
+		}
+	}
+	return "", false
 }

--- a/spec/features/completion_test.go
+++ b/spec/features/completion_test.go
@@ -1,6 +1,7 @@
 package features
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -510,4 +511,411 @@ func TestDateSuggestions_ThisPrefixCoversNamedPeriods(t *testing.T) {
 			t.Errorf("DateSuggestions(\"this\") missing %q; got %v", want, names)
 		}
 	}
+}
+
+// TestDateSuggestions_QPrefixSurfacesCalendarQuarters verifies that
+// typing `Q` in a calc block surfaces the four calendar-quarter
+// literal forms the lexer accepts (`Q1`-`Q4`). Reported 2026-04-28
+// against calcmark-web: typing `FQ` or `Q` produces zero suggestions
+// despite the lexer recognizing `CALENDAR_QUARTER_LITERAL` /
+// `FISCAL_QUARTER_LITERAL` and the evaluator computing them
+// correctly. This test pins the contract: every literal token kind
+// the lexer accepts must be discoverable via prefix completion.
+func TestDateSuggestions_QPrefixSurfacesCalendarQuarters(t *testing.T) {
+	required := []string{"Q1", "Q2", "Q3", "Q4"}
+	got := DateSuggestions("Q")
+	for _, want := range required {
+		found := false
+		for _, s := range got {
+			if s.Name == want {
+				found = true
+				if s.Category != "Date" {
+					t.Errorf("suggestion %q has category %q, want Date", s.Name, s.Category)
+				}
+				break
+			}
+		}
+		if !found {
+			names := make([]string, len(got))
+			for i, s := range got {
+				names[i] = s.Name
+			}
+			t.Errorf("DateSuggestions(\"Q\") missing %q; got %v", want, names)
+		}
+	}
+}
+
+// TestDateSuggestions_QPrefixCaseInsensitive — calcmark identifiers
+// are case-insensitive in the lexer (q1 → CALENDAR_QUARTER_LITERAL).
+// Completion mirrors that: lowercase prefix returns the same set.
+func TestDateSuggestions_QPrefixCaseInsensitive(t *testing.T) {
+	got := DateSuggestions("q")
+	if len(got) < 4 {
+		t.Errorf("DateSuggestions(\"q\") should return at least 4 quarter items; got %d", len(got))
+	}
+}
+
+// TestDateSuggestions_Q1ExactPrefixSelectsOne — typing the literal
+// itself narrows to exactly that entry.
+func TestDateSuggestions_Q1ExactPrefixSelectsOne(t *testing.T) {
+	got := DateSuggestions("Q1")
+	count := 0
+	for _, s := range got {
+		if s.Name == "Q1" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("DateSuggestions(\"Q1\") should match exactly one Q1 entry; got %d matches in %v", count, got)
+	}
+}
+
+// TestDateSuggestions_Q5ReturnsNothingMatchingQ5 — the parser rejects
+// Q5 (`invalid calendar quarter`); completion must not offer it.
+func TestDateSuggestions_Q5ReturnsNothingMatchingQ5(t *testing.T) {
+	got := DateSuggestions("Q5")
+	for _, s := range got {
+		if s.Name == "Q5" {
+			t.Errorf("DateSuggestions(\"Q5\") unexpectedly surfaced %q", s.Name)
+		}
+	}
+}
+
+// TestDateSuggestions_QuarterEntriesHaveDescriptionAndExample —
+// every new entry must carry the full registry shape so hover docs
+// and the LSP detail panel have content to show.
+func TestDateSuggestions_QuarterEntriesHaveDescriptionAndExample(t *testing.T) {
+	got := DateSuggestions("Q")
+	for _, s := range got {
+		if s.Name != "Q1" && s.Name != "Q2" && s.Name != "Q3" && s.Name != "Q4" {
+			continue
+		}
+		if s.Description == "" {
+			t.Errorf("calendar-quarter %q has empty Description", s.Name)
+		}
+		if s.Syntax == "" {
+			t.Errorf("calendar-quarter %q has empty Syntax", s.Name)
+		}
+	}
+}
+
+// TestDateSuggestions_FQPrefixSurfacesFiscalQuarters — typing `FQ`
+// returns FQ1-FQ4. Symmetric to Q1-Q4 but documented as requiring
+// `fiscal_year_starts` frontmatter (the interpreter raises a
+// fiscal-required runtime error otherwise; surfacing that
+// requirement in the completion description prevents user
+// confusion).
+func TestDateSuggestions_FQPrefixSurfacesFiscalQuarters(t *testing.T) {
+	required := []string{"FQ1", "FQ2", "FQ3", "FQ4"}
+	got := DateSuggestions("FQ")
+	for _, want := range required {
+		found := false
+		for _, s := range got {
+			if s.Name == want {
+				found = true
+				if s.Category != "Date" {
+					t.Errorf("suggestion %q has category %q, want Date", s.Name, s.Category)
+				}
+				if !strings.Contains(s.Description, "fiscal_year_starts") {
+					t.Errorf("FQ-family suggestion %q description should mention fiscal_year_starts; got %q",
+						s.Name, s.Description)
+				}
+				break
+			}
+		}
+		if !found {
+			names := make([]string, len(got))
+			for i, s := range got {
+				names[i] = s.Name
+			}
+			t.Errorf("DateSuggestions(\"FQ\") missing %q; got %v", want, names)
+		}
+	}
+}
+
+// TestDateSuggestions_FQ0AndFQ5RejectedByLexer — completion mirrors
+// what the lexer accepts. FQ0 / FQ5 are not valid lexer tokens, so
+// they must not appear as suggestions.
+func TestDateSuggestions_FQ0AndFQ5RejectedByLexer(t *testing.T) {
+	got := DateSuggestions("FQ")
+	for _, s := range got {
+		if s.Name == "FQ0" || s.Name == "FQ5" {
+			t.Errorf("DateSuggestions(\"FQ\") unexpectedly surfaced %q", s.Name)
+		}
+	}
+}
+
+// TestDateSuggestions_FiscalQuarterShorthandAliases — the lexer
+// already accepts `this FQ` / `next FQ` / `last FQ` (verified in
+// spec/lexer/date_tokenizer_test.go). The registry should reflect
+// that by listing them as Parseable aliases on `fiscal quarter`.
+// This test exercises the alias path through DateSuggestions.
+func TestDateSuggestions_FiscalQuarterShorthandAliases(t *testing.T) {
+	wanted := []string{"this FQ", "next FQ", "last FQ"}
+	got := DateSuggestions("this F")
+	gotNext := DateSuggestions("next F")
+	gotLast := DateSuggestions("last F")
+	all := append(append(append([]Suggestion{}, got...), gotNext...), gotLast...)
+	for _, want := range wanted {
+		found := false
+		for _, s := range all {
+			if s.Name == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			names := make([]string, len(all))
+			for i, s := range all {
+				names[i] = s.Name
+			}
+			t.Errorf("expected alias %q across this/next/last F prefix queries; got %v", want, names)
+		}
+	}
+}
+
+// TestDateSuggestions_FiscalYearShorthandAliases — `this FY` /
+// `next FY` / `last FY` are lexed equivalently; same registry
+// alias treatment.
+func TestDateSuggestions_FiscalYearShorthandAliases(t *testing.T) {
+	wanted := []string{"this FY", "next FY", "last FY"}
+	all := append(append(append(
+		[]Suggestion{},
+		DateSuggestions("this F")...),
+		DateSuggestions("next F")...),
+		DateSuggestions("last F")...)
+	for _, want := range wanted {
+		found := false
+		for _, s := range all {
+			if s.Name == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected alias %q across this/next/last F prefix queries", want)
+		}
+	}
+}
+
+// TestDateSuggestions_FYPrefixSurfacesYearLiteralSnippet — typing
+// `FY` returns a single snippet completion that fills in the current
+// calendar year as a placeholder. The lexer recognizes `FY26` and
+// `FY2026` as FISCAL_YEAR_LITERAL; this entry is the discoverability
+// path. The snippet's InsertText carries `${1:NNNN}` so editors can
+// honor it as a placeholder. The registry stores the snippet text;
+// LSP-layer conversion to `InsertTextFormat: Snippet` happens
+// downstream in lsp/completion.go (covered by U3's lsp/ test).
+func TestDateSuggestions_FYPrefixSurfacesYearLiteralSnippet(t *testing.T) {
+	got := DateSuggestions("FY")
+	found := false
+	for _, s := range got {
+		// Allow a single FY entry whose InsertText contains
+		// `${1:` (the snippet placeholder marker).
+		if s.Name == "FY" && strings.Contains(s.InsertText, "${1:") {
+			found = true
+			if !strings.Contains(s.Description, "fiscal_year_starts") {
+				t.Errorf("FY snippet description should mention fiscal_year_starts; got %q", s.Description)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("DateSuggestions(\"FY\") missing FY snippet entry with ${1:NNNN} placeholder; got %v", got)
+	}
+}
+
+// TestDateSuggestions_FYSnippetDefaultsToCurrentYear — the
+// placeholder default is `now.Year()` so users see a sensible
+// pre-filled value. Format: `FY${1:2026}`.
+func TestDateSuggestions_FYSnippetDefaultsToCurrentYear(t *testing.T) {
+	got := DateSuggestions("FY")
+	for _, s := range got {
+		if s.Name != "FY" {
+			continue
+		}
+		// The exact year value depends on `time.Now()` at call time;
+		// verify the placeholder is exactly 4 digits in the default
+		// position so editors can interpret it as a year.
+		if !strings.Contains(s.InsertText, "${1:20") {
+			t.Errorf("FY snippet should default to a current-millennium year (FY${1:20YY}); got %q", s.InsertText)
+		}
+		return
+	}
+	t.Fatalf("no FY entry returned by DateSuggestions(\"FY\")")
+}
+
+// TestDateSuggestions_CYPrefixSurfacesYearLiteralSnippet — symmetric
+// to FY, for calendar years.
+func TestDateSuggestions_CYPrefixSurfacesYearLiteralSnippet(t *testing.T) {
+	got := DateSuggestions("CY")
+	found := false
+	for _, s := range got {
+		if s.Name == "CY" && strings.Contains(s.InsertText, "${1:") {
+			found = true
+			if s.Description == "" {
+				t.Errorf("CY snippet description should be non-empty")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Errorf("DateSuggestions(\"CY\") missing CY snippet entry; got %v", got)
+	}
+}
+
+// TestDateSuggestions_EndPrefixSynthesizesEndOfPeriods — typing
+// `end` returns synthesized `end of <period>` items, derived from
+// the registered period-bearing date features. The synthesis
+// handler skips non-period date entries (`today`, `tomorrow`,
+// `days`, `weeks`, etc.) via a local skip-list. New period kinds
+// added to the registry automatically flow through this handler
+// without manual registry expansion.
+func TestDateSuggestions_EndPrefixSynthesizesEndOfPeriods(t *testing.T) {
+	got := DateSuggestions("end")
+	required := []string{
+		"end of Q1", "end of Q2", "end of Q3", "end of Q4",
+		"end of FQ1", "end of FQ2", "end of FQ3", "end of FQ4",
+		"end of this month", "end of this quarter", "end of this year",
+		"end of fiscal quarter", "end of fiscal year",
+	}
+	for _, want := range required {
+		found := false
+		for _, s := range got {
+			if s.Name == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			names := make([]string, len(got))
+			for i, s := range got {
+				names[i] = s.Name
+			}
+			t.Errorf("DateSuggestions(\"end\") missing %q; got %v", want, names)
+		}
+	}
+}
+
+// TestDateSuggestions_EndOfPrefixEquivalentToEnd — typing `end of`
+// returns the same synthesized set as `end` (the trailing space + of
+// don't change which period set is offered).
+func TestDateSuggestions_EndOfPrefixEquivalentToEnd(t *testing.T) {
+	gotEnd := DateSuggestions("end")
+	gotEndOf := DateSuggestions("end of")
+	endNames := nameSet(gotEnd)
+	endOfNames := nameSet(gotEndOf)
+	for name := range endNames {
+		if !endOfNames[name] {
+			t.Errorf("DateSuggestions(\"end of\") missing %q present in DateSuggestions(\"end\")", name)
+		}
+	}
+}
+
+// TestDateSuggestions_EndOfQNarrowsToCalendarQuarters — partial
+// prefix narrows the synthesized set.
+func TestDateSuggestions_EndOfQNarrowsToCalendarQuarters(t *testing.T) {
+	got := DateSuggestions("end of Q")
+	required := []string{"end of Q1", "end of Q2", "end of Q3", "end of Q4"}
+	for _, want := range required {
+		found := false
+		for _, s := range got {
+			if s.Name == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("DateSuggestions(\"end of Q\") missing %q", want)
+		}
+	}
+	// Should NOT include FQ-family items (different prefix).
+	for _, s := range got {
+		if strings.HasPrefix(s.Name, "end of FQ") {
+			t.Errorf("DateSuggestions(\"end of Q\") unexpectedly surfaced FQ-family item %q", s.Name)
+		}
+	}
+}
+
+// TestDateSuggestions_StartPrefixMirrorsEnd — `start of <period>`
+// is the symmetric form. Same synthesized set with `start` prefix.
+func TestDateSuggestions_StartPrefixMirrorsEnd(t *testing.T) {
+	got := DateSuggestions("start")
+	required := []string{
+		"start of Q1", "start of FQ1",
+		"start of this month", "start of fiscal quarter",
+	}
+	for _, want := range required {
+		found := false
+		for _, s := range got {
+			if s.Name == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			names := make([]string, len(got))
+			for i, s := range got {
+				names[i] = s.Name
+			}
+			t.Errorf("DateSuggestions(\"start\") missing %q; got %v", want, names)
+		}
+	}
+}
+
+// TestDateSuggestions_EndPrefixSkipsNonPeriodEntries — synthesis
+// excludes non-period date features (today, tomorrow, days, weeks)
+// because `end of today` is not a meaningful expression.
+func TestDateSuggestions_EndPrefixSkipsNonPeriodEntries(t *testing.T) {
+	got := DateSuggestions("end")
+	for _, s := range got {
+		for _, banned := range []string{
+			"end of today", "end of tomorrow", "end of yesterday", "end of now",
+			"end of days", "end of weeks", "end of months", "end of years",
+			"end of from", "end of ago",
+		} {
+			if s.Name == banned {
+				t.Errorf("DateSuggestions(\"end\") unexpectedly synthesized %q", banned)
+			}
+		}
+	}
+}
+
+// TestDateSuggestions_EndingDoesNotMatchSynthesis — the literal
+// English word `ending` should NOT trigger synthesis. The handler
+// must use a word-boundary check, not a naive prefix match.
+func TestDateSuggestions_EndingDoesNotMatchSynthesis(t *testing.T) {
+	got := DateSuggestions("ending")
+	for _, s := range got {
+		if strings.HasPrefix(s.Name, "end of") {
+			t.Errorf("DateSuggestions(\"ending\") incorrectly synthesized %q", s.Name)
+		}
+	}
+}
+
+// TestDateSuggestions_EndOfFYPropagatesSnippet — the year-bearing
+// FY/CY entries carry snippet placeholders. The synthesis handler
+// must propagate them so `end of FY${1:NNNN}` is offered (rather
+// than `end of FY` with no placeholder).
+func TestDateSuggestions_EndOfFYPropagatesSnippet(t *testing.T) {
+	got := DateSuggestions("end of FY")
+	found := false
+	for _, s := range got {
+		if s.Name == "end of FY" && strings.Contains(s.InsertText, "${1:") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("DateSuggestions(\"end of FY\") should offer snippet `end of FY${1:NNNN}`; got %v", got)
+	}
+}
+
+// nameSet — small helper for set-membership comparisons.
+func nameSet(ss []Suggestion) map[string]bool {
+	m := make(map[string]bool, len(ss))
+	for _, s := range ss {
+		m[s.Name] = true
+	}
+	return m
 }

--- a/spec/features/completion_test.go
+++ b/spec/features/completion_test.go
@@ -919,3 +919,91 @@ func nameSet(ss []Suggestion) map[string]bool {
 	}
 	return m
 }
+
+// TestDateSuggestions_BareFQSurfacesThisFQAlias — typing `FQ`
+// alone should surface `this FQ` (and friends) as suggestions
+// even though the lexer rejects bare `FQ`. The dropdown shows
+// the alias-name (`this FQ`), inserts the alias-name (which the
+// lexer accepts), and the user gets "current fiscal quarter"
+// semantics — what they probably wanted by typing FQ.
+//
+// Lexer-design context: spec/lexer/date_keywords.go:26 explicitly
+// excludes bare CY/FY/CQ/FQ from DateKeywords because they collide
+// with the notation parser (`FQ` would consume out of `FQ1`).
+// This suffix-matching path bridges the discoverability gap
+// without changing the lexer.
+func TestDateSuggestions_BareFQSurfacesThisFQAlias(t *testing.T) {
+	got := DateSuggestions("FQ")
+	wanted := []string{"this FQ", "next FQ", "last FQ"}
+	for _, want := range wanted {
+		found := false
+		for _, s := range got {
+			if s.Name == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			names := make([]string, len(got))
+			for i, s := range got {
+				names[i] = s.Name
+			}
+			t.Errorf("DateSuggestions(\"FQ\") missing %q; got %v", want, names)
+		}
+	}
+}
+
+// TestDateSuggestions_BareFYSurfacesThisFYAlias — same shape for FY.
+func TestDateSuggestions_BareFYSurfacesThisFYAlias(t *testing.T) {
+	got := DateSuggestions("FY")
+	wanted := []string{"this FY", "next FY", "last FY"}
+	for _, want := range wanted {
+		found := false
+		for _, s := range got {
+			if s.Name == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("DateSuggestions(\"FY\") missing %q", want)
+		}
+	}
+}
+
+// TestDateSuggestions_BareCYSurfacesThisCYAlias — symmetric for
+// calendar year. `CY` aliases need to be registered first; this
+// test will exercise that wiring.
+func TestDateSuggestions_BareCYSurfacesThisCYAlias(t *testing.T) {
+	got := DateSuggestions("CY")
+	want := "this CY"
+	found := false
+	for _, s := range got {
+		if s.Name == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		// CY aliases not yet registered — this test will pass once
+		// the next commit adds them. Fail loudly so it doesn't slip.
+		t.Errorf("DateSuggestions(\"CY\") missing %q (CY aliases need to be registered on `this year`)", want)
+	}
+}
+
+// TestDateSuggestions_BareCQSurfacesThisCQAlias — calendar quarter
+// abbreviation.
+func TestDateSuggestions_BareCQSurfacesThisCQAlias(t *testing.T) {
+	got := DateSuggestions("CQ")
+	want := "this CQ"
+	found := false
+	for _, s := range got {
+		if s.Name == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("DateSuggestions(\"CQ\") missing %q (CQ aliases need to be registered on `this quarter`)", want)
+	}
+}

--- a/spec/features/period_operators_test.go
+++ b/spec/features/period_operators_test.go
@@ -1,0 +1,88 @@
+package features
+
+import (
+	"strings"
+	"testing"
+)
+
+// U15 — v2.0 period operators registered in the feature catalog.
+// LSP completion + help search both pull from the same Registry, so
+// these tests pin discoverability for both surfaces.
+
+func TestRegistry_PeriodOperatorDiscoverability(t *testing.T) {
+	r := NewRegistry()
+
+	// Each query should match the named entry by exact name.
+	cases := []struct {
+		query    string
+		wantName string
+	}{
+		{"between", "between"},
+		{"length of", "length of"},
+		{"days in", "days in"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.query, func(t *testing.T) {
+			matches := r.Search(tc.query)
+			if len(matches) == 0 {
+				t.Fatalf("Search(%q) returned 0 matches; v2.0 operator should be discoverable", tc.query)
+			}
+			found := false
+			for _, m := range matches {
+				if m.Name == tc.wantName {
+					found = true
+					break
+				}
+			}
+			if !found {
+				names := make([]string, 0, len(matches))
+				for _, m := range matches {
+					names = append(names, m.Name)
+				}
+				t.Errorf("Search(%q) didn't return %q; got: %s",
+					tc.query, tc.wantName, strings.Join(names, ", "))
+			}
+		})
+	}
+}
+
+func TestRegistry_BetweenHasFromToAlias(t *testing.T) {
+	r := NewRegistry()
+	feat := r.GetByName("between")
+	if feat == nil {
+		t.Fatal("Registry missing `between` feature")
+	}
+	if len(feat.Aliases) == 0 {
+		t.Fatal("`between` should have at least one alias (from A to B)")
+	}
+	found := false
+	for _, a := range feat.Aliases {
+		if strings.Contains(strings.ToLower(a.Name), "from") &&
+			strings.Contains(strings.ToLower(a.Name), "to") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("`between` should alias `from A to B`; got aliases: %+v", feat.Aliases)
+	}
+}
+
+func TestRegistry_LengthOfHasUsefulInsertText(t *testing.T) {
+	r := NewRegistry()
+	for _, name := range []string{"length of", "days in"} {
+		t.Run(name, func(t *testing.T) {
+			feat := r.GetByName(name)
+			if feat == nil {
+				t.Fatalf("Registry missing %q", name)
+			}
+			if feat.InsertText == "" {
+				t.Errorf("%q has no InsertText; LSP completion needs a snippet placeholder", name)
+			}
+			if !strings.Contains(feat.InsertText, "${1:") {
+				t.Errorf("%q InsertText (%q) should include a snippet placeholder ${1:...}",
+					name, feat.InsertText)
+			}
+		})
+	}
+}

--- a/spec/features/registry.go
+++ b/spec/features/registry.go
@@ -617,16 +617,36 @@ func getDateFeatures() []Feature {
 			Category:    CategoryDate,
 			Syntax:      "this year",
 			Description: "First day of the current calendar year",
-			Aliases:     []Alias{{Name: "next year", Parseable: true}, {Name: "last year", Parseable: true}},
-			Example:     "this year + 6 months",
+			// `this CY` / `next CY` / `last CY` shorthand forms are
+			// already lexed (spec/lexer/date_keywords.go) but were
+			// not registered. Surfacing as Parseable aliases means
+			// typing the bare abbreviation `CY` shows these as
+			// completions (via suffix-matching in DateSuggestions),
+			// even though the lexer rejects bare `CY` due to
+			// notation-collision (CY2026).
+			Aliases: []Alias{
+				{Name: "next year", Parseable: true},
+				{Name: "last year", Parseable: true},
+				{Name: "this CY", Parseable: true},
+				{Name: "next CY", Parseable: true},
+				{Name: "last CY", Parseable: true},
+			},
+			Example: "this year + 6 months",
 		},
 		{
 			Name:        "this quarter",
 			Category:    CategoryDate,
 			Syntax:      "this quarter",
 			Description: "First day of the current calendar quarter",
-			Aliases:     []Alias{{Name: "next quarter", Parseable: true}, {Name: "last quarter", Parseable: true}},
-			Example:     "this quarter + 30 days",
+			// `this CQ` / `next CQ` / `last CQ` symmetric to CY.
+			Aliases: []Alias{
+				{Name: "next quarter", Parseable: true},
+				{Name: "last quarter", Parseable: true},
+				{Name: "this CQ", Parseable: true},
+				{Name: "next CQ", Parseable: true},
+				{Name: "last CQ", Parseable: true},
+			},
+			Example: "this quarter + 30 days",
 		},
 		{
 			Name:        "fiscal quarter",

--- a/spec/features/registry.go
+++ b/spec/features/registry.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/CalcMark/go-calcmark/spec/identifiers"
 	"github.com/CalcMark/go-calcmark/spec/types"
@@ -50,6 +51,13 @@ type Feature struct {
 	Params      []types.ParamSpec // Parameter specifications for functions (empty for non-functions)
 	Example     string            // Example usage (function-call form for help display)
 	NLExample   string            // Natural language example for autosuggest (e.g., "100 MB/s over 1 day")
+	// InsertText is the literal text to insert when the user accepts
+	// this completion. When empty, suggestion-builders fall back to
+	// `Name`. Use the LSP `${N:default}` snippet syntax for entries
+	// that need user-fillable placeholders (e.g., year-bearing date
+	// literals like `FY${1:NNNN}`). When set, downstream LSP layers
+	// flag the resulting completion item as InsertTextFormat: Snippet.
+	InsertText string
 }
 
 // Match checks if a query matches this feature (case-insensitive prefix match).
@@ -625,16 +633,131 @@ func getDateFeatures() []Feature {
 			Category:    CategoryDate,
 			Syntax:      "this fiscal quarter",
 			Description: "First day of the current fiscal quarter (requires fiscal_year_starts frontmatter)",
-			Aliases:     []Alias{{Name: "next fiscal quarter", Parseable: true}, {Name: "last fiscal quarter", Parseable: true}},
-			Example:     "this fiscal quarter",
+			// `this FQ` / `next FQ` / `last FQ` shorthand forms are
+			// already accepted by the lexer (see
+			// spec/lexer/date_tokenizer_test.go); registering them
+			// as Parseable aliases makes the registry truthful and
+			// surfaces them in completion when the user types `this F`,
+			// `next F`, or `last F`.
+			Aliases: []Alias{
+				{Name: "next fiscal quarter", Parseable: true},
+				{Name: "last fiscal quarter", Parseable: true},
+				{Name: "this FQ", Parseable: true},
+				{Name: "next FQ", Parseable: true},
+				{Name: "last FQ", Parseable: true},
+			},
+			Example: "this fiscal quarter",
 		},
 		{
 			Name:        "fiscal year",
 			Category:    CategoryDate,
 			Syntax:      "this fiscal year",
 			Description: "First day of the current fiscal year (requires fiscal_year_starts frontmatter)",
-			Aliases:     []Alias{{Name: "next fiscal year", Parseable: true}, {Name: "last fiscal year", Parseable: true}},
-			Example:     "this fiscal year",
+			Aliases: []Alias{
+				{Name: "next fiscal year", Parseable: true},
+				{Name: "last fiscal year", Parseable: true},
+				{Name: "this FY", Parseable: true},
+				{Name: "next FY", Parseable: true},
+				{Name: "last FY", Parseable: true},
+			},
+			Example: "this fiscal year",
+		},
+		// Calendar-quarter literals (Q1-Q4). The lexer recognizes
+		// `Q1`-`Q4` as CALENDAR_QUARTER_LITERAL tokens and the
+		// interpreter resolves each to the first day of the
+		// corresponding calendar quarter (Jan/Apr/Jul/Oct 1 of the
+		// current year). Registering here makes them discoverable via
+		// LSP completion -- prior to this, typing `Q` returned zero
+		// suggestions despite the language fully supporting the form.
+		// User report 2026-04-28 (calcmark-web): "I'm not sure what
+		// to even type to get FQ or FY. Or the 'end of FQ2'."
+		{
+			Name:        "Q1",
+			Category:    CategoryDate,
+			Syntax:      "Q1",
+			Description: "First day of calendar quarter 1 (Jan 1 of the current year)",
+			Example:     "end of Q1",
+		},
+		{
+			Name:        "Q2",
+			Category:    CategoryDate,
+			Syntax:      "Q2",
+			Description: "First day of calendar quarter 2 (Apr 1 of the current year)",
+			Example:     "end of Q2",
+		},
+		{
+			Name:        "Q3",
+			Category:    CategoryDate,
+			Syntax:      "Q3",
+			Description: "First day of calendar quarter 3 (Jul 1 of the current year)",
+			Example:     "end of Q3",
+		},
+		{
+			Name:        "Q4",
+			Category:    CategoryDate,
+			Syntax:      "Q4",
+			Description: "First day of calendar quarter 4 (Oct 1 of the current year)",
+			Example:     "end of Q4",
+		},
+		// Fiscal-quarter literals (FQ1-FQ4). The lexer recognizes
+		// `FQ1`-`FQ4` as FISCAL_QUARTER_LITERAL tokens. Resolution
+		// requires `fiscal_year_starts` in the document frontmatter
+		// -- evaluation without it produces a "fiscal expressions
+		// require a 'fiscal_year_starts' frontmatter key" diagnostic.
+		// Description copy mentions the requirement so users see it
+		// before typing.
+		{
+			Name:        "FQ1",
+			Category:    CategoryDate,
+			Syntax:      "FQ1",
+			Description: "First day of fiscal quarter 1 (per fiscal_year_starts frontmatter)",
+			Example:     "end of FQ1",
+		},
+		{
+			Name:        "FQ2",
+			Category:    CategoryDate,
+			Syntax:      "FQ2",
+			Description: "First day of fiscal quarter 2 (3 months after fiscal_year_starts)",
+			Example:     "end of FQ2",
+		},
+		{
+			Name:        "FQ3",
+			Category:    CategoryDate,
+			Syntax:      "FQ3",
+			Description: "First day of fiscal quarter 3 (6 months after fiscal_year_starts)",
+			Example:     "end of FQ3",
+		},
+		{
+			Name:        "FQ4",
+			Category:    CategoryDate,
+			Syntax:      "FQ4",
+			Description: "First day of fiscal quarter 4 (9 months after fiscal_year_starts; requires fiscal_year_starts frontmatter)",
+			Example:     "end of FQ4",
+		},
+		// Year-bearing literals (FY, CY) are snippet completions: the
+		// LSP placeholder `${1:<current-year>}` lets the user accept
+		// the suggestion and have the year pre-selected for editing.
+		// Year is captured at registry-build time -- this is a
+		// `sync.Once` per-process value, so the default reflects the
+		// year the process started (LSP servers re-spawn frequently
+		// enough that this stays current). Year arithmetic is the
+		// interpreter's job; the registry just makes the literal
+		// shape discoverable.
+		{
+			Name:        "FY",
+			Category:    CategoryDate,
+			Syntax:      "FY<NNNN>",
+			Description: "Specific fiscal year start (Microsoft convention: FY2027 with July start = Jul 1 2026 -> Jun 30 2027). Requires fiscal_year_starts frontmatter.",
+			InsertText:  fmt.Sprintf("FY${1:%d}", time.Now().Year()),
+			Example:     "end of FY2027",
+		},
+		{
+			Name:        "CY",
+			Category:    CategoryDate,
+			Syntax:      "CY<NNNN>",
+			Description: "Specific calendar year start (Jan 1 of that year). Two-digit forms (CY26) interpreted as 2000+NN.",
+			InsertText:  fmt.Sprintf("CY${1:%d}", time.Now().Year()),
+			Example:     "end of CY2026",
 		},
 	}
 }

--- a/spec/features/registry.go
+++ b/spec/features/registry.go
@@ -767,7 +767,7 @@ func getDateFeatures() []Feature {
 			Name:        "FY",
 			Category:    CategoryDate,
 			Syntax:      "FY<NNNN>",
-			Description: "Specific fiscal year start (Microsoft convention: FY2027 with July start = Jul 1 2026 -> Jun 30 2027). Requires fiscal_year_starts frontmatter.",
+			Description: "Specific fiscal year start. Default labeling is by the year the FY ENDS in (matches the Australian government year, US tax year, and most publicly traded companies): FY2027 with July start = Jul 1 2026 -> Jun 30 2027. Set 'calendar_year_offset: after' in frontmatter to label by start year instead. Requires fiscal_year_starts frontmatter.",
 			InsertText:  fmt.Sprintf("FY${1:%d}", time.Now().Year()),
 			Example:     "end of FY2027",
 		},
@@ -1189,6 +1189,25 @@ func getFrontmatterFeatures() []Feature {
 				"\"troy\" mass is for precious metals (1 troy oz = 31.10g). " +
 				"Optional strict: true/false controls whether formatter annotates bare ambiguous units in output.",
 			Example: "measurement:\n  volume: imperial\n  mass: troy",
+		},
+		{
+			Name:     "fiscal_year_starts",
+			Category: CategoryFrontmatter,
+			Syntax:   "fiscal_year_starts: <Month> [<Day>]",
+			Description: "Anchors fiscal-period expressions (FQ1, FY26, 'this fiscal quarter') to a calendar start. " +
+				"Accepts a month name (january through december, or short forms jul/oct), optionally followed by a day of the month (defaults to 1). " +
+				"Without this key, all fiscal expressions error out.",
+			Example: "fiscal_year_starts: July 1",
+		},
+		{
+			Name:     "calendar_year_offset",
+			Category: CategoryFrontmatter,
+			Syntax:   "calendar_year_offset: before|after",
+			Description: "Selects which calendar year a fiscal-year label refers to. " +
+				"'before' (default) — FY label = year FY ends in (Australian government year, US tax year, most publicly traded companies). " +
+				"'after' — FY label = year FY starts in (some companies). " +
+				"Has no effect when fiscal_year_starts is January.",
+			Example: "calendar_year_offset: after",
 		},
 		{
 			Name:        "@scale",

--- a/spec/features/registry.go
+++ b/spec/features/registry.go
@@ -779,6 +779,37 @@ func getDateFeatures() []Feature {
 			InsertText:  fmt.Sprintf("CY${1:%d}", time.Now().Year()),
 			Example:     "end of CY2026",
 		},
+		// v2.0 period operators: between A and B / from A to B
+		// construct a custom Period; length of / days in measure a
+		// Period's span. Discoverable via LSP completion so users
+		// don't have to guess the surface forms.
+		{
+			Name:        "between",
+			Category:    CategoryDate,
+			Syntax:      "between <date1> and <date2>",
+			Description: "Construct a custom Period spanning two dates (closed interval, inclusive). end >= start required.",
+			InsertText:  "between ${1:Apr 15 2026} and ${2:Jul 4 2026}",
+			Aliases: []Alias{
+				{Name: "from A to B", Parseable: true, Example: "from Apr 15 2026 to Jul 4 2026"},
+			},
+			Example: "between Apr 15 2026 and Jul 4 2026",
+		},
+		{
+			Name:        "length of",
+			Category:    CategoryDate,
+			Syntax:      "length of <period>",
+			Description: "Length of a period as a Duration in days (closed-interval, inclusive). Composes with duration arithmetic.",
+			InsertText:  "length of ${1:Q1}",
+			Example:     "length of Q1",
+		},
+		{
+			Name:        "days in",
+			Category:    CategoryDate,
+			Syntax:      "days in <period>",
+			Description: "Number of days in a period (integer count, closed-interval). Returns Number for use in arithmetic.",
+			InsertText:  "days in ${1:April}",
+			Example:     "days in April",
+		},
 	}
 }
 

--- a/spec/features/registry_test.go
+++ b/spec/features/registry_test.go
@@ -266,16 +266,22 @@ func TestRegistry_FrontmatterCategory(t *testing.T) {
 	r := NewRegistry()
 	features := r.ByCategory(CategoryFrontmatter)
 
-	if len(features) != 5 {
-		t.Errorf("expected 5 frontmatter features, got %d", len(features))
+	// Bumped from 5 to 7 when fiscal_year_starts and
+	// calendar_year_offset were added to the features registry
+	// (they were already in the document Registry but were missing
+	// from the docs feature-table). 2026-04-30.
+	if len(features) != 7 {
+		t.Errorf("expected 7 frontmatter features, got %d", len(features))
 	}
 
 	expected := map[string]bool{
-		"exchange":    false,
-		"globals":     false,
-		"scale":       false,
-		"convert_to":  false,
-		"measurement": false,
+		"exchange":             false,
+		"globals":              false,
+		"scale":                false,
+		"convert_to":           false,
+		"measurement":          false,
+		"fiscal_year_starts":   false,
+		"calendar_year_offset": false,
 	}
 	for _, f := range features {
 		if _, ok := expected[f.Name]; !ok {

--- a/spec/lexer/date_keywords.go
+++ b/spec/lexer/date_keywords.go
@@ -58,6 +58,16 @@ var RelativeDateKeywords = map[string]TokenType{
 	"length of": LENGTH_OF, // `length of <Period>` → Duration
 	"days in":   DAYS_IN,   // `days in <Period>` → Number
 
+	// Bare-form fiscal period aliases. `end of fiscal quarter` reads
+	// naturally in English; users already configure fiscal_year_starts
+	// in frontmatter, so the implied "this" is unambiguous. Single-word
+	// forms (`quarter`, `year`, `month`, `week`) stay as identifiers
+	// because they conflict with common variable names; the multi-word
+	// fiscal phrases use a space and don't collide with snake_case
+	// variable conventions.
+	"fiscal quarter": DATE_THIS_FISCAL_QUARTER,
+	"fiscal year":    DATE_THIS_FISCAL_YEAR,
+
 	// Calendar quarters
 	"this quarter": DATE_THIS_QUARTER,
 	"next quarter": DATE_NEXT_QUARTER,

--- a/spec/lexer/date_keywords.go
+++ b/spec/lexer/date_keywords.go
@@ -54,6 +54,10 @@ var RelativeDateKeywords = map[string]TokenType{
 	"start of": START_OF,
 	"end of":   END_OF,
 
+	// v2.0 Period operators
+	"length of": LENGTH_OF, // `length of <Period>` → Duration
+	"days in":   DAYS_IN,   // `days in <Period>` → Number
+
 	// Calendar quarters
 	"this quarter": DATE_THIS_QUARTER,
 	"next quarter": DATE_NEXT_QUARTER,

--- a/spec/lexer/date_tokenizer.go
+++ b/spec/lexer/date_tokenizer.go
@@ -206,6 +206,7 @@ func (l *Lexer) readDateLiteral() Token {
 
 	var day string
 	var year string
+	var hasExplicitDay bool
 
 	// Try to read day (number)
 	if unicode.IsDigit(l.currentChar()) {
@@ -214,12 +215,13 @@ func (l *Lexer) readDateLiteral() Token {
 
 		// Check if this number is a year (4 digits) or a day
 		if len(numStr) == 4 {
-			// It's a year: "January 2026"
+			// It's a year: "January 2026" — no day number scanned.
 			year = numStr
 			day = "1" // Default to 1st
 		} else {
 			// It's a day: "January 15"
 			day = numStr
+			hasExplicitDay = true
 
 			// Try to read year (4-digit number)
 			if unicode.IsDigit(l.currentChar()) {
@@ -233,13 +235,21 @@ func (l *Lexer) readDateLiteral() Token {
 		day = "1"
 	}
 
-	// Combine into value: "month:day:year"
+	// Combine into value: "month:day:year:hasExplicitDay" where
+	// the last field is "1" or "0". Parser splits by ":" and reads
+	// parts[3] when present; legacy callers reading parts[0..2] are
+	// unaffected.
+	flag := "0"
+	if hasExplicitDay {
+		flag = "1"
+	}
 	value := month + ":" + day
 	if year != "" {
 		value += ":" + year
 	} else {
 		value += ":"
 	}
+	value += ":" + flag
 
 	sourceText := string(l.text[startPos:l.pos])
 

--- a/spec/lexer/date_tokenizer.go
+++ b/spec/lexer/date_tokenizer.go
@@ -5,6 +5,30 @@ import (
 	"unicode"
 )
 
+// isPotentialNotationFollow reports whether the rune at pos is a
+// digit AND the matched phrase ends with a notation prefix (FQ /
+// CQ / FY / CY). This indicates the user intends notation literal
+// (FQ1, CY2026) and we should NOT consume the matched phrase
+// keyword. Lowercased compare on the trailing two letters of the
+// phrase.
+func isPotentialNotationFollow(text []rune, pos int, phrase string) bool {
+	if pos >= len(text) {
+		return false
+	}
+	if !unicode.IsDigit(text[pos]) {
+		return false
+	}
+	if len(phrase) < 2 {
+		return false
+	}
+	tail := strings.ToLower(phrase[len(phrase)-2:])
+	switch tail {
+	case "fq", "cq", "fy", "cy":
+		return true
+	}
+	return false
+}
+
 // tryReadDateKeyword attempts to read a date keyword (today, tomorrow, etc.)
 // Returns token type and true if matched, otherwise 0 and false
 // Performance: O(1) map lookups
@@ -19,12 +43,25 @@ func (l *Lexer) tryReadDateKeyword() (TokenType, bool) {
 		return tokenType, true
 	}
 
-	// Try two-word phrases (this week, next month, last year)
+	// Try two-word phrases (this week, next month, last year). When
+	// the phrase ends with a notation prefix (FQ, CQ, FY, CY) and is
+	// followed immediately by a digit, do NOT match — `next FQ1`
+	// means "FQ1 of next FY" (notation literal), not the bare-phrase
+	// `next FQ` keyword. Without this guard the lexer greedily eats
+	// `next FQ` and leaves `1` dangling as a NUMBER.
 	twoWords := l.peekTwoWords()
 	if tokenType, ok := RelativeDateKeywords[strings.ToLower(twoWords)]; ok {
-		// Consume both words
-		l.pos = startPos + len([]rune(twoWords))
-		return tokenType, true
+		consumed := len([]rune(twoWords))
+		nextPos := startPos + consumed
+		// Peek the rune after the matched phrase. Reject the match if
+		// it's a digit and the second word is a 2-char notation prefix
+		// — covers `next FQ1`, `last CY26`, `this FY2027`, etc.
+		if isPotentialNotationFollow(l.text, nextPos, twoWords) {
+			// Fall through to single-word match below.
+		} else {
+			l.pos = startPos + consumed
+			return tokenType, true
+		}
 	}
 
 	// Try three-word phrases (this fiscal quarter, next fiscal year)

--- a/spec/lexer/date_tokenizer_test.go
+++ b/spec/lexer/date_tokenizer_test.go
@@ -64,17 +64,22 @@ func TestDateKeywordTokenization(t *testing.T) {
 	}
 }
 
-// TestDateLiteralTokenization tests date literal recognition
+// TestDateLiteralTokenization tests date literal recognition.
+// Token Value format (v2.0): "Month:Day:Year:HasExplicitDay" where
+// the trailing field is "1" when the user wrote a day number in
+// source, "0" otherwise. Discriminator drives the parser's choice
+// between DateLiteral (specific date) and RelativeDateLiteral (bare
+// month → Period). See U5 in the v2.0 plan.
 func TestDateLiteralTokenization(t *testing.T) {
 	tests := []struct {
 		input         string
-		expectedValue string // Format: "Month:Day:Year"
+		expectedValue string // Format: "Month:Day:Year:HasExplicitDay"
 	}{
-		{"Dec 12", "December:12:"},
-		{"December 25", "December:25:"},
-		{"Dec 12 2026", "December:12:2026"},
-		{"December 25 2025", "December:25:2025"},
-		{"January 2026", "January:1:2026"},
+		{"Dec 12", "December:12::1"},
+		{"December 25", "December:25::1"},
+		{"Dec 12 2026", "December:12:2026:1"},
+		{"December 25 2025", "December:25:2025:1"},
+		{"January 2026", "January:1:2026:0"}, // year-only, no explicit day
 	}
 
 	for _, tt := range tests {

--- a/spec/lexer/lexer.go
+++ b/spec/lexer/lexer.go
@@ -42,6 +42,7 @@ var ReservedKeywords = map[string]TokenType{
 	"over":    OVER,    // Rate accumulation: "100 MB/s over 1 day"
 	"with":    WITH,    // Capacity planning (legacy): "10000 req/s with 450 req/s"
 	// NOTE: "downtime" is NOT a reserved keyword - checked contextually in parser
+	"between":  BETWEEN, // v2.0 Period: `between A and B` — breaking change, was an identifier pre-v2.0
 	"while":    WHILE,
 	"return":   RETURN,
 	"break":    BREAK,

--- a/spec/lexer/period_keywords_test.go
+++ b/spec/lexer/period_keywords_test.go
@@ -1,0 +1,151 @@
+package lexer_test
+
+import (
+	"testing"
+
+	"github.com/CalcMark/go-calcmark/spec/lexer"
+)
+
+// U6 — new period-operator keywords for v2.0:
+//   - `between`           → BETWEEN          (single-word reserved)
+//   - `length of`         → LENGTH_OF        (multi-word, after `end of` pattern)
+//   - `days in`           → DAYS_IN          (multi-word)
+//
+// `between` becomes a v2.0 breaking change: any user variable named
+// `between` will fail to parse. Migration diagnostic for that case
+// lives in U7 (parser).
+//
+// `to` stays as a ContextualKeyword (growth-NL: `depreciate ... to
+// 5000`); the period synonym `from A to B` is parser-side
+// disambiguation in U7, not a lexer keyword.
+
+func tokenize(t *testing.T, input string) []lexer.Token {
+	t.Helper()
+	l := lexer.NewLexer(input)
+	tokens, err := l.Tokenize()
+	if err != nil {
+		t.Fatalf("Tokenize(%q): %v", input, err)
+	}
+	return tokens
+}
+
+// firstToken returns tokens[0] for a single-token input. Skips the
+// trailing EOF that NewLexer / Tokenize always appends.
+func firstToken(t *testing.T, input string) lexer.Token {
+	t.Helper()
+	tokens := tokenize(t, input)
+	if len(tokens) < 1 {
+		t.Fatalf("Tokenize(%q) returned 0 tokens", input)
+	}
+	return tokens[0]
+}
+
+func TestLexer_BetweenKeyword(t *testing.T) {
+	cases := []string{"between", "BETWEEN", "Between"}
+	for _, input := range cases {
+		t.Run(input, func(t *testing.T) {
+			got := firstToken(t, input)
+			if got.Type != lexer.BETWEEN {
+				t.Errorf("Tokenize(%q)[0].Type = %v, want BETWEEN", input, got.Type)
+			}
+		})
+	}
+}
+
+func TestLexer_LengthOfKeyword(t *testing.T) {
+	cases := []string{"length of", "Length Of", "LENGTH OF"}
+	for _, input := range cases {
+		t.Run(input, func(t *testing.T) {
+			got := firstToken(t, input)
+			if got.Type != lexer.LENGTH_OF {
+				t.Errorf("Tokenize(%q)[0].Type = %v, want LENGTH_OF", input, got.Type)
+			}
+		})
+	}
+}
+
+func TestLexer_DaysInKeyword(t *testing.T) {
+	cases := []string{"days in", "Days In", "DAYS IN"}
+	for _, input := range cases {
+		t.Run(input, func(t *testing.T) {
+			got := firstToken(t, input)
+			if got.Type != lexer.DAYS_IN {
+				t.Errorf("Tokenize(%q)[0].Type = %v, want DAYS_IN", input, got.Type)
+			}
+		})
+	}
+}
+
+// TestLexer_NewKeywordsRequireWordBoundary — the new keywords must
+// not match prefixes of longer identifiers. A user variable named
+// `betweens` or `lengths` continues to lex as IDENTIFIER (other
+// migration concerns aside; `between` itself is the v2.0 break).
+func TestLexer_NewKeywordsRequireWordBoundary(t *testing.T) {
+	cases := []struct {
+		input   string
+		notType lexer.TokenType
+	}{
+		{"betweens", lexer.BETWEEN},
+		{"betwixt", lexer.BETWEEN},
+		{"lengths", lexer.LENGTH_OF},
+		{"lengthof", lexer.LENGTH_OF}, // no space → not the multi-word keyword
+		{"daysin", lexer.DAYS_IN},     // no space → not the multi-word keyword
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			got := firstToken(t, tc.input)
+			if got.Type == tc.notType {
+				t.Errorf("Tokenize(%q)[0].Type = %v, must NOT be %v (word-boundary)",
+					tc.input, got.Type, tc.notType)
+			}
+		})
+	}
+}
+
+// TestLexer_BackwardCompat_DurationFromKeyword — the existing
+// `2 days from today` flow must keep working. `days` here is part
+// of the duration literal, not the start of `days in`.
+func TestLexer_BackwardCompat_DurationFromKeyword(t *testing.T) {
+	tokens := tokenize(t, "2 days from today")
+	// Expected: DURATION_LITERAL, FROM, DATE_TODAY, EOF
+	if len(tokens) < 3 {
+		t.Fatalf("expected at least 3 tokens, got %d: %+v", len(tokens), tokens)
+	}
+	if tokens[0].Type != lexer.DURATION_LITERAL {
+		t.Errorf("tokens[0].Type = %v, want DURATION_LITERAL", tokens[0].Type)
+	}
+	if tokens[1].Type != lexer.FROM {
+		t.Errorf("tokens[1].Type = %v, want FROM", tokens[1].Type)
+	}
+	if tokens[2].Type != lexer.DATE_TODAY {
+		t.Errorf("tokens[2].Type = %v, want DATE_TODAY", tokens[2].Type)
+	}
+	for _, tok := range tokens {
+		if tok.Type == lexer.DAYS_IN {
+			t.Errorf("`days from today` must not lex as DAYS_IN; got %+v", tok)
+		}
+	}
+}
+
+// TestLexer_BackwardCompat_LengthAlone — `length` without `of`
+// stays as an IDENTIFIER. Avoids accidentally consuming user
+// variables / function names that happen to start with `length`.
+func TestLexer_BackwardCompat_LengthAlone(t *testing.T) {
+	tokens := tokenize(t, "length")
+	if len(tokens) < 1 {
+		t.Fatalf("expected at least 1 token")
+	}
+	if tokens[0].Type == lexer.LENGTH_OF {
+		t.Errorf("bare `length` must not lex as LENGTH_OF; got %+v", tokens[0])
+	}
+}
+
+// TestLexer_BetweenIsReserved — once between is a keyword, it
+// classifies as a reserved keyword token (used by the parser to
+// surface the `between = 50` migration diagnostic).
+func TestLexer_BetweenIsReserved(t *testing.T) {
+	tok := firstToken(t, "between")
+	if !lexer.IsReservedKeywordToken(tok.Type) {
+		t.Errorf("BETWEEN should be a reserved keyword token (so parser can flag `between = 50` as a migration error)")
+	}
+}

--- a/spec/lexer/token.go
+++ b/spec/lexer/token.go
@@ -134,8 +134,11 @@ const (
 	AGO // "ago" — as in "2 weeks ago"
 
 	// Period modifier keywords
-	START_OF // "start of" — explicit form of "this quarter" (resolves to first day)
-	END_OF   // "end of" — as in "end of this quarter" (resolves to last day)
+	START_OF  // "start of" — explicit form of "this quarter" (resolves to first day)
+	END_OF    // "end of" — as in "end of this quarter" (resolves to last day)
+	BETWEEN   // "between" — `between A and B` constructs a custom Period (v2.0)
+	LENGTH_OF // "length of" — `length of <Period>` returns Duration (v2.0)
+	DAYS_IN   // "days in" — `days in <Period>` returns Number (v2.0)
 
 	// Quarter keywords
 	DATE_THIS_QUARTER // "this quarter"
@@ -343,6 +346,12 @@ func (tt TokenType) String() string {
 		return "START_OF"
 	case END_OF:
 		return "END_OF"
+	case BETWEEN:
+		return "BETWEEN"
+	case LENGTH_OF:
+		return "LENGTH_OF"
+	case DAYS_IN:
+		return "DAYS_IN"
 	case DATE_THIS_QUARTER:
 		return "DATE_THIS_QUARTER"
 	case DATE_NEXT_QUARTER:

--- a/spec/parser/end_of_expr_test.go
+++ b/spec/parser/end_of_expr_test.go
@@ -1,0 +1,255 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/CalcMark/go-calcmark/spec/ast"
+)
+
+// parseFirstStmt extracts the first statement's expression body
+// from a calc-line input. Most parser tests need just one
+// expression; this helper keeps test bodies focused on AST shape.
+func parseFirstStmt(t *testing.T, input string) ast.Node {
+	t.Helper()
+	nodes, err := Parse(input)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", input, err)
+	}
+	if len(nodes) == 0 {
+		t.Fatalf("Parse(%q) returned 0 nodes", input)
+	}
+	// Top-level node may be Assignment, ExpressionStmt, or BinaryOp
+	// depending on the input. Walk into common wrappers to get the
+	// underlying expression. Tests inspect specific paths.
+	return nodes[0]
+}
+
+// expressionFromAssignment extracts the right-hand-side expression
+// from `name = expr`. Used for tests that pin AST shape against an
+// assignment-form input.
+func expressionFromAssignment(t *testing.T, n ast.Node) ast.Node {
+	t.Helper()
+	a, ok := n.(*ast.Assignment)
+	if !ok {
+		t.Fatalf("expected *ast.Assignment, got %T (%v)", n, n)
+	}
+	return a.Value
+}
+
+// TestParser_EndOfQ1ProducesEndOfExpr — the core refactor: the
+// parser emits a structured EndOfExpr node, not a flat
+// RelativeDateLiteral with concatenated string keyword.
+func TestParser_EndOfQ1ProducesEndOfExpr(t *testing.T) {
+	expr := expressionFromAssignment(t, parseFirstStmt(t, "x = end of Q1"))
+	endOf, ok := expr.(*ast.EndOfExpr)
+	if !ok {
+		t.Fatalf("expected *ast.EndOfExpr, got %T (%v)", expr, expr)
+	}
+	if endOf.Period == nil {
+		t.Fatal("EndOfExpr.Period is nil")
+	}
+	inner, ok := endOf.Period.(*ast.RelativeDateLiteral)
+	if !ok {
+		t.Fatalf("expected inner *ast.RelativeDateLiteral, got %T", endOf.Period)
+	}
+	if inner.Keyword != "Q:1" {
+		t.Errorf("inner Keyword = %q, want %q", inner.Keyword, "Q:1")
+	}
+}
+
+// TestParser_StartOfQ1ProducesStartOfExpr — symmetric.
+func TestParser_StartOfQ1ProducesStartOfExpr(t *testing.T) {
+	expr := expressionFromAssignment(t, parseFirstStmt(t, "x = start of Q1"))
+	startOf, ok := expr.(*ast.StartOfExpr)
+	if !ok {
+		t.Fatalf("expected *ast.StartOfExpr, got %T", expr)
+	}
+	if startOf.Period == nil {
+		t.Fatal("StartOfExpr.Period is nil")
+	}
+}
+
+// TestParser_EndOfFQ1AndFQ2_AllFiscalQuarters — every fiscal
+// quarter literal must work as inner.
+func TestParser_EndOfFQ1AndFQ2_AllFiscalQuarters(t *testing.T) {
+	for _, q := range []string{"FQ1", "FQ2", "FQ3", "FQ4"} {
+		expr := expressionFromAssignment(t, parseFirstStmt(t, "x = end of "+q))
+		endOf, ok := expr.(*ast.EndOfExpr)
+		if !ok {
+			t.Errorf("end of %s: expected *ast.EndOfExpr, got %T", q, expr)
+			continue
+		}
+		inner, ok := endOf.Period.(*ast.RelativeDateLiteral)
+		if !ok {
+			t.Errorf("end of %s: inner not *ast.RelativeDateLiteral, got %T", q, endOf.Period)
+			continue
+		}
+		want := "FQ:" + string(q[2])
+		if inner.Keyword != want {
+			t.Errorf("end of %s: inner Keyword = %q, want %q", q, inner.Keyword, want)
+		}
+	}
+}
+
+// TestParser_EndOfThisMonth — relative-period inner.
+func TestParser_EndOfThisMonth(t *testing.T) {
+	expr := expressionFromAssignment(t, parseFirstStmt(t, "x = end of this month"))
+	endOf, ok := expr.(*ast.EndOfExpr)
+	if !ok {
+		t.Fatalf("expected *ast.EndOfExpr, got %T", expr)
+	}
+	inner, ok := endOf.Period.(*ast.RelativeDateLiteral)
+	if !ok {
+		t.Fatalf("expected inner *ast.RelativeDateLiteral, got %T", endOf.Period)
+	}
+	if inner.Keyword != "this month" {
+		t.Errorf("inner Keyword = %q, want %q", inner.Keyword, "this month")
+	}
+}
+
+// TestParser_EndOfThisFiscalQuarter — multi-word relative-period.
+func TestParser_EndOfThisFiscalQuarter(t *testing.T) {
+	expr := expressionFromAssignment(t, parseFirstStmt(t, "x = end of this fiscal quarter"))
+	endOf, ok := expr.(*ast.EndOfExpr)
+	if !ok {
+		t.Fatalf("expected *ast.EndOfExpr, got %T", expr)
+	}
+	inner, ok := endOf.Period.(*ast.RelativeDateLiteral)
+	if !ok {
+		t.Fatalf("expected inner *ast.RelativeDateLiteral, got %T", endOf.Period)
+	}
+	if inner.Keyword != "this fiscal quarter" {
+		t.Errorf("inner Keyword = %q, want %q", inner.Keyword, "this fiscal quarter")
+	}
+}
+
+// TestParser_EndOfIdentifierComposes — the load-bearing R9-emergent
+// behavior: `end of <variable>` parses successfully. The parser
+// doesn't enforce the variable resolves to a Period; the type
+// checker (semantic) and interpreter (runtime) handle that.
+func TestParser_EndOfIdentifierComposes(t *testing.T) {
+	nodes, err := Parse("q = Q1\ne = end of q")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(nodes) < 2 {
+		t.Fatalf("expected 2 statements, got %d", len(nodes))
+	}
+	expr := expressionFromAssignment(t, nodes[1])
+	endOf, ok := expr.(*ast.EndOfExpr)
+	if !ok {
+		t.Fatalf("expected *ast.EndOfExpr, got %T", expr)
+	}
+	id, ok := endOf.Period.(*ast.Identifier)
+	if !ok {
+		t.Fatalf("expected inner *ast.Identifier, got %T", endOf.Period)
+	}
+	if id.Name != "q" {
+		t.Errorf("inner Identifier.Name = %q, want %q", id.Name, "q")
+	}
+}
+
+// TestParser_EndOfPrecedence_AdditiveOuter — `end of Q1 + 1 day`
+// must parse as `(end of Q1) + 1 day`, NOT `end of (Q1 + 1 day)`.
+// The plan's Key Decision: parsePrimary()-inner preserves
+// precedence so the outer additive operator binds across the
+// EndOfExpr boundary, not into it.
+func TestParser_EndOfPrecedence_AdditiveOuter(t *testing.T) {
+	expr := expressionFromAssignment(t, parseFirstStmt(t, "x = end of Q1 + 1 day"))
+	bo, ok := expr.(*ast.BinaryOp)
+	if !ok {
+		t.Fatalf("expected *ast.BinaryOp at the top, got %T (input parses as `end of (Q1 + 1 day)` which is wrong)", expr)
+	}
+	if _, ok := bo.Left.(*ast.EndOfExpr); !ok {
+		t.Errorf("expected BinaryOp.Left to be *ast.EndOfExpr, got %T", bo.Left)
+	}
+}
+
+// TestParser_EndOfWithExplicitParens — `end of (Q1)` parses with
+// the parenthesized inner. After PR-1b, `end of (Q1 + 1 day)` is a
+// type error (BinaryOp returns Date, not Period), but the PARSER
+// accepts it -- semantic check is what rejects it.
+func TestParser_EndOfWithExplicitParens(t *testing.T) {
+	expr := expressionFromAssignment(t, parseFirstStmt(t, "x = end of (Q1)"))
+	endOf, ok := expr.(*ast.EndOfExpr)
+	if !ok {
+		t.Fatalf("expected *ast.EndOfExpr, got %T", expr)
+	}
+	if endOf.Period == nil {
+		t.Fatal("Period is nil")
+	}
+}
+
+// TestParser_EndOfMissingInnerErrors — clear error when nothing
+// follows `end of`.
+func TestParser_EndOfMissingInnerErrors(t *testing.T) {
+	_, err := Parse("x = end of")
+	if err == nil {
+		t.Fatal("Parse(\"x = end of\") should error; got nil")
+	}
+	// Error mentions the modifier so the user knows where the
+	// problem is. Loose match -- exact wording is implementation.
+	if !strings.Contains(strings.ToLower(err.Error()), "end of") &&
+		!strings.Contains(strings.ToLower(err.Error()), "period") &&
+		!strings.Contains(strings.ToLower(err.Error()), "expression") {
+		t.Errorf("error message %q should mention 'end of', 'period', or 'expression'", err.Error())
+	}
+}
+
+// TestParser_StartOfMissingInnerErrors — symmetric error.
+func TestParser_StartOfMissingInnerErrors(t *testing.T) {
+	_, err := Parse("x = start of")
+	if err == nil {
+		t.Fatal("Parse(\"x = start of\") should error; got nil")
+	}
+}
+
+// TestParser_EndOfRangeIsPopulated — parser must populate Range so
+// type-check diagnostics can point back to source. Pin via line +
+// column non-zero.
+func TestParser_EndOfRangeIsPopulated(t *testing.T) {
+	expr := expressionFromAssignment(t, parseFirstStmt(t, "x = end of Q1"))
+	endOf := expr.(*ast.EndOfExpr)
+	if endOf.GetRange() == nil {
+		t.Fatal("EndOfExpr.Range is nil")
+	}
+}
+
+// TestParser_BackwardCompat_AllOldEndOfFormsStillParse — every
+// inner that worked under the bounded-token-list before the
+// refactor must still parse. The list is exhaustive over the
+// inner forms the old code accepted.
+func TestParser_BackwardCompat_AllOldEndOfFormsStillParse(t *testing.T) {
+	inputs := []string{
+		// Calendar-relative
+		"x = end of this week",
+		"x = end of this month",
+		"x = end of this year",
+		"x = end of this quarter",
+		"x = end of next month",
+		"x = end of last month",
+		// Fiscal-relative
+		"x = end of this fiscal quarter",
+		"x = end of next fiscal quarter",
+		"x = end of last fiscal quarter",
+		"x = end of this fiscal year",
+		// Notation literals
+		"x = end of Q2",
+		"x = end of FQ1",
+		// Symmetric start-of
+		"x = start of Q1",
+		"x = start of this month",
+	}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			expr := expressionFromAssignment(t, parseFirstStmt(t, input))
+			switch expr.(type) {
+			case *ast.EndOfExpr, *ast.StartOfExpr:
+				// OK
+			default:
+				t.Errorf("expected EndOfExpr/StartOfExpr, got %T", expr)
+			}
+		})
+	}
+}

--- a/spec/parser/period_literal_test.go
+++ b/spec/parser/period_literal_test.go
@@ -1,0 +1,150 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/CalcMark/go-calcmark/spec/ast"
+)
+
+// U5 — bare month names parse to a Period-bearing AST.
+//
+// Pre-v2.0, `April` lexes as DATE_LITERAL("April:1:") and the parser
+// emits ast.DateLiteral{Month: "April", Day: "1", Year: nil}. PR-1b's
+// `end of <Period>` check then needed a transitional shim to accept
+// this DateLiteral as period-bearing.
+//
+// v2.0 fixes the discrimination at the parser: the lexer threads
+// HasExplicitDay (whether a day number was scanned) into the token,
+// and the parser routes:
+//
+//   - HasExplicitDay = false (bare month: `April`, `Apr`, `january`)
+//     → RelativeDateLiteral{Keyword: "this <Month>"}.
+//     This is the same AST shape as `this April`, so the existing
+//     period-keyword evaluation path handles it directly.
+//
+//   - HasExplicitDay = true (specific date: `April 1`, `April 15
+//     2026`) → DateLiteral{HasExplicitDay: true, ...}, unchanged.
+//
+//   - Year-only (`April 2026`, no explicit day) → DateLiteral
+//     (status quo). Period-of-year-month is a future feature; for
+//     now it remains a Date.
+//
+// Discrimination must be lexer-driven, not source-text substring
+// matching — the latter drifts with whitespace, comments, and
+// future lexer changes (reviewer F1).
+
+func TestParser_BareMonthName_ProducesRelativeDateLiteral(t *testing.T) {
+	// The lexer canonicalizes month names ("Apr" → "April", "sept"
+	// → "September"), so the parser-emitted Keyword is always the
+	// canonical form regardless of how the user typed it. This is
+	// the same canonicalization that `this April` / `this Sep`
+	// already go through; the parser routes both inputs to the same
+	// keyword string.
+	cases := []struct {
+		input       string
+		wantKeyword string
+	}{
+		{"April", "this April"},
+		{"Apr", "this April"},
+		{"january", "this January"},
+		{"Dec", "this December"},
+		{"sept", "this September"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			n := parseFirstStmt(t, "x = "+tc.input)
+			expr := expressionFromAssignment(t, n)
+			rdl, ok := expr.(*ast.RelativeDateLiteral)
+			if !ok {
+				t.Fatalf("input %q: expected *ast.RelativeDateLiteral, got %T (%v)", tc.input, expr, expr)
+			}
+			if rdl.Keyword != tc.wantKeyword {
+				t.Errorf("input %q: Keyword = %q, want %q", tc.input, rdl.Keyword, tc.wantKeyword)
+			}
+		})
+	}
+}
+
+func TestParser_SpecificDate_ProducesDateLiteralWithExplicitDay(t *testing.T) {
+	cases := []struct {
+		input    string
+		wantDay  string
+		wantYear *string
+	}{
+		{"April 1", "1", nil},
+		{"April 15", "15", nil},
+		{"Apr 1 2026", "1", strptr("2026")},
+		{"April 15 2026", "15", strptr("2026")},
+		{"December 25 2026", "25", strptr("2026")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			n := parseFirstStmt(t, "x = "+tc.input)
+			expr := expressionFromAssignment(t, n)
+			dl, ok := expr.(*ast.DateLiteral)
+			if !ok {
+				t.Fatalf("input %q: expected *ast.DateLiteral, got %T (%v)", tc.input, expr, expr)
+			}
+			if !dl.HasExplicitDay {
+				t.Errorf("input %q: HasExplicitDay = false, want true (specific date had a day number)", tc.input)
+			}
+			if dl.Day != tc.wantDay {
+				t.Errorf("input %q: Day = %q, want %q", tc.input, dl.Day, tc.wantDay)
+			}
+			if (tc.wantYear == nil) != (dl.Year == nil) {
+				t.Errorf("input %q: Year nil mismatch: got %v, want %v", tc.input, dl.Year, tc.wantYear)
+			}
+			if tc.wantYear != nil && dl.Year != nil && *dl.Year != *tc.wantYear {
+				t.Errorf("input %q: Year = %q, want %q", tc.input, *dl.Year, *tc.wantYear)
+			}
+		})
+	}
+}
+
+// TestParser_YearOnlyMonth_StaysAsDateLiteral — `January 2026`
+// (year scanned, no explicit day) preserves status-quo as
+// DateLiteral. Period-of-year-month is out of scope for U5 — a
+// later PR can route this to a MonthOfYear period node if the
+// product calls for it.
+func TestParser_YearOnlyMonth_StaysAsDateLiteral(t *testing.T) {
+	cases := []string{"January 2026", "April 2026", "Dec 2025"}
+	for _, input := range cases {
+		t.Run(input, func(t *testing.T) {
+			n := parseFirstStmt(t, "x = "+input)
+			expr := expressionFromAssignment(t, n)
+			dl, ok := expr.(*ast.DateLiteral)
+			if !ok {
+				t.Fatalf("input %q: expected *ast.DateLiteral, got %T (%v)", input, expr, expr)
+			}
+			if dl.HasExplicitDay {
+				t.Errorf("input %q: HasExplicitDay = true, want false (no day number was scanned)", input)
+			}
+			if dl.Year == nil {
+				t.Errorf("input %q: Year nil, expected the year to be captured", input)
+			}
+		})
+	}
+}
+
+// TestParser_BareMonthFlowsThroughEndOf — integration: with U5,
+// `end of April` parses as EndOfExpr{Period: RelativeDateLiteral},
+// which is the same shape as `end of this April`. This eliminates
+// the transitional *ast.DateLiteral arm in spec/semantic (deferred
+// to U9 to actually remove the shim).
+func TestParser_BareMonthFlowsThroughEndOf(t *testing.T) {
+	n := parseFirstStmt(t, "x = end of April")
+	expr := expressionFromAssignment(t, n)
+	endOf, ok := expr.(*ast.EndOfExpr)
+	if !ok {
+		t.Fatalf("expected *ast.EndOfExpr, got %T (%v)", expr, expr)
+	}
+	rdl, ok := endOf.Period.(*ast.RelativeDateLiteral)
+	if !ok {
+		t.Fatalf("end of April: inner expected *ast.RelativeDateLiteral, got %T (%v)", endOf.Period, endOf.Period)
+	}
+	if rdl.Keyword != "this April" {
+		t.Errorf("end of April: inner Keyword = %q, want %q", rdl.Keyword, "this April")
+	}
+}
+
+func strptr(s string) *string { return &s }

--- a/spec/parser/period_literal_test.go
+++ b/spec/parser/period_literal_test.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/CalcMark/go-calcmark/spec/ast"
@@ -148,3 +149,217 @@ func TestParser_BareMonthFlowsThroughEndOf(t *testing.T) {
 }
 
 func strptr(s string) *string { return &s }
+
+// --- U7: BetweenExpr productions ---
+
+func TestParser_Between_HappyPath(t *testing.T) {
+	n := parseFirstStmt(t, "x = between Apr 15 2026 and Jul 4 2026")
+	expr := expressionFromAssignment(t, n)
+	be, ok := expr.(*ast.BetweenExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BetweenExpr, got %T (%v)", expr, expr)
+	}
+	if _, ok := be.Start.(*ast.DateLiteral); !ok {
+		t.Errorf("Start = %T, want *ast.DateLiteral", be.Start)
+	}
+	if _, ok := be.End.(*ast.DateLiteral); !ok {
+		t.Errorf("End = %T, want *ast.DateLiteral", be.End)
+	}
+}
+
+func TestParser_FromTo_Synonym(t *testing.T) {
+	n := parseFirstStmt(t, "x = from Apr 15 2026 to Jul 4 2026")
+	expr := expressionFromAssignment(t, n)
+	be, ok := expr.(*ast.BetweenExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BetweenExpr, got %T (%v)", expr, expr)
+	}
+	if _, ok := be.Start.(*ast.DateLiteral); !ok {
+		t.Errorf("Start = %T, want *ast.DateLiteral", be.Start)
+	}
+	if _, ok := be.End.(*ast.DateLiteral); !ok {
+		t.Errorf("End = %T, want *ast.DateLiteral", be.End)
+	}
+}
+
+// TestParser_BetweenAndFromTo_ASTEquivalent — both surface forms
+// must produce structurally identical AST trees. Catches subtle
+// parser-side divergence (different Range, swapped fields) that
+// semantic + eval would silently absorb.
+func TestParser_BetweenAndFromTo_ASTEquivalent(t *testing.T) {
+	a := parseFirstStmt(t, "x = between Apr 15 2026 and Jul 4 2026")
+	b := parseFirstStmt(t, "x = from Apr 15 2026 to Jul 4 2026")
+
+	beA, ok := expressionFromAssignment(t, a).(*ast.BetweenExpr)
+	if !ok {
+		t.Fatalf("`between ...`: expected BetweenExpr, got %T", expressionFromAssignment(t, a))
+	}
+	beB, ok := expressionFromAssignment(t, b).(*ast.BetweenExpr)
+	if !ok {
+		t.Fatalf("`from ... to ...`: expected BetweenExpr, got %T", expressionFromAssignment(t, b))
+	}
+	// Compare Start/End via String() — full deep-equal would fail
+	// on Range positions which differ legitimately by source offset.
+	if beA.Start.String() != beB.Start.String() {
+		t.Errorf("Start mismatch:\n  between: %s\n  from-to: %s", beA.Start.String(), beB.Start.String())
+	}
+	if beA.End.String() != beB.End.String() {
+		t.Errorf("End mismatch:\n  between: %s\n  from-to: %s", beA.End.String(), beB.End.String())
+	}
+}
+
+func TestParser_Between_RelativeDates(t *testing.T) {
+	n := parseFirstStmt(t, "x = between today and next month")
+	expr := expressionFromAssignment(t, n)
+	be, ok := expr.(*ast.BetweenExpr)
+	if !ok {
+		t.Fatalf("expected *ast.BetweenExpr, got %T", expr)
+	}
+	if _, ok := be.Start.(*ast.RelativeDateLiteral); !ok {
+		t.Errorf("Start = %T, want *ast.RelativeDateLiteral (today)", be.Start)
+	}
+	if _, ok := be.End.(*ast.RelativeDateLiteral); !ok {
+		t.Errorf("End = %T, want *ast.RelativeDateLiteral (next month)", be.End)
+	}
+}
+
+func TestParser_Between_MissingAnd(t *testing.T) {
+	_, err := Parse("x = between Apr 15 2026")
+	if err == nil {
+		t.Fatal("expected parse error for `between Apr 15 2026` (missing `and`)")
+	}
+}
+
+func TestParser_Between_AtEOF(t *testing.T) {
+	_, err := Parse("x = between")
+	if err == nil {
+		t.Fatal("expected parse error for `x = between` (no operands)")
+	}
+}
+
+func TestParser_FromTo_MissingEnd(t *testing.T) {
+	_, err := Parse("x = from Apr 15 2026 to")
+	if err == nil {
+		t.Fatal("expected parse error for `from Apr 15 2026 to` (missing End)")
+	}
+}
+
+// TestParser_BetweenAsIdentifier_MigrationDiagnostic — `between = 50`
+// is the v2.0 breaking-change scenario. The parser must surface a
+// clear migration message rather than crashing or silently
+// accepting it.
+func TestParser_BetweenAsIdentifier_MigrationDiagnostic(t *testing.T) {
+	_, err := Parse("between = 50")
+	if err == nil {
+		t.Fatal("expected migration diagnostic for `between = 50`")
+	}
+	msg := err.Error()
+	if !strings.Contains(strings.ToLower(msg), "between") {
+		t.Errorf("error %q should mention `between`", msg)
+	}
+	if !strings.Contains(strings.ToLower(msg), "reserved") &&
+		!strings.Contains(strings.ToLower(msg), "keyword") {
+		t.Errorf("error %q should explain that `between` is now a reserved keyword", msg)
+	}
+}
+
+// TestParser_DurationFromArith_NotABetween — the existing
+// `2 days from today` arithmetic must keep working. The new
+// `from A to B` parser branch fires only when FROM is at the start
+// of a primary expression, not after a duration.
+func TestParser_DurationFromArith_NotABetween(t *testing.T) {
+	n := parseFirstStmt(t, "x = 2 days from today")
+	expr := expressionFromAssignment(t, n)
+	if _, ok := expr.(*ast.BetweenExpr); ok {
+		t.Errorf("`2 days from today` must not parse as BetweenExpr; got %T", expr)
+	}
+}
+
+// --- U8: LengthOfExpr productions ---
+
+func TestParser_LengthOf_BareMonth(t *testing.T) {
+	n := parseFirstStmt(t, "x = length of April")
+	expr := expressionFromAssignment(t, n)
+	loe, ok := expr.(*ast.LengthOfExpr)
+	if !ok {
+		t.Fatalf("expected *ast.LengthOfExpr, got %T", expr)
+	}
+	if loe.AsNumber {
+		t.Errorf("AsNumber = true, want false (`length of` form)")
+	}
+	rdl, ok := loe.Period.(*ast.RelativeDateLiteral)
+	if !ok {
+		t.Fatalf("Period inner = %T, want *ast.RelativeDateLiteral (April → this April)", loe.Period)
+	}
+	if rdl.Keyword != "this April" {
+		t.Errorf("Period.Keyword = %q, want %q", rdl.Keyword, "this April")
+	}
+}
+
+func TestParser_DaysIn_BareMonth(t *testing.T) {
+	n := parseFirstStmt(t, "x = days in April")
+	expr := expressionFromAssignment(t, n)
+	loe, ok := expr.(*ast.LengthOfExpr)
+	if !ok {
+		t.Fatalf("expected *ast.LengthOfExpr, got %T", expr)
+	}
+	if !loe.AsNumber {
+		t.Errorf("AsNumber = false, want true (`days in` form)")
+	}
+}
+
+// TestParser_LengthOf_PrecedenceLockIn — `length of Q1 + 2 days`
+// must parse as `(length of Q1) + 2 days`, top-level BinaryOp.
+// Pinned at the AST level so the contract is locked even if the
+// interpreter or formatter accidentally cancels out a precedence
+// bug at runtime.
+func TestParser_LengthOf_PrecedenceLockIn(t *testing.T) {
+	n := parseFirstStmt(t, "x = length of Q1 + 2 days")
+	expr := expressionFromAssignment(t, n)
+	bop, ok := expr.(*ast.BinaryOp)
+	if !ok {
+		t.Fatalf("expected top-level *ast.BinaryOp (length of Q1 + 2 days), got %T", expr)
+	}
+	if bop.Operator != "+" {
+		t.Errorf("Operator = %q, want %q", bop.Operator, "+")
+	}
+	if _, ok := bop.Left.(*ast.LengthOfExpr); !ok {
+		t.Errorf("Left = %T, want *ast.LengthOfExpr", bop.Left)
+	}
+	if _, ok := bop.Right.(*ast.DurationLiteral); !ok {
+		t.Errorf("Right = %T, want *ast.DurationLiteral", bop.Right)
+	}
+}
+
+func TestParser_DaysIn_PrecedenceLockIn(t *testing.T) {
+	n := parseFirstStmt(t, "x = days in April * 100")
+	expr := expressionFromAssignment(t, n)
+	bop, ok := expr.(*ast.BinaryOp)
+	if !ok {
+		t.Fatalf("expected top-level *ast.BinaryOp, got %T", expr)
+	}
+	if bop.Operator != "*" {
+		t.Errorf("Operator = %q, want %q", bop.Operator, "*")
+	}
+	loe, ok := bop.Left.(*ast.LengthOfExpr)
+	if !ok {
+		t.Fatalf("Left = %T, want *ast.LengthOfExpr", bop.Left)
+	}
+	if !loe.AsNumber {
+		t.Errorf("Left.AsNumber = false, want true (days in)")
+	}
+}
+
+func TestParser_LengthOf_AtEOF(t *testing.T) {
+	_, err := Parse("x = length of")
+	if err == nil {
+		t.Fatal("expected parse error for `length of` at EOF")
+	}
+}
+
+func TestParser_DaysIn_AtEOF(t *testing.T) {
+	_, err := Parse("x = days in")
+	if err == nil {
+		t.Fatal("expected parse error for `days in` at EOF")
+	}
+}

--- a/spec/parser/primary.go
+++ b/spec/parser/primary.go
@@ -386,6 +386,112 @@ func (p *RecursiveDescentParser) parsePrimary() (ast.Node, error) {
 		return &ast.StartOfExpr{Period: inner, SourceText: sourceText, Range: full}, nil
 	}
 
+	// `length of <Period>` / `days in <Period>` — v2.0 query
+	// operators. Inner parses via parsePrimary so precedence
+	// preserves: `length of Q1 + 2 days` parses as
+	// `(length of Q1) + 2 days`. Type-check enforces Period inner
+	// in U9.
+	if p.match(lexer.LENGTH_OF, lexer.DAYS_IN) {
+		op := p.previous()
+		asNumber := op.Type == lexer.DAYS_IN
+		modifier := "length of"
+		if asNumber {
+			modifier = "days in"
+		}
+		startRange := tokenRange(op)
+		inner, err := p.parsePrimary()
+		if err != nil {
+			return nil, p.error("expected period expression after '" + modifier + "' (e.g., '" + modifier + " April', '" + modifier + " Q1'); got: " + err.Error())
+		}
+		if inner == nil {
+			return nil, p.error("expected period expression after '" + modifier + "'")
+		}
+		full := startRange
+		if innerR := inner.GetRange(); innerR != nil {
+			full = &ast.Range{Start: startRange.Start, End: innerR.End}
+		}
+		sourceText := modifier + " " + innerSourceText(inner)
+		return &ast.LengthOfExpr{
+			Period:     inner,
+			AsNumber:   asNumber,
+			SourceText: sourceText,
+			Range:      full,
+		}, nil
+	}
+
+	// `between A and B` — v2.0 user-defined Period.
+	if p.match(lexer.BETWEEN) {
+		op := p.previous()
+		startRange := tokenRange(op)
+		startExpr, err := p.parsePrimary()
+		if err != nil {
+			return nil, p.error("expected expression after 'between'; got: " + err.Error())
+		}
+		if startExpr == nil {
+			return nil, p.error("expected expression after 'between'")
+		}
+		if !p.match(lexer.AND) {
+			return nil, p.error("expected 'and' after 'between <expr>' (e.g., 'between Apr 1 2026 and Jul 4 2026')")
+		}
+		endExpr, err := p.parsePrimary()
+		if err != nil {
+			return nil, p.error("expected expression after 'and'; got: " + err.Error())
+		}
+		if endExpr == nil {
+			return nil, p.error("expected expression after 'and'")
+		}
+		full := startRange
+		if endR := endExpr.GetRange(); endR != nil {
+			full = &ast.Range{Start: startRange.Start, End: endR.End}
+		}
+		sourceText := "between " + innerSourceText(startExpr) + " and " + innerSourceText(endExpr)
+		return &ast.BetweenExpr{
+			Start:      startExpr,
+			End:        endExpr,
+			SourceText: sourceText,
+			Range:      full,
+		}, nil
+	}
+
+	// `from A to B` — synonym for `between A and B`. Only fires when
+	// FROM is at the start of a primary expression. The existing
+	// `<duration> from <date>` arithmetic consumes FROM inside the
+	// DURATION_LITERAL branch (below), so a FROM reaching here is
+	// always the start of the period synonym.
+	if p.match(lexer.FROM) {
+		op := p.previous()
+		startRange := tokenRange(op)
+		startExpr, err := p.parsePrimary()
+		if err != nil {
+			return nil, p.error("expected expression after 'from'; got: " + err.Error())
+		}
+		if startExpr == nil {
+			return nil, p.error("expected expression after 'from'")
+		}
+		if !p.checkIdentValue("to") {
+			return nil, p.error("expected 'to' after 'from <expr>' (e.g., 'from Apr 1 2026 to Jul 4 2026')")
+		}
+		p.advance() // consume "to"
+		endExpr, err := p.parsePrimary()
+		if err != nil {
+			return nil, p.error("expected expression after 'to'; got: " + err.Error())
+		}
+		if endExpr == nil {
+			return nil, p.error("expected expression after 'to'")
+		}
+		full := startRange
+		if endR := endExpr.GetRange(); endR != nil {
+			full = &ast.Range{Start: startRange.Start, End: endR.End}
+		}
+		sourceText := "from " + innerSourceText(startExpr) + " to " + innerSourceText(endExpr)
+		return &ast.BetweenExpr{
+			Start:      startExpr,
+			End:        endExpr,
+			SourceText: sourceText,
+			Range:      full,
+		}, nil
+	}
+
 	// Date keywords: today, tomorrow, yesterday, this/next/last week/month/year, weekdays
 	if p.match(lexer.DATE_TODAY, lexer.DATE_TOMORROW, lexer.DATE_YESTERDAY,
 		lexer.DATE_THIS_WEEK, lexer.DATE_THIS_MONTH, lexer.DATE_THIS_YEAR,

--- a/spec/parser/primary.go
+++ b/spec/parser/primary.go
@@ -812,16 +812,35 @@ func (p *RecursiveDescentParser) parseFromTarget() (ast.Node, error) {
 		}, nil
 	}
 
-	// Try relative date expressions (weekdays, months, periods)
-	if p.match(lexer.DATE_WEEKDAY, lexer.DATE_THIS_WEEKDAY, lexer.DATE_NEXT_WEEKDAY, lexer.DATE_LAST_WEEKDAY,
+	// Try relative date expressions (weekdays, months, periods).
+	//
+	// Period-bearing tokens (DATE_THIS_QUARTER, DATE_NEXT_MONTH,
+	// DATE_THIS_YEAR, etc.) evaluate to *types.Period in v2.0. The
+	// `from <X>` arithmetic context is a Date-narrowing context — the
+	// user means "starting from the start of that period" — so we
+	// wrap period-bearing tokens in StartOfExpr at parse time.
+	// Day-bearing tokens (weekdays) stay as RelativeDateLiteral.
+	if p.match(lexer.DATE_WEEKDAY, lexer.DATE_THIS_WEEKDAY, lexer.DATE_NEXT_WEEKDAY, lexer.DATE_LAST_WEEKDAY) {
+		return &ast.RelativeDateLiteral{
+			Keyword:    string(p.previous().Value),
+			SourceText: string(p.previous().OriginalText),
+		}, nil
+	}
+	if p.match(
 		lexer.DATE_THIS_MONTH_NAME, lexer.DATE_NEXT_MONTH_NAME, lexer.DATE_LAST_MONTH_NAME,
 		lexer.DATE_THIS_QUARTER, lexer.DATE_NEXT_QUARTER, lexer.DATE_LAST_QUARTER,
 		lexer.DATE_THIS_WEEK, lexer.DATE_THIS_MONTH, lexer.DATE_THIS_YEAR,
 		lexer.DATE_NEXT_WEEK, lexer.DATE_NEXT_MONTH, lexer.DATE_NEXT_YEAR,
 		lexer.DATE_LAST_WEEK, lexer.DATE_LAST_MONTH, lexer.DATE_LAST_YEAR) {
-		return &ast.RelativeDateLiteral{
-			Keyword:    string(p.previous().Value),
-			SourceText: string(p.previous().OriginalText),
+		tok := p.previous()
+		inner := &ast.RelativeDateLiteral{
+			Keyword:    string(tok.Value),
+			SourceText: string(tok.OriginalText),
+		}
+		return &ast.StartOfExpr{
+			Period:     inner,
+			SourceText: "start of " + string(tok.OriginalText),
+			Range:      tokenRange(tok),
 		}, nil
 	}
 

--- a/spec/parser/primary.go
+++ b/spec/parser/primary.go
@@ -403,22 +403,43 @@ func (p *RecursiveDescentParser) parsePrimary() (ast.Node, error) {
 		}, nil
 	}
 
-	// Date literals: "Dec 12", "December 25 2025"
+	// Date literals: "Dec 12", "December 25 2025", and bare months
+	// like "April".
 	if p.match(lexer.DATE_LITERAL) {
 		tok := p.previous()
-		// Value format: "Month:Day:Year" (e.g., "December:25:2025")
+		// Value format: "Month:Day:Year:HasExplicitDay" where the
+		// last field is "1" or "0". Pre-v2.0 tokens may lack the
+		// 4th field; treat absence as HasExplicitDay = true so
+		// legacy callers (e.g., synthesized tokens) keep their
+		// existing Date semantics.
 		parts := strings.Split(string(tok.Value), ":")
 
 		var year *string
 		if len(parts) >= 3 && parts[2] != "" {
 			year = &parts[2]
 		}
+		hasExplicitDay := true
+		if len(parts) >= 4 {
+			hasExplicitDay = parts[3] == "1"
+		}
+
+		// Bare month name (no day, no year): semantically a Period
+		// (the whole month). Emit RelativeDateLiteral so it flows
+		// through the existing period-keyword evaluation path
+		// shared with `this April` / `next April`.
+		if !hasExplicitDay && year == nil {
+			return &ast.RelativeDateLiteral{
+				Keyword:    "this " + parts[0],
+				SourceText: string(tok.OriginalText),
+			}, nil
+		}
 
 		return &ast.DateLiteral{
-			Month:      parts[0],
-			Day:        parts[1],
-			Year:       year,
-			SourceText: string(tok.OriginalText),
+			Month:          parts[0],
+			Day:            parts[1],
+			Year:           year,
+			HasExplicitDay: hasExplicitDay,
+			SourceText:     string(tok.OriginalText),
 		}, nil
 	}
 
@@ -698,7 +719,10 @@ func (p *RecursiveDescentParser) parseFromTarget() (ast.Node, error) {
 		}, nil
 	}
 
-	// Try date literal (Dec 25, December 25 2025)
+	// Try date literal (Dec 25, December 25 2025). In `from <date>`
+	// position the user typically writes a specific date; we treat
+	// any DATE_LITERAL here as a Date and preserve HasExplicitDay
+	// for downstream consumers.
 	if p.match(lexer.DATE_LITERAL) {
 		tok := p.previous()
 		parts := strings.Split(string(tok.Value), ":")
@@ -707,12 +731,17 @@ func (p *RecursiveDescentParser) parseFromTarget() (ast.Node, error) {
 		if len(parts) >= 3 && parts[2] != "" {
 			year = &parts[2]
 		}
+		hasExplicitDay := true
+		if len(parts) >= 4 {
+			hasExplicitDay = parts[3] == "1"
+		}
 
 		return &ast.DateLiteral{
-			Month:      parts[0],
-			Day:        parts[1],
-			Year:       year,
-			SourceText: string(tok.OriginalText),
+			Month:          parts[0],
+			Day:            parts[1],
+			Year:           year,
+			HasExplicitDay: hasExplicitDay,
+			SourceText:     string(tok.OriginalText),
 		}, nil
 	}
 

--- a/spec/parser/primary.go
+++ b/spec/parser/primary.go
@@ -347,37 +347,43 @@ func (p *RecursiveDescentParser) parsePrimary() (ast.Node, error) {
 		}, nil
 	}
 
-	// "start of <period>" — explicit form, equivalent to bare period (first day)
-	// "end of <period>" — resolves to last day of the period
+	// "start of <period>" / "end of <period>" — first-class language
+	// operators. The inner is parsed via parsePrimary() so any
+	// expression that resolves to a Period at semantic-check time
+	// works (literal periods, identifiers bound to periods,
+	// parenthesized period expressions). Precedence is preserved:
+	// `end of Q1 + 1 day` parses as `(end of Q1) + 1 day` because
+	// parsePrimary() doesn't reach across the additive boundary.
+	//
+	// Replaces the previous bounded-token-list + string-flattening
+	// where the inner had to be one of an enumerated set of tokens
+	// and the AST stored `Keyword: modifier + " " + innerKeyword`.
+	// See spec/ast/nodes.go EndOfExpr / StartOfExpr.
 	if p.match(lexer.START_OF, lexer.END_OF) {
-		modifier := string(p.previous().Value) // "start of" or "end of"
-		// Parse the period expression that follows
-		if p.match(lexer.DATE_THIS_WEEK, lexer.DATE_THIS_MONTH, lexer.DATE_THIS_YEAR,
-			lexer.DATE_NEXT_WEEK, lexer.DATE_NEXT_MONTH, lexer.DATE_NEXT_YEAR,
-			lexer.DATE_LAST_WEEK, lexer.DATE_LAST_MONTH, lexer.DATE_LAST_YEAR,
-			lexer.DATE_THIS_QUARTER, lexer.DATE_NEXT_QUARTER, lexer.DATE_LAST_QUARTER,
-			lexer.DATE_THIS_FISCAL_QUARTER, lexer.DATE_NEXT_FISCAL_QUARTER, lexer.DATE_LAST_FISCAL_QUARTER,
-			lexer.DATE_THIS_FISCAL_YEAR, lexer.DATE_NEXT_FISCAL_YEAR, lexer.DATE_LAST_FISCAL_YEAR,
-			lexer.DATE_THIS_MONTH_NAME, lexer.DATE_NEXT_MONTH_NAME, lexer.DATE_LAST_MONTH_NAME) {
-			tok := p.previous()
-			return &ast.RelativeDateLiteral{
-				Keyword:    modifier + " " + string(tok.Value),
-				SourceText: modifier + " " + string(tok.Value),
-			}, nil
+		op := p.previous()
+		modifier := string(op.Value) // "start of" or "end of"
+		startRange := tokenRange(op)
+		inner, err := p.parsePrimary()
+		if err != nil {
+			return nil, p.error("expected period expression after '" + modifier + "' (e.g., '" + modifier + " this month' or '" + modifier + " Q1'); got: " + err.Error())
 		}
-		// Also accept notation tokens: "end of Q2", "end of FQ1"
-		if p.match(lexer.CALENDAR_QUARTER_LITERAL, lexer.FISCAL_QUARTER_LITERAL) {
-			tok := p.previous()
-			prefix := "Q"
-			if tok.Type == lexer.FISCAL_QUARTER_LITERAL {
-				prefix = "FQ"
-			}
-			return &ast.RelativeDateLiteral{
-				Keyword:    modifier + " " + prefix + ":" + string(tok.Value),
-				SourceText: modifier + " " + string(tok.OriginalText),
-			}, nil
+		if inner == nil {
+			return nil, p.error("expected period expression after '" + modifier + "'")
 		}
-		return nil, p.error("expected period expression after '" + modifier + "' (e.g., '" + modifier + " this month')")
+		// Span from the operator's start through the inner's end.
+		full := startRange
+		if innerR := inner.GetRange(); innerR != nil {
+			full = &ast.Range{Start: startRange.Start, End: innerR.End}
+		}
+		// SourceText spans from the operator through the inner --
+		// the inner's SourceText if available, else fall back to its
+		// String() form. Used in diagnostics and AST round-tripping.
+		innerText := innerSourceText(inner)
+		sourceText := modifier + " " + innerText
+		if op.Type == lexer.END_OF {
+			return &ast.EndOfExpr{Period: inner, SourceText: sourceText, Range: full}, nil
+		}
+		return &ast.StartOfExpr{Period: inner, SourceText: sourceText, Range: full}, nil
 	}
 
 	// Date keywords: today, tomorrow, yesterday, this/next/last week/month/year, weekdays
@@ -811,4 +817,31 @@ func (p *RecursiveDescentParser) parseFractionLiteral() (ast.Node, error) {
 	}
 
 	return fracNode, nil
+}
+
+// innerSourceText returns a best-effort source-text representation
+// of an expression-producing AST node, used to populate
+// EndOfExpr.SourceText / StartOfExpr.SourceText. Walks the common
+// AST node types and reads their SourceText / Keyword / Name
+// fields. Falls back to the node's String() form for unrecognized
+// shapes -- not perfect for round-tripping but sufficient for
+// diagnostic messages.
+func innerSourceText(n ast.Node) string {
+	switch v := n.(type) {
+	case *ast.RelativeDateLiteral:
+		if v.SourceText != "" {
+			return v.SourceText
+		}
+		return v.Keyword
+	case *ast.Identifier:
+		return v.Name
+	case *ast.NumberLiteral:
+		return v.Value
+	case *ast.DateLiteral:
+		if v.SourceText != "" {
+			return v.SourceText
+		}
+		return v.Month + " " + v.Day
+	}
+	return n.String()
 }

--- a/spec/parser/primary.go
+++ b/spec/parser/primary.go
@@ -324,23 +324,31 @@ func (p *RecursiveDescentParser) parsePrimary() (ast.Node, error) {
 		return p.parseNaturalLanguageFunction()
 	}
 
+	// Directed notation: `next FQ1`, `last CY2026`, `this Q1`. The
+	// IDENTIFIER `this`/`next`/`last` followed by a notation literal
+	// (Q/FQ/FY/CY) means "the Nth quarter / year of the relative
+	// fiscal year". Lexer no longer greedy-matches `next FQ` (etc.)
+	// when followed by a digit, so the direction word arrives here
+	// as an IDENTIFIER.
+	if (p.checkIdentValue("next") || p.checkIdentValue("last") || p.checkIdentValue("this")) &&
+		isNotationLiteralToken(p.peekAhead(1).Type) {
+		dirTok := p.advance()
+		direction := strings.ToLower(string(dirTok.Value))
+		notationTok := p.advance()
+		prefix := notationLiteralPrefix(notationTok.Type)
+		return &ast.RelativeDateLiteral{
+			Keyword: direction + " " + prefix + ":" + string(notationTok.Value),
+			SourceText: string(dirTok.Value) + " " + string(notationTok.OriginalText),
+		}, nil
+	}
+
 	// Notation: Q1-Q4, FQ1-FQ4, FY26, CY2026
 	if p.match(lexer.CALENDAR_QUARTER_LITERAL, lexer.FISCAL_QUARTER_LITERAL,
 		lexer.FISCAL_YEAR_LITERAL, lexer.CALENDAR_YEAR_LITERAL) {
 		tok := p.previous()
 		// Encode as RelativeDateLiteral with prefix+value keyword
 		// e.g., "Q:1", "FQ:3", "FY:2026", "CY:26"
-		prefix := ""
-		switch tok.Type {
-		case lexer.CALENDAR_QUARTER_LITERAL:
-			prefix = "Q"
-		case lexer.FISCAL_QUARTER_LITERAL:
-			prefix = "FQ"
-		case lexer.FISCAL_YEAR_LITERAL:
-			prefix = "FY"
-		case lexer.CALENDAR_YEAR_LITERAL:
-			prefix = "CY"
-		}
+		prefix := notationLiteralPrefix(tok.Type)
 		return &ast.RelativeDateLiteral{
 			Keyword:    prefix + ":" + string(tok.Value),
 			SourceText: string(tok.OriginalText),
@@ -979,6 +987,36 @@ func (p *RecursiveDescentParser) parseFractionLiteral() (ast.Node, error) {
 // AST node types and reads their SourceText / Keyword / Name
 // fields. Falls back to the node's String() form for unrecognized
 // shapes -- not perfect for round-tripping but sufficient for
+// isNotationLiteralToken reports whether the given token type is
+// one of the date-notation literals (Q1, FQ1, FY2026, CY2026). Used
+// by the directed-notation parser path (`next FQ1`, etc.).
+func isNotationLiteralToken(t lexer.TokenType) bool {
+	switch t {
+	case lexer.CALENDAR_QUARTER_LITERAL, lexer.FISCAL_QUARTER_LITERAL,
+		lexer.FISCAL_YEAR_LITERAL, lexer.CALENDAR_YEAR_LITERAL:
+		return true
+	}
+	return false
+}
+
+// notationLiteralPrefix returns the canonical Q / FQ / FY / CY prefix
+// for a notation-literal token type. Used to encode the keyword
+// string ("FQ:1" / "next FQ:1" / etc.) consumed by the interpreter's
+// evalNotation switch.
+func notationLiteralPrefix(t lexer.TokenType) string {
+	switch t {
+	case lexer.CALENDAR_QUARTER_LITERAL:
+		return "Q"
+	case lexer.FISCAL_QUARTER_LITERAL:
+		return "FQ"
+	case lexer.FISCAL_YEAR_LITERAL:
+		return "FY"
+	case lexer.CALENDAR_YEAR_LITERAL:
+		return "CY"
+	}
+	return ""
+}
+
 // diagnostic messages.
 func innerSourceText(n ast.Node) string {
 	switch v := n.(type) {

--- a/spec/parser/rdparser.go
+++ b/spec/parser/rdparser.go
@@ -269,6 +269,14 @@ func (p *RecursiveDescentParser) parseStatement() (ast.Node, error) {
 		return p.parseAssignment()
 	}
 
+	// v2.0 migration diagnostic: `between = <expr>`. Pre-v2.0,
+	// `between` could be used as a variable name. v2.0 reserves it
+	// for the period operator. Surface a clear migration message
+	// rather than the generic "unexpected token: BETWEEN".
+	if p.check(lexer.BETWEEN) && p.peekAhead(1).Type == lexer.ASSIGN {
+		return nil, p.error("'between' is a reserved keyword in v2.0; rename the variable (e.g., 'between_value')")
+	}
+
 	// Otherwise, it's an expression
 	return p.parseExpression()
 }

--- a/spec/semantic/checker.go
+++ b/spec/semantic/checker.go
@@ -191,6 +191,15 @@ func (c *Checker) checkNode(node ast.Node) {
 		c.checkEndOfStartOfInner(n.Period, "end of", n.Range)
 	case *ast.StartOfExpr:
 		c.checkEndOfStartOfInner(n.Period, "start of", n.Range)
+	case *ast.LengthOfExpr:
+		op := "length of"
+		if n.AsNumber {
+			op = "days in"
+		}
+		c.checkLengthOfInner(n.Period, op, n.Range)
+	case *ast.BetweenExpr:
+		c.checkBetweenEndpoint(n.Start, "start", n.Range)
+		c.checkBetweenEndpoint(n.End, "end", n.Range)
 	case *ast.TimeLiteral, *ast.DurationLiteral:
 		// Validated at parse time
 	case *ast.QuantityLiteral:

--- a/spec/semantic/checker.go
+++ b/spec/semantic/checker.go
@@ -187,6 +187,10 @@ func (c *Checker) checkNode(node ast.Node) {
 		c.checkDateLiteral(n) // USER REQUIREMENT: Validate dates
 	case *ast.RelativeDateLiteral:
 		// Validated by lexer/parser
+	case *ast.EndOfExpr:
+		c.checkEndOfStartOfInner(n.Period, "end of", n.Range)
+	case *ast.StartOfExpr:
+		c.checkEndOfStartOfInner(n.Period, "start of", n.Range)
 	case *ast.TimeLiteral, *ast.DurationLiteral:
 		// Validated at parse time
 	case *ast.QuantityLiteral:

--- a/spec/semantic/diagnostics.go
+++ b/spec/semantic/diagnostics.go
@@ -63,6 +63,11 @@ const (
 	DiagInvalidLeapYear    = "invalid_leap_year"
 	DiagInvalidEndOfPeriod = "invalid_end_of_period"
 
+	// Period operator diagnostics (v2.0)
+	DiagInvalidLengthOfPeriod  = "invalid_length_of_period"  // length of / days in inner not Period
+	DiagInvalidBetweenEndpoint = "invalid_between_endpoint" // between A and B endpoint not Date
+	DiagInvalidPeriodRange     = "invalid_period_range"     // between A and B where end < start (statically detectable)
+
 	// Variable diagnostics
 	DiagUndefinedVariable    = "undefined_variable"
 	DiagVariableRedefinition = "variable_redefinition"

--- a/spec/semantic/diagnostics.go
+++ b/spec/semantic/diagnostics.go
@@ -56,11 +56,12 @@ const (
 	DiagIncompatibleUnits    = "incompatible_units"
 
 	// Date diagnostics (USER REQUIREMENT)
-	DiagInvalidDate     = "invalid_date"
-	DiagInvalidMonth    = "invalid_month"
-	DiagInvalidDay      = "invalid_day"
-	DiagInvalidYear     = "invalid_year"
-	DiagInvalidLeapYear = "invalid_leap_year"
+	DiagInvalidDate        = "invalid_date"
+	DiagInvalidMonth       = "invalid_month"
+	DiagInvalidDay         = "invalid_day"
+	DiagInvalidYear        = "invalid_year"
+	DiagInvalidLeapYear    = "invalid_leap_year"
+	DiagInvalidEndOfPeriod = "invalid_end_of_period"
 
 	// Variable diagnostics
 	DiagUndefinedVariable    = "undefined_variable"

--- a/spec/semantic/end_of_check.go
+++ b/spec/semantic/end_of_check.go
@@ -113,25 +113,14 @@ func (c *Checker) checkEndOfStartOfInner(inner ast.Node, op string, r *ast.Range
 			})
 		}
 	case *ast.DateLiteral:
-		// Bare month names like `April` parse as DateLiteral with
-		// implicit Day=1, Year=nil. Semantically these are calendar
-		// periods (the whole month), not specific dates -- they were
-		// accepted as period inners pre-PR-1b through the old
-		// string-prefix dispatch's resolveEndOfMonth fallback.
-		// Accept them here so `end of April` keeps working.
-		// Discriminator: SourceText with no digits => bare month
-		// name (no day, no year). With digits => specific date
-		// (e.g., `April 15`, `Apr 1 2026`) and reject.
+		// DateLiteral always represents a specific date in v2.0 —
+		// bare month names (`April`) are routed to RelativeDateLiteral
+		// by the parser (U5). Any DateLiteral reaching here is
+		// unambiguously a Date, not a Period.
 		//
-		// This is a transitional shim. The brainstorm at
-		// docs/brainstorms/2026-04-29-period-data-type-and-go-semantics-requirements.md
-		// (calcmark-web) decided April should become a Period type
-		// outright; once that migration lands, the parser will emit
-		// a Period-bearing node directly and this DateLiteral arm
-		// can collapse back to a single rejection rule.
-		if !sourceTextHasDigit(v.SourceText) {
-			break // accept as period
-		}
+		// Pre-U5, this arm carried a transitional shim that accepted
+		// SourceText-without-digits as a bare-month period. After U5,
+		// that path is unreachable — collapsed.
 		c.addDiagnostic(Diagnostic{
 			Severity: Error,
 			Code:     DiagInvalidEndOfPeriod,
@@ -177,15 +166,3 @@ func (c *Checker) checkEndOfStartOfInner(inner ast.Node, op string, r *ast.Range
 	c.checkNode(inner)
 }
 
-// sourceTextHasDigit reports whether s contains any digit character.
-// Used to distinguish bare month names (`April`) from specific date
-// literals (`April 15`, `Apr 1 2026`) since both parse as the same
-// AST node type but only the former is period-bearing.
-func sourceTextHasDigit(s string) bool {
-	for _, r := range s {
-		if r >= '0' && r <= '9' {
-			return true
-		}
-	}
-	return false
-}

--- a/spec/semantic/end_of_check.go
+++ b/spec/semantic/end_of_check.go
@@ -1,0 +1,159 @@
+// Period-bearing inner-expression check for `end of` / `start of`
+// operators. Inline-AST only -- does NOT extend the TypeKind enum.
+// See docs/plans (downstream calcmark-web) for the rationale: a new
+// TypeKind value would be a public API break for downstream
+// consumers that switch on TypeKind without `default`.
+package semantic
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/CalcMark/go-calcmark/spec/ast"
+)
+
+// isPeriodKeyword reports whether the given RelativeDateLiteral
+// keyword names a period-producing form (something `end of` /
+// `start of` can take). Mirrors evalRelativeDateLiteral's
+// period-bearing arms in impl/interpreter/datetime.go -- when a new
+// period kind is added there, add it here too.
+//
+// Non-period date keywords (today, tomorrow, yesterday, now) return
+// false. They evaluate to a single Date, not a Period.
+func isPeriodKeyword(keyword string) bool {
+	kw := strings.ToLower(strings.TrimSpace(keyword))
+
+	// Known relative-period keywords (this/next/last + period unit).
+	switch kw {
+	case "this week", "next week", "last week",
+		"this month", "next month", "last month",
+		"this year", "next year", "last year",
+		"this quarter", "next quarter", "last quarter",
+		"this fiscal quarter", "next fiscal quarter", "last fiscal quarter",
+		"this fiscal year", "next fiscal year", "last fiscal year":
+		return true
+	}
+
+	// Notation forms: Q:N, FQ:N, FY:NNNN, CY:NNNN.
+	if strings.HasPrefix(kw, "q:") || strings.HasPrefix(kw, "fq:") ||
+		strings.HasPrefix(kw, "fy:") || strings.HasPrefix(kw, "cy:") {
+		return true
+	}
+
+	// Named months (`this january`, `next april`, etc.). Bare month
+	// names without a modifier are not period literals on their own
+	// in the lexer; the parser wraps them with `this`. So we only
+	// need to recognize the modifier-prefixed forms here.
+	for _, prefix := range []string{"this ", "next ", "last "} {
+		if strings.HasPrefix(kw, prefix) {
+			rest := strings.TrimPrefix(kw, prefix)
+			if isMonthName(rest) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// isMonthName reports whether the given lowercase string is a
+// recognized month name or 3-letter abbreviation. Mirrors the
+// `canonicalMonths` map in impl/interpreter/datetime.go.
+func isMonthName(s string) bool {
+	switch s {
+	case "january", "jan",
+		"february", "feb",
+		"march", "mar",
+		"april", "apr",
+		"may",
+		"june", "jun",
+		"july", "jul",
+		"august", "aug",
+		"september", "sep", "sept",
+		"october", "oct",
+		"november", "nov",
+		"december", "dec":
+		return true
+	}
+	return false
+}
+
+// checkEndOfStartOfInner validates that the inner expression of an
+// `end of` / `start of` operator is a period-bearing AST shape.
+//
+// Inline-AST check (no TypeKind enum extension):
+//   - *ast.RelativeDateLiteral with isPeriodKeyword(.Keyword) -> OK.
+//     Includes Q1-Q4, FQ1-FQ4, FY/CY year literals (which become
+//     "FY:NNNN" / "CY:NNNN" keywords from the parser), this/next/last
+//     <period>, named-month forms.
+//   - *ast.Identifier -> OK at type-check; runtime catches non-Period
+//     bindings. Documented as the R9-demoted path -- introducing
+//     forward type-inference through assignment is a separate PR.
+//   - Anything else -> Diagnostic with the actual node type named
+//     in the message.
+func (c *Checker) checkEndOfStartOfInner(inner ast.Node, op string, r *ast.Range) {
+	if inner == nil {
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidEndOfPeriod,
+			Message:  fmt.Sprintf("%s: missing inner expression", op),
+			Range:    r,
+		})
+		return
+	}
+
+	switch v := inner.(type) {
+	case *ast.RelativeDateLiteral:
+		if !isPeriodKeyword(v.Keyword) {
+			c.addDiagnostic(Diagnostic{
+				Severity: Error,
+				Code:     DiagInvalidEndOfPeriod,
+				Message:  fmt.Sprintf("%s requires a period; got Date (%s)", op, v.Keyword),
+				Range:    r,
+			})
+		}
+	case *ast.Identifier:
+		// Variable-bound: type-checker permits, runtime catches
+		// non-Period values. R9 emergent capability is deferred to
+		// a future PR with full *types.Period plumbing.
+	case *ast.NumberLiteral:
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidEndOfPeriod,
+			Message:  fmt.Sprintf("%s requires a period; got Number", op),
+			Range:    r,
+		})
+	case *ast.CurrencyLiteral:
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidEndOfPeriod,
+			Message:  fmt.Sprintf("%s requires a period; got Currency", op),
+			Range:    r,
+		})
+	case *ast.DateLiteral:
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidEndOfPeriod,
+			Message:  fmt.Sprintf("%s requires a period; got Date", op),
+			Range:    r,
+		})
+	case *ast.QuantityLiteral:
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidEndOfPeriod,
+			Message:  fmt.Sprintf("%s requires a period; got Quantity", op),
+			Range:    r,
+		})
+	default:
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidEndOfPeriod,
+			Message:  fmt.Sprintf("%s requires a period; inner expression is not a period", op),
+			Range:    r,
+		})
+	}
+	// Recurse so nested issues still surface (e.g., inner uses an
+	// undefined identifier — the existing identifier-check handles
+	// that).
+	c.checkNode(inner)
+}

--- a/spec/semantic/end_of_check.go
+++ b/spec/semantic/end_of_check.go
@@ -112,6 +112,32 @@ func (c *Checker) checkEndOfStartOfInner(inner ast.Node, op string, r *ast.Range
 				Range:    r,
 			})
 		}
+	case *ast.DateLiteral:
+		// Bare month names like `April` parse as DateLiteral with
+		// implicit Day=1, Year=nil. Semantically these are calendar
+		// periods (the whole month), not specific dates -- they were
+		// accepted as period inners pre-PR-1b through the old
+		// string-prefix dispatch's resolveEndOfMonth fallback.
+		// Accept them here so `end of April` keeps working.
+		// Discriminator: SourceText with no digits => bare month
+		// name (no day, no year). With digits => specific date
+		// (e.g., `April 15`, `Apr 1 2026`) and reject.
+		//
+		// This is a transitional shim. The brainstorm at
+		// docs/brainstorms/2026-04-29-period-data-type-and-go-semantics-requirements.md
+		// (calcmark-web) decided April should become a Period type
+		// outright; once that migration lands, the parser will emit
+		// a Period-bearing node directly and this DateLiteral arm
+		// can collapse back to a single rejection rule.
+		if !sourceTextHasDigit(v.SourceText) {
+			break // accept as period
+		}
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidEndOfPeriod,
+			Message:  fmt.Sprintf("%s requires a period; got Date", op),
+			Range:    r,
+		})
 	case *ast.Identifier:
 		// Variable-bound: type-checker permits, runtime catches
 		// non-Period values. R9 emergent capability is deferred to
@@ -128,13 +154,6 @@ func (c *Checker) checkEndOfStartOfInner(inner ast.Node, op string, r *ast.Range
 			Severity: Error,
 			Code:     DiagInvalidEndOfPeriod,
 			Message:  fmt.Sprintf("%s requires a period; got Currency", op),
-			Range:    r,
-		})
-	case *ast.DateLiteral:
-		c.addDiagnostic(Diagnostic{
-			Severity: Error,
-			Code:     DiagInvalidEndOfPeriod,
-			Message:  fmt.Sprintf("%s requires a period; got Date", op),
 			Range:    r,
 		})
 	case *ast.QuantityLiteral:
@@ -156,4 +175,17 @@ func (c *Checker) checkEndOfStartOfInner(inner ast.Node, op string, r *ast.Range
 	// undefined identifier — the existing identifier-check handles
 	// that).
 	c.checkNode(inner)
+}
+
+// sourceTextHasDigit reports whether s contains any digit character.
+// Used to distinguish bare month names (`April`) from specific date
+// literals (`April 15`, `Apr 1 2026`) since both parse as the same
+// AST node type but only the former is period-bearing.
+func sourceTextHasDigit(s string) bool {
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			return true
+		}
+	}
+	return false
 }

--- a/spec/semantic/end_of_check_test.go
+++ b/spec/semantic/end_of_check_test.go
@@ -109,6 +109,61 @@ func TestSemantic_StartOfTomorrowRejected(t *testing.T) {
 	}
 }
 
+// TestSemantic_EndOfBareMonthNameIsAccepted — regression for a
+// PR-1b bug. Pre-PR-1b, `end of April` (bare month name, no `this`
+// modifier) worked because the old string-prefix dispatch was
+// forgiving. PR-1b's stricter AST-level type check rejects it
+// because the parser emits *ast.DateLiteral{Month: "April",
+// Day: "1", Year: nil, SourceText: "April"} for the bare form,
+// and DateLiteral wasn't recognized as a period. The downstream
+// brainstorm decided April should become a Period type entirely,
+// but until that migration lands, bare month names need to be
+// accepted as period-bearing inner expressions.
+//
+// Discriminator for "bare month name" (vs specific date like
+// `April 15`): SourceText contains no digits. Bare month names
+// don't have a day or year written; specific dates always do.
+func TestSemantic_EndOfBareMonthNameIsAccepted(t *testing.T) {
+	for _, input := range []string{
+		"x = end of April",
+		"x = end of January",
+		"x = end of December",
+		"x = end of Apr",
+		"x = end of jan", // case-insensitive
+		"x = start of April",
+		"x = start of November",
+	} {
+		t.Run(input, func(t *testing.T) {
+			diags := runChecker(t, input)
+			if hasEndOfPeriodDiagnostic(diags) {
+				t.Errorf("bare month name should be accepted as period; %q got %v",
+					input, diags)
+			}
+		})
+	}
+}
+
+// TestSemantic_EndOfSpecificDateRejected — the inverse: when the
+// user writes an explicit date (with day or year), it's a Date
+// not a Period, and `end of` rejects it. Discriminator: source
+// text contains digits.
+func TestSemantic_EndOfSpecificDateRejected(t *testing.T) {
+	for _, input := range []string{
+		"x = end of April 15",
+		"x = end of Apr 1 2026",
+		"x = end of December 25 2026",
+		"x = end of Jan 1",
+	} {
+		t.Run(input, func(t *testing.T) {
+			diags := runChecker(t, input)
+			if !hasEndOfPeriodDiagnostic(diags) {
+				t.Errorf("specific date should be rejected by end of; %q got no diagnostic",
+					input)
+			}
+		})
+	}
+}
+
 func TestSemantic_EndOfIdentifierAcceptedAtTypeCheck(t *testing.T) {
 	// Variable-bound case is the R9 demoted path -- semantic
 	// permits, runtime catches non-Period values. Asserts NO

--- a/spec/semantic/end_of_check_test.go
+++ b/spec/semantic/end_of_check_test.go
@@ -1,0 +1,136 @@
+package semantic
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/CalcMark/go-calcmark/spec/parser"
+)
+
+// runChecker parses + checks the input and returns its diagnostics.
+func runChecker(t *testing.T, input string) []Diagnostic {
+	t.Helper()
+	nodes, err := parser.Parse(input)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", input, err)
+	}
+	c := NewChecker()
+	c.Check(nodes)
+	return c.diagnostics
+}
+
+// hasEndOfPeriodDiagnostic reports whether the diag list contains
+// the period-required error (used for both `end of` and `start of`).
+func hasEndOfPeriodDiagnostic(diags []Diagnostic) bool {
+	for _, d := range diags {
+		if d.Code == DiagInvalidEndOfPeriod {
+			return true
+		}
+	}
+	return false
+}
+
+// findInvalidEndOfPeriodMessage returns the first matching diag's
+// message for substring assertions, or "" if no diagnostic exists.
+func findInvalidEndOfPeriodMessage(diags []Diagnostic) string {
+	for _, d := range diags {
+		if d.Code == DiagInvalidEndOfPeriod {
+			return d.Message
+		}
+	}
+	return ""
+}
+
+func TestSemantic_EndOfPeriodLiteralIsClean(t *testing.T) {
+	for _, input := range []string{
+		"x = end of Q1",
+		"x = end of Q2",
+		"x = end of FQ1",
+		"x = end of this month",
+		"x = end of this fiscal quarter",
+		"x = end of this fiscal year",
+		"x = end of next quarter",
+		"x = end of last fiscal year",
+	} {
+		t.Run(input, func(t *testing.T) {
+			diags := runChecker(t, input)
+			if hasEndOfPeriodDiagnostic(diags) {
+				t.Errorf("expected no end-of-period diagnostic for %q; got %v", input, diags)
+			}
+		})
+	}
+}
+
+func TestSemantic_StartOfPeriodLiteralIsClean(t *testing.T) {
+	for _, input := range []string{
+		"x = start of Q1",
+		"x = start of FQ2",
+		"x = start of this month",
+	} {
+		t.Run(input, func(t *testing.T) {
+			diags := runChecker(t, input)
+			if hasEndOfPeriodDiagnostic(diags) {
+				t.Errorf("expected no diagnostic for %q; got %v", input, diags)
+			}
+		})
+	}
+}
+
+func TestSemantic_EndOfTodayRejected(t *testing.T) {
+	diags := runChecker(t, "x = end of today")
+	msg := findInvalidEndOfPeriodMessage(diags)
+	if msg == "" {
+		t.Fatalf("expected end-of-period diagnostic for `end of today`; got %v", diags)
+	}
+	if !strings.Contains(msg, "Date") || !strings.Contains(msg, "end of") {
+		t.Errorf("diagnostic message %q should mention `Date` and `end of`", msg)
+	}
+}
+
+func TestSemantic_EndOfNumberRejected(t *testing.T) {
+	diags := runChecker(t, "x = end of 5")
+	msg := findInvalidEndOfPeriodMessage(diags)
+	if msg == "" {
+		t.Fatalf("expected end-of-period diagnostic for `end of 5`; got %v", diags)
+	}
+	if !strings.Contains(msg, "Number") {
+		t.Errorf("diagnostic message %q should mention `Number`", msg)
+	}
+}
+
+func TestSemantic_StartOfTomorrowRejected(t *testing.T) {
+	diags := runChecker(t, "x = start of tomorrow")
+	msg := findInvalidEndOfPeriodMessage(diags)
+	if msg == "" {
+		t.Fatalf("expected diagnostic for `start of tomorrow`; got %v", diags)
+	}
+	if !strings.Contains(msg, "start of") {
+		t.Errorf("diagnostic message %q should mention `start of`", msg)
+	}
+}
+
+func TestSemantic_EndOfIdentifierAcceptedAtTypeCheck(t *testing.T) {
+	// Variable-bound case is the R9 demoted path -- semantic
+	// permits, runtime catches non-Period values. Asserts NO
+	// invalid-end-of-period diagnostic fires.
+	diags := runChecker(t, "q = Q1\ne = end of q")
+	if hasEndOfPeriodDiagnostic(diags) {
+		t.Errorf("type-checker should not reject `end of q` (variable-bound); deferred to runtime. Got: %v", diags)
+	}
+}
+
+func TestSemantic_NoTypePeriodInTypeKindEnum(t *testing.T) {
+	// Invariant per the deepening pass: do NOT extend the TypeKind
+	// enum with TypePeriod. Avoids breaking downstream consumers
+	// switching on TypeKind without `default`.
+	//
+	// This is structural: if a future maintainer adds TypePeriod,
+	// the test below fails -- forcing them to revisit the design.
+	const wantKindCount = 8 // Number / Currency / Boolean / Date / Time / Duration / Quantity / Percentage
+	last := TypePercentage // last constant in the iota sequence
+	if int(last) != wantKindCount-1 {
+		t.Errorf("TypeKind enum size changed: last value %d, want %d. "+
+			"If TypePeriod was added, revisit the API-break analysis in the PR-1b plan.",
+			int(last), wantKindCount-1)
+	}
+}

--- a/spec/semantic/period_operator_checks.go
+++ b/spec/semantic/period_operator_checks.go
@@ -1,0 +1,172 @@
+// Period-operator inner checks for v2.0 forms:
+//   - `length of <P>` / `days in <P>` (LengthOfExpr): inner must
+//     type as Period.
+//   - `between A and B` (BetweenExpr): both endpoints must type as
+//     Date.
+//
+// Like checkEndOfStartOfInner, these are AST-shape checks (not full
+// type inference). Variable-bound inputs (Identifier) defer to
+// runtime — the R9-deferred path. NumberLiteral / BooleanLiteral /
+// QuantityLiteral / etc. are rejected up-front because their type
+// is statically obvious.
+package semantic
+
+import (
+	"fmt"
+
+	"github.com/CalcMark/go-calcmark/spec/ast"
+)
+
+// checkLengthOfInner validates the inner expression of `length of
+// <P>` / `days in <P>`. Mirrors checkEndOfStartOfInner. The op
+// argument is "length of" or "days in" so the diagnostic message
+// names the surface form the user typed.
+func (c *Checker) checkLengthOfInner(inner ast.Node, op string, r *ast.Range) {
+	if inner == nil {
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidLengthOfPeriod,
+			Message:  fmt.Sprintf("%s: missing inner expression", op),
+			Range:    r,
+		})
+		return
+	}
+
+	switch v := inner.(type) {
+	case *ast.RelativeDateLiteral:
+		// Period keywords (Q1, this month, this April, FY2027, etc.)
+		// → accept. True date keywords (today, tomorrow, yesterday,
+		// now) → reject.
+		if !isPeriodKeyword(v.Keyword) {
+			c.addDiagnostic(Diagnostic{
+				Severity: Error,
+				Code:     DiagInvalidLengthOfPeriod,
+				Message:  fmt.Sprintf("%s requires a period; got Date (%s)", op, v.Keyword),
+				Range:    r,
+			})
+		}
+	case *ast.DateLiteral:
+		// Specific date (April 15, Apr 1 2026, January 2026 with
+		// year). Bare months no longer reach this arm — U5 routes
+		// them to RelativeDateLiteral.
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidLengthOfPeriod,
+			Message:  fmt.Sprintf("%s requires a period; got Date", op),
+			Range:    r,
+		})
+	case *ast.Identifier:
+		// Variable-bound: type-checker permits, runtime catches
+		// non-Period bindings. Same R9-deferred path as end-of.
+	case *ast.NumberLiteral:
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidLengthOfPeriod,
+			Message:  fmt.Sprintf("%s requires a period; got Number", op),
+			Range:    r,
+		})
+	case *ast.BooleanLiteral:
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidLengthOfPeriod,
+			Message:  fmt.Sprintf("%s requires a period; got Boolean", op),
+			Range:    r,
+		})
+	case *ast.CurrencyLiteral:
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidLengthOfPeriod,
+			Message:  fmt.Sprintf("%s requires a period; got Currency", op),
+			Range:    r,
+		})
+	case *ast.QuantityLiteral:
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidLengthOfPeriod,
+			Message:  fmt.Sprintf("%s requires a period; got Quantity", op),
+			Range:    r,
+		})
+	case *ast.DurationLiteral:
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidLengthOfPeriod,
+			Message:  fmt.Sprintf("%s requires a period; got Duration", op),
+			Range:    r,
+		})
+	default:
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidLengthOfPeriod,
+			Message:  fmt.Sprintf("%s requires a period; inner expression is not a period", op),
+			Range:    r,
+		})
+	}
+	// Recurse so nested issues still surface (undefined identifiers,
+	// invalid date components, etc.).
+	c.checkNode(inner)
+}
+
+// checkBetweenEndpoint validates one endpoint of a `between A and
+// B` / `from A to B` form. Both Start and End must type as Date.
+// Variable-bound endpoints (Identifier) defer to runtime; obvious
+// non-Date literals are rejected.
+//
+// labelKind is "start" or "end" so the diagnostic message tells the
+// user which endpoint is wrong.
+func (c *Checker) checkBetweenEndpoint(node ast.Node, labelKind string, r *ast.Range) {
+	if node == nil {
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidBetweenEndpoint,
+			Message:  fmt.Sprintf("between: missing %s endpoint", labelKind),
+			Range:    r,
+		})
+		return
+	}
+	switch node.(type) {
+	case *ast.DateLiteral, *ast.RelativeDateLiteral, *ast.Identifier, *ast.BinaryOp:
+		// Date literals (`Apr 15 2026`), date keywords (`today`,
+		// `tomorrow`, `next month` — Period inputs are also accepted
+		// here for now since runtime will narrow them to Date),
+		// variable-bound (R9-deferred path), and BinaryOp expressions
+		// like `today + 30 days` (must reduce to Date at runtime).
+		// Runtime catches non-Date results.
+	case *ast.NumberLiteral:
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidBetweenEndpoint,
+			Message:  fmt.Sprintf("between requires Date inputs; got Number for %s endpoint", labelKind),
+			Range:    r,
+		})
+	case *ast.BooleanLiteral:
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidBetweenEndpoint,
+			Message:  fmt.Sprintf("between requires Date inputs; got Boolean for %s endpoint", labelKind),
+			Range:    r,
+		})
+	case *ast.CurrencyLiteral:
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidBetweenEndpoint,
+			Message:  fmt.Sprintf("between requires Date inputs; got Currency for %s endpoint", labelKind),
+			Range:    r,
+		})
+	case *ast.QuantityLiteral:
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidBetweenEndpoint,
+			Message:  fmt.Sprintf("between requires Date inputs; got Quantity for %s endpoint", labelKind),
+			Range:    r,
+		})
+	case *ast.DurationLiteral:
+		c.addDiagnostic(Diagnostic{
+			Severity: Error,
+			Code:     DiagInvalidBetweenEndpoint,
+			Message:  fmt.Sprintf("between requires Date inputs; got Duration for %s endpoint", labelKind),
+			Range:    r,
+		})
+	}
+	// Recurse so nested issues surface.
+	c.checkNode(node)
+}

--- a/spec/semantic/period_operators_test.go
+++ b/spec/semantic/period_operators_test.go
@@ -1,0 +1,241 @@
+package semantic
+
+import (
+	"strings"
+	"testing"
+)
+
+// U9 — semantic checks for v2.0 period operators.
+//
+// `length of <P>` / `days in <P>` mirror `end of <P>` / `start of
+// <P>`: inner must be period-bearing (RelativeDateLiteral with a
+// period keyword, an Identifier deferred to runtime, or a future
+// Period literal). Non-period inner (NumberLiteral, BareCurrency,
+// DateLiteral with explicit day, true date keywords like `today`)
+// is rejected at the semantic layer.
+//
+// `between A and B` / `from A to B` requires both endpoints to type
+// as Date. Identifiers defer to runtime; obvious non-Date literals
+// (NumberLiteral, BooleanLiteral) are rejected.
+
+func hasDiag(diags []Diagnostic, code string) bool {
+	for _, d := range diags {
+		if d.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func findDiagMessage(diags []Diagnostic, code string) string {
+	for _, d := range diags {
+		if d.Code == code {
+			return d.Message
+		}
+	}
+	return ""
+}
+
+// --- length of / days in ---
+
+func TestSemantic_LengthOfPeriodLiteralIsClean(t *testing.T) {
+	for _, input := range []string{
+		"x = length of Q1",
+		"x = length of FQ1",
+		"x = length of this month",
+		"x = length of this fiscal quarter",
+		"x = length of next quarter",
+		"x = length of April",
+		"x = length of last fiscal year",
+	} {
+		t.Run(input, func(t *testing.T) {
+			diags := runChecker(t, input)
+			if hasDiag(diags, DiagInvalidLengthOfPeriod) {
+				t.Errorf("expected no length-of diagnostic for %q; got %v", input, diags)
+			}
+		})
+	}
+}
+
+func TestSemantic_DaysInPeriodLiteralIsClean(t *testing.T) {
+	for _, input := range []string{
+		"x = days in Q1",
+		"x = days in this month",
+		"x = days in April",
+	} {
+		t.Run(input, func(t *testing.T) {
+			diags := runChecker(t, input)
+			if hasDiag(diags, DiagInvalidLengthOfPeriod) {
+				t.Errorf("expected no days-in diagnostic for %q; got %v", input, diags)
+			}
+		})
+	}
+}
+
+func TestSemantic_LengthOfTodayRejected(t *testing.T) {
+	diags := runChecker(t, "x = length of today")
+	msg := findDiagMessage(diags, DiagInvalidLengthOfPeriod)
+	if msg == "" {
+		t.Fatalf("expected length-of diagnostic for `length of today`; got %v", diags)
+	}
+	// Wording locked: cmw e2e + LSP surfaces match against this.
+	if !strings.Contains(msg, "length of requires a period") {
+		t.Errorf("diagnostic %q should contain 'length of requires a period'", msg)
+	}
+	if !strings.Contains(msg, "Date") {
+		t.Errorf("diagnostic %q should mention 'Date'", msg)
+	}
+}
+
+func TestSemantic_DaysInTodayRejected(t *testing.T) {
+	diags := runChecker(t, "x = days in today")
+	msg := findDiagMessage(diags, DiagInvalidLengthOfPeriod)
+	if msg == "" {
+		t.Fatalf("expected days-in diagnostic for `days in today`; got %v", diags)
+	}
+	if !strings.Contains(msg, "days in requires a period") {
+		t.Errorf("diagnostic %q should contain 'days in requires a period'", msg)
+	}
+	if !strings.Contains(msg, "Date") {
+		t.Errorf("diagnostic %q should mention 'Date'", msg)
+	}
+}
+
+func TestSemantic_DaysInNumberRejected(t *testing.T) {
+	diags := runChecker(t, "x = days in 5")
+	msg := findDiagMessage(diags, DiagInvalidLengthOfPeriod)
+	if msg == "" {
+		t.Fatalf("expected days-in diagnostic for `days in 5`; got %v", diags)
+	}
+	if !strings.Contains(msg, "days in requires a period") {
+		t.Errorf("diagnostic %q should contain 'days in requires a period'", msg)
+	}
+	if !strings.Contains(msg, "Number") {
+		t.Errorf("diagnostic %q should mention 'Number'", msg)
+	}
+}
+
+func TestSemantic_LengthOfSpecificDateRejected(t *testing.T) {
+	// `April 15` parses to DateLiteral with HasExplicitDay=true.
+	// That's a specific Date, not a Period; length-of must reject.
+	for _, input := range []string{
+		"x = length of April 15",
+		"x = length of Apr 1 2026",
+		"x = length of December 25 2026",
+	} {
+		t.Run(input, func(t *testing.T) {
+			diags := runChecker(t, input)
+			if !hasDiag(diags, DiagInvalidLengthOfPeriod) {
+				t.Errorf("specific date should be rejected by length-of; %q got no diagnostic", input)
+			}
+		})
+	}
+}
+
+func TestSemantic_LengthOfIdentifierAcceptedAtTypeCheck(t *testing.T) {
+	// Same R9-deferred path as `end of q`: classifier permits,
+	// runtime catches non-Period bindings.
+	diags := runChecker(t, "q = Q1\ne = length of q")
+	if hasDiag(diags, DiagInvalidLengthOfPeriod) {
+		t.Errorf("type-checker should not reject `length of q` (variable-bound); deferred to runtime. Got: %v", diags)
+	}
+}
+
+// --- between / from-to ---
+
+func TestSemantic_BetweenDateLiteralIsClean(t *testing.T) {
+	for _, input := range []string{
+		"x = between Apr 15 2026 and Jul 4 2026",
+		"x = from Apr 15 2026 to Jul 4 2026",
+		"x = between today and next month",
+		"x = between today and tomorrow",
+	} {
+		t.Run(input, func(t *testing.T) {
+			diags := runChecker(t, input)
+			if hasDiag(diags, DiagInvalidBetweenEndpoint) {
+				t.Errorf("expected no between-endpoint diagnostic for %q; got %v", input, diags)
+			}
+		})
+	}
+}
+
+func TestSemantic_BetweenNumberEndpointRejected(t *testing.T) {
+	diags := runChecker(t, "x = between today and 5")
+	msg := findDiagMessage(diags, DiagInvalidBetweenEndpoint)
+	if msg == "" {
+		t.Fatalf("expected between-endpoint diagnostic for `between today and 5`; got %v", diags)
+	}
+	if !strings.Contains(msg, "between") {
+		t.Errorf("diagnostic %q should mention 'between'", msg)
+	}
+	if !strings.Contains(msg, "Date") {
+		t.Errorf("diagnostic %q should mention 'Date'", msg)
+	}
+}
+
+func TestSemantic_BetweenBooleanEndpointRejected(t *testing.T) {
+	diags := runChecker(t, "x = between true and today")
+	msg := findDiagMessage(diags, DiagInvalidBetweenEndpoint)
+	if msg == "" {
+		t.Fatalf("expected between-endpoint diagnostic for `between true and today`; got %v", diags)
+	}
+}
+
+// TestSemantic_BetweenIdentifierAcceptedAtTypeCheck — mirrors the
+// R9-deferred path. Variable-bound endpoints type-check; runtime
+// catches non-Date bindings.
+func TestSemantic_BetweenIdentifierAcceptedAtTypeCheck(t *testing.T) {
+	diags := runChecker(t, "a = today\nb = tomorrow\np = between a and b")
+	if hasDiag(diags, DiagInvalidBetweenEndpoint) {
+		t.Errorf("type-checker should not reject identifier endpoints; deferred to runtime. Got: %v", diags)
+	}
+}
+
+// --- transitional shim collapse (U5 + U9) ---
+//
+// Pre-U5, bare month names like `April` parsed as DateLiteral with
+// HasExplicitDay=false. The end-of/start-of checker had a
+// transitional shim that accepted DateLiteral when SourceText
+// contained no digits. After U5, bare months parse as
+// RelativeDateLiteral{Keyword: "this April"} directly, so the shim
+// is dead code. U9 collapses the shim back to "DateLiteral always
+// rejects" — `end of April` still works because it goes through
+// the RelativeDateLiteral arm via isPeriodKeyword("this April").
+
+func TestSemantic_EndOfBareMonth_StillAcceptedViaRelativeDateLiteral(t *testing.T) {
+	// Regression test for the shim collapse: bare month names must
+	// still flow through end-of cleanly via the new
+	// RelativeDateLiteral routing (U5).
+	for _, input := range []string{
+		"x = end of April",
+		"x = end of January",
+		"x = end of December",
+		"x = start of April",
+	} {
+		t.Run(input, func(t *testing.T) {
+			diags := runChecker(t, input)
+			if hasDiag(diags, DiagInvalidEndOfPeriod) {
+				t.Errorf("bare month should still be accepted (via RelativeDateLiteral path); %q got %v", input, diags)
+			}
+		})
+	}
+}
+
+// TestSemantic_EndOfDateLiteral_AlwaysRejected — after the shim
+// collapse, ANY DateLiteral inner is a specific date (since bare
+// months no longer produce DateLiteral) and must be rejected.
+// Pinning this so the simplification can't regress.
+func TestSemantic_EndOfDateLiteral_AlwaysRejected(t *testing.T) {
+	for _, input := range []string{
+		"x = end of April 15",
+		"x = end of Apr 1 2026",
+		"x = end of January 2026", // year-only: no explicit day, but Year set → still DateLiteral
+	} {
+		t.Run(input, func(t *testing.T) {
+			diags := runChecker(t, input)
+			if !hasDiag(diags, DiagInvalidEndOfPeriod) {
+				t.Errorf("DateLiteral should be rejected by end-of; %q got no diagnostic", input)
+			}
+		})
+	}
+}

--- a/spec/types/number.go
+++ b/spec/types/number.go
@@ -67,6 +67,8 @@ func typeName(t Type) string {
 		return "Date"
 	case *Duration:
 		return "Duration"
+	case *Period:
+		return "Period"
 	case *Rate:
 		return "Rate"
 	case *Percentage:

--- a/spec/types/period.go
+++ b/spec/types/period.go
@@ -173,6 +173,15 @@ func NewCalendarQuarter(year, quarter int) (*Period, error) {
 // fyStart's day-of-month is preserved across all four quarters so a
 // July-15 fiscal start yields FQ2 = Oct 15, FQ3 = Jan 15, etc.
 // Returns an error for quarters outside [1, 4].
+//
+// Period.Year is the FY *label* (Microsoft convention: the calendar
+// year the FY ENDS in). For Jul-start FY, fyStart=Jul 1 2025 →
+// fiscal year ends Jun 30 2026 → label 2026. So FQ1 of FY2026 is
+// "Fiscal Q1 2026", not "Fiscal Q1 2025" — matching how users
+// reference the quarter in conversation. The calendar year of the
+// FQ's start (which can differ from the label, e.g. FQ1 starts in
+// 2025 but belongs to FY2026) is recoverable from Period.Start
+// when needed.
 func NewFiscalQuarter(fyStart time.Time, quarter int) (*Period, error) {
 	if quarter < 1 || quarter > 4 {
 		return nil, fmt.Errorf("invalid fiscal quarter: FQ%d (must be 1-4)", quarter)
@@ -186,12 +195,20 @@ func NewFiscalQuarter(fyStart time.Time, quarter int) (*Period, error) {
 	}
 	startT := time.Date(startYear, startMonth, fyStart.Day(), 0, 0, 0, 0, time.UTC)
 	endT := startT.AddDate(0, 3, -1)
+
+	// FY label: year FY ends in. When FY-start month > 1, the FY
+	// straddles two calendar years and the label is start-year + 1.
+	// When FY-start month == 1 (Jan-start), label = start-year.
+	fyLabel := fyStart.Year()
+	if fyStart.Month() > time.January {
+		fyLabel++
+	}
 	return &Period{
 		Start:        NewDateFromTime(startT),
 		End:          NewDateFromTime(endT),
 		Kind:         PeriodFiscalQuarter,
 		QuarterIndex: quarter,
-		Year:         fyStart.Year(),
+		Year:         fyLabel,
 	}, nil
 }
 

--- a/spec/types/period.go
+++ b/spec/types/period.go
@@ -29,25 +29,31 @@ import (
 // import `impl/`. Period carries DATA, not behavior. End-of /
 // start-of arithmetic lives in impl/interpreter.
 type Period struct {
-	// Start is the first day of this period. Always populated; the
-	// rest of the fields are auxiliary context the interpreter uses
-	// to compute the period's end without re-deriving from Start.
+	// Start is the first day of this period. Always populated.
 	Start *Date
 
+	// End is the last day of this period (closed interval, day
+	// precision). Always populated by every factory at construction
+	// — code consuming Period must not need to re-derive End from
+	// Kind+context. PeriodCustom kinds carry End directly from the
+	// caller (`between A and B` / `from A to B`); named kinds
+	// (calendar/fiscal quarters, years, months, relatives) compute
+	// End once at factory time.
+	End *Date
+
 	// Kind is the period's discriminant. Switch on this in any code
-	// that needs kind-specific handling.
+	// that needs kind-specific handling (formatting, JSON shape).
 	Kind PeriodKind
 
 	// QuarterIndex is 1-4 for PeriodCalendarQuarter and
-	// PeriodFiscalQuarter; 0 for other kinds. Captures which quarter
-	// within the year so the interpreter can compute the next-quarter
-	// boundary (start + 3 months) without recomputing from Start.
+	// PeriodFiscalQuarter; 0 for other kinds.
 	QuarterIndex int
 
 	// Year is the calendar/fiscal year label:
 	//   - PeriodCalendarQuarter / PeriodCalendarYear / PeriodCalendarMonth: calendar year
 	//   - PeriodFiscalQuarter / PeriodFiscalYear: fiscal year label (Microsoft convention)
 	//   - Relative kinds: 0 (Direction is the relevant signal)
+	//   - PeriodCustom: 0
 	Year int
 
 	// Month is the calendar month (1-12) for PeriodCalendarMonth and
@@ -78,6 +84,10 @@ const (
 	PeriodRelativeQuarter
 	PeriodRelativeFiscalQuarter
 	PeriodRelativeFiscalYear
+	// PeriodCustom — user-defined period via `between A and B` /
+	// `from A to B`. Start and End come from the caller; no Year /
+	// Month / QuarterIndex / Direction context.
+	PeriodCustom
 )
 
 // String returns a human-readable description. Used in interpreter
@@ -108,6 +118,13 @@ func (p *Period) String() string {
 		return relativeLabel(p.Direction, "fiscal quarter")
 	case PeriodRelativeFiscalYear:
 		return relativeLabel(p.Direction, "fiscal year")
+	case PeriodCustom:
+		if p.Start != nil && p.End != nil {
+			return fmt.Sprintf("%s to %s",
+				p.Start.Time.Format("2006-01-02"),
+				p.End.Time.Format("2006-01-02"))
+		}
+		return "Period(custom)"
 	}
 	return fmt.Sprintf("Period(unknown kind %d)", p.Kind)
 }
@@ -132,9 +149,11 @@ func NewCalendarQuarter(year, quarter int) (*Period, error) {
 		return nil, fmt.Errorf("invalid calendar quarter: Q%d (must be 1-4)", quarter)
 	}
 	month := time.Month((quarter-1)*3 + 1) // Q1=Jan(1), Q2=Apr(4), Q3=Jul(7), Q4=Oct(10)
-	start := NewDateFromTime(time.Date(year, month, 1, 0, 0, 0, 0, time.UTC))
+	startT := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+	endT := startT.AddDate(0, 3, -1)
 	return &Period{
-		Start:        start,
+		Start:        NewDateFromTime(startT),
+		End:          NewDateFromTime(endT),
 		Kind:         PeriodCalendarQuarter,
 		QuarterIndex: quarter,
 		Year:         year,
@@ -158,9 +177,11 @@ func NewFiscalQuarter(fyStart time.Time, quarter int) (*Period, error) {
 		startMonth -= 12
 		startYear++
 	}
-	start := NewDateFromTime(time.Date(startYear, startMonth, fyStart.Day(), 0, 0, 0, 0, time.UTC))
+	startT := time.Date(startYear, startMonth, fyStart.Day(), 0, 0, 0, 0, time.UTC)
+	endT := startT.AddDate(0, 3, -1)
 	return &Period{
-		Start:        start,
+		Start:        NewDateFromTime(startT),
+		End:          NewDateFromTime(endT),
 		Kind:         PeriodFiscalQuarter,
 		QuarterIndex: quarter,
 		Year:         fyStart.Year(),
@@ -170,8 +191,11 @@ func NewFiscalQuarter(fyStart time.Time, quarter int) (*Period, error) {
 // NewCalendarYear creates a Period for Jan 1 - Dec 31 of the given
 // year.
 func NewCalendarYear(year int) *Period {
+	startT := time.Date(year, time.January, 1, 0, 0, 0, 0, time.UTC)
+	endT := time.Date(year, time.December, 31, 0, 0, 0, 0, time.UTC)
 	return &Period{
-		Start: NewDateFromTime(time.Date(year, time.January, 1, 0, 0, 0, 0, time.UTC)),
+		Start: NewDateFromTime(startT),
+		End:   NewDateFromTime(endT),
 		Kind:  PeriodCalendarYear,
 		Year:  year,
 	}
@@ -187,18 +211,25 @@ func NewFiscalYear(fyLabel int, fyStartMonth time.Month, fyStartDay int) *Period
 	if fyStartMonth > time.January {
 		startYear = fyLabel - 1
 	}
+	startT := time.Date(startYear, fyStartMonth, fyStartDay, 0, 0, 0, 0, time.UTC)
+	endT := startT.AddDate(1, 0, -1)
 	return &Period{
-		Start: NewDateFromTime(time.Date(startYear, fyStartMonth, fyStartDay, 0, 0, 0, 0, time.UTC)),
+		Start: NewDateFromTime(startT),
+		End:   NewDateFromTime(endT),
 		Kind:  PeriodFiscalYear,
 		Year:  fyLabel,
 	}
 }
 
 // NewCalendarMonth creates a Period for the 1st through last day of
-// the given month + year.
+// the given month + year. End handles leap years correctly via
+// time.Date normalization (Feb 29 in leap years, Feb 28 otherwise).
 func NewCalendarMonth(year int, month time.Month) *Period {
+	startT := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+	endT := startT.AddDate(0, 1, -1)
 	return &Period{
-		Start: NewDateFromTime(time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)),
+		Start: NewDateFromTime(startT),
+		End:   NewDateFromTime(endT),
 		Kind:  PeriodCalendarMonth,
 		Year:  year,
 		Month: int(month),
@@ -222,8 +253,11 @@ func NewRelativeQuarter(now time.Time, direction int) *Period {
 		year++
 	}
 	month := time.Month((q-1)*3 + 1)
+	startT := time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)
+	endT := startT.AddDate(0, 3, -1)
 	return &Period{
-		Start:        NewDateFromTime(time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)),
+		Start:        NewDateFromTime(startT),
+		End:          NewDateFromTime(endT),
 		Kind:         PeriodRelativeQuarter,
 		QuarterIndex: q,
 		Year:         year,
@@ -256,12 +290,38 @@ func NewRelativeFiscalQuarter(now time.Time, fyStartMonth time.Month, fyStartDay
 
 	// Apply direction.
 	fqStart = fqStart.AddDate(0, direction*3, 0)
+	fqEnd := fqStart.AddDate(0, 3, -1)
 
 	return &Period{
 		Start:     NewDateFromTime(fqStart),
+		End:       NewDateFromTime(fqEnd),
 		Kind:      PeriodRelativeFiscalQuarter,
 		Direction: direction,
 	}
+}
+
+// NewCustomPeriod creates a user-defined period spanning [start,
+// end] inclusive (closed interval, day precision). Backs the
+// `between A and B` / `from A to B` language forms.
+//
+// Validates: both endpoints non-nil; end >= start (single-day
+// periods where start == end are valid).
+func NewCustomPeriod(start, end *Date) (*Period, error) {
+	if start == nil {
+		return nil, fmt.Errorf("custom period: start is nil")
+	}
+	if end == nil {
+		return nil, fmt.Errorf("custom period: end is nil")
+	}
+	if end.Time.Before(start.Time) {
+		return nil, fmt.Errorf("custom period: end (%s) is before start (%s)",
+			end.Time.Format("2006-01-02"), start.Time.Format("2006-01-02"))
+	}
+	return &Period{
+		Start: start,
+		End:   end,
+		Kind:  PeriodCustom,
+	}, nil
 }
 
 // calendarQuarterOf returns 1-4 for the calendar quarter containing

--- a/spec/types/period.go
+++ b/spec/types/period.go
@@ -1,0 +1,271 @@
+package types
+
+import (
+	"fmt"
+	"time"
+)
+
+// Period represents a span of time -- a thing whose start and end
+// dates can be computed. The interpreter dispatches `end of` /
+// `start of` operators by Period.Kind: each kind knows enough about
+// its context (quarter index, year, fiscal-vs-calendar tag,
+// direction) to compute its end without re-parsing source text.
+//
+// Kinds in this enum cover every period-bearing keyword the lexer
+// accepts today: calendar quarters/years/months, fiscal
+// quarters/years, and the relative `this/next/last <period>` forms.
+// Adding a new kind requires (1) a new const here, (2) a factory
+// function, (3) an `evalEndOf` arm in impl/interpreter, (4) tests
+// across all three.
+//
+// Why a flat struct with conditional context fields rather than a
+// type hierarchy: mirrors the existing `spec/types/Duration` flat
+// shape (Value/Unit). Calcmark's value-type idiom is "one struct,
+// kind tag, fields populated per kind." Keeps the upstream
+// `types.Type` interface minimal (just String()) and avoids
+// scattering Period's eval logic across many type files.
+//
+// Dependency boundary: this package is `spec/types` -- it must not
+// import `impl/`. Period carries DATA, not behavior. End-of /
+// start-of arithmetic lives in impl/interpreter.
+type Period struct {
+	// Start is the first day of this period. Always populated; the
+	// rest of the fields are auxiliary context the interpreter uses
+	// to compute the period's end without re-deriving from Start.
+	Start *Date
+
+	// Kind is the period's discriminant. Switch on this in any code
+	// that needs kind-specific handling.
+	Kind PeriodKind
+
+	// QuarterIndex is 1-4 for PeriodCalendarQuarter and
+	// PeriodFiscalQuarter; 0 for other kinds. Captures which quarter
+	// within the year so the interpreter can compute the next-quarter
+	// boundary (start + 3 months) without recomputing from Start.
+	QuarterIndex int
+
+	// Year is the calendar/fiscal year label:
+	//   - PeriodCalendarQuarter / PeriodCalendarYear / PeriodCalendarMonth: calendar year
+	//   - PeriodFiscalQuarter / PeriodFiscalYear: fiscal year label (Microsoft convention)
+	//   - Relative kinds: 0 (Direction is the relevant signal)
+	Year int
+
+	// Month is the calendar month (1-12) for PeriodCalendarMonth and
+	// PeriodNamedMonth; 0 for other kinds.
+	Month int
+
+	// Direction is -1 / 0 / +1 for last / this / next on the relative
+	// kinds (PeriodRelativeWeek / Month / Year / Quarter /
+	// FiscalQuarter / FiscalYear). 0 for non-relative kinds.
+	Direction int
+}
+
+// PeriodKind discriminates Period values. Used by the interpreter's
+// `evalEndOf` switch and by `spec/semantic` to recognize
+// period-bearing AST shapes.
+type PeriodKind int
+
+const (
+	PeriodCalendarQuarter PeriodKind = iota
+	PeriodFiscalQuarter
+	PeriodCalendarMonth
+	PeriodCalendarYear
+	PeriodFiscalYear
+	PeriodNamedMonth
+	PeriodRelativeWeek
+	PeriodRelativeMonth
+	PeriodRelativeYear
+	PeriodRelativeQuarter
+	PeriodRelativeFiscalQuarter
+	PeriodRelativeFiscalYear
+)
+
+// String returns a human-readable description. Used in interpreter
+// diagnostics ("end of <period>") and debug output.
+func (p *Period) String() string {
+	switch p.Kind {
+	case PeriodCalendarQuarter:
+		return fmt.Sprintf("Calendar Q%d %d", p.QuarterIndex, p.Year)
+	case PeriodFiscalQuarter:
+		return fmt.Sprintf("Fiscal Q%d %d", p.QuarterIndex, p.Year)
+	case PeriodCalendarMonth:
+		return fmt.Sprintf("%s %d", time.Month(p.Month).String(), p.Year)
+	case PeriodCalendarYear:
+		return fmt.Sprintf("Calendar Year %d", p.Year)
+	case PeriodFiscalYear:
+		return fmt.Sprintf("Fiscal Year %d", p.Year)
+	case PeriodNamedMonth:
+		return time.Month(p.Month).String()
+	case PeriodRelativeWeek:
+		return relativeLabel(p.Direction, "week")
+	case PeriodRelativeMonth:
+		return relativeLabel(p.Direction, "month")
+	case PeriodRelativeYear:
+		return relativeLabel(p.Direction, "year")
+	case PeriodRelativeQuarter:
+		return relativeLabel(p.Direction, "quarter")
+	case PeriodRelativeFiscalQuarter:
+		return relativeLabel(p.Direction, "fiscal quarter")
+	case PeriodRelativeFiscalYear:
+		return relativeLabel(p.Direction, "fiscal year")
+	}
+	return fmt.Sprintf("Period(unknown kind %d)", p.Kind)
+}
+
+func relativeLabel(direction int, base string) string {
+	switch direction {
+	case -1:
+		return "last " + base
+	case 0:
+		return "this " + base
+	case +1:
+		return "next " + base
+	}
+	return base
+}
+
+// NewCalendarQuarter creates a Period for Q1-Q4 in the given year.
+// Q1=Jan-Mar, Q2=Apr-Jun, Q3=Jul-Sep, Q4=Oct-Dec. Returns an error
+// for quarters outside [1, 4].
+func NewCalendarQuarter(year, quarter int) (*Period, error) {
+	if quarter < 1 || quarter > 4 {
+		return nil, fmt.Errorf("invalid calendar quarter: Q%d (must be 1-4)", quarter)
+	}
+	month := time.Month((quarter-1)*3 + 1) // Q1=Jan(1), Q2=Apr(4), Q3=Jul(7), Q4=Oct(10)
+	start := NewDateFromTime(time.Date(year, month, 1, 0, 0, 0, 0, time.UTC))
+	return &Period{
+		Start:        start,
+		Kind:         PeriodCalendarQuarter,
+		QuarterIndex: quarter,
+		Year:         year,
+	}, nil
+}
+
+// NewFiscalQuarter creates a Period for the Nth fiscal quarter
+// starting from `fyStart` (the first day of FQ1). FQ1 == fyStart;
+// FQ2 = fyStart + 3 months; ... FQ4 = fyStart + 9 months.
+// fyStart's day-of-month is preserved across all four quarters so a
+// July-15 fiscal start yields FQ2 = Oct 15, FQ3 = Jan 15, etc.
+// Returns an error for quarters outside [1, 4].
+func NewFiscalQuarter(fyStart time.Time, quarter int) (*Period, error) {
+	if quarter < 1 || quarter > 4 {
+		return nil, fmt.Errorf("invalid fiscal quarter: FQ%d (must be 1-4)", quarter)
+	}
+	// Add (quarter-1)*3 months to fyStart while preserving the day.
+	startMonth := fyStart.Month() + time.Month((quarter-1)*3)
+	startYear := fyStart.Year()
+	for startMonth > 12 {
+		startMonth -= 12
+		startYear++
+	}
+	start := NewDateFromTime(time.Date(startYear, startMonth, fyStart.Day(), 0, 0, 0, 0, time.UTC))
+	return &Period{
+		Start:        start,
+		Kind:         PeriodFiscalQuarter,
+		QuarterIndex: quarter,
+		Year:         fyStart.Year(),
+	}, nil
+}
+
+// NewCalendarYear creates a Period for Jan 1 - Dec 31 of the given
+// year.
+func NewCalendarYear(year int) *Period {
+	return &Period{
+		Start: NewDateFromTime(time.Date(year, time.January, 1, 0, 0, 0, 0, time.UTC)),
+		Kind:  PeriodCalendarYear,
+		Year:  year,
+	}
+}
+
+// NewFiscalYear creates a Period whose start is fyStartMonth /
+// fyStartDay of the calendar year (fyLabel - 1) when fyStartMonth >
+// 1, else of fyLabel itself. Microsoft convention: FY2027 with July
+// start = Jul 1 2026 -> Jun 30 2027. The Period's Year field stores
+// the FY label (the year the FY ENDS), not the start year.
+func NewFiscalYear(fyLabel int, fyStartMonth time.Month, fyStartDay int) *Period {
+	startYear := fyLabel
+	if fyStartMonth > time.January {
+		startYear = fyLabel - 1
+	}
+	return &Period{
+		Start: NewDateFromTime(time.Date(startYear, fyStartMonth, fyStartDay, 0, 0, 0, 0, time.UTC)),
+		Kind:  PeriodFiscalYear,
+		Year:  fyLabel,
+	}
+}
+
+// NewCalendarMonth creates a Period for the 1st through last day of
+// the given month + year.
+func NewCalendarMonth(year int, month time.Month) *Period {
+	return &Period{
+		Start: NewDateFromTime(time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)),
+		Kind:  PeriodCalendarMonth,
+		Year:  year,
+		Month: int(month),
+	}
+}
+
+// NewRelativeQuarter creates a Period for `this`/`next`/`last
+// quarter` relative to `now`. Direction: -1 for last, 0 for this,
+// +1 for next. Start is the first day of the calendar quarter
+// containing the (offset-adjusted) now.
+func NewRelativeQuarter(now time.Time, direction int) *Period {
+	q := calendarQuarterOf(now.Month())
+	year := now.Year()
+	q += direction
+	for q < 1 {
+		q += 4
+		year--
+	}
+	for q > 4 {
+		q -= 4
+		year++
+	}
+	month := time.Month((q-1)*3 + 1)
+	return &Period{
+		Start:        NewDateFromTime(time.Date(year, month, 1, 0, 0, 0, 0, time.UTC)),
+		Kind:         PeriodRelativeQuarter,
+		QuarterIndex: q,
+		Year:         year,
+		Direction:    direction,
+	}
+}
+
+// NewRelativeFiscalQuarter creates a Period for `this`/`next`/`last
+// fiscal quarter` relative to `now`. Direction: -1 / 0 / +1.
+// fyStartMonth + fyStartDay are the configured fiscal-year start.
+func NewRelativeFiscalQuarter(now time.Time, fyStartMonth time.Month, fyStartDay int, direction int) *Period {
+	// Find the start of the fiscal quarter containing `now`.
+	// fyStart for the FY containing `now`:
+	startYear := now.Year()
+	if now.Month() < fyStartMonth || (now.Month() == fyStartMonth && now.Day() < fyStartDay) {
+		startYear--
+	}
+	fyStart := time.Date(startYear, fyStartMonth, fyStartDay, 0, 0, 0, 0, time.UTC)
+
+	// Walk forward in 3-month increments until we pass `now`. The
+	// last increment's start is the FQ containing `now`.
+	fqStart := fyStart
+	for {
+		next := fqStart.AddDate(0, 3, 0)
+		if next.After(now) {
+			break
+		}
+		fqStart = next
+	}
+
+	// Apply direction.
+	fqStart = fqStart.AddDate(0, direction*3, 0)
+
+	return &Period{
+		Start:     NewDateFromTime(fqStart),
+		Kind:      PeriodRelativeFiscalQuarter,
+		Direction: direction,
+	}
+}
+
+// calendarQuarterOf returns 1-4 for the calendar quarter containing
+// the given month.
+func calendarQuarterOf(month time.Month) int {
+	return int((month-1)/3) + 1
+}

--- a/spec/types/period.go
+++ b/spec/types/period.go
@@ -51,7 +51,7 @@ type Period struct {
 
 	// Year is the calendar/fiscal year label:
 	//   - PeriodCalendarQuarter / PeriodCalendarYear / PeriodCalendarMonth: calendar year
-	//   - PeriodFiscalQuarter / PeriodFiscalYear: fiscal year label (Microsoft convention)
+	//   - PeriodFiscalQuarter / PeriodFiscalYear: fiscal year label (per FYLabelMode; default = year FY ends in)
 	//   - Relative kinds: 0 (Direction is the relevant signal)
 	//   - PeriodCustom: 0
 	Year int
@@ -167,22 +167,49 @@ func NewCalendarQuarter(year, quarter int) (*Period, error) {
 	}, nil
 }
 
+// FYLabelMode controls which calendar year the fiscal-year label
+// corresponds to. Documents declare it via the `calendar_year_offset`
+// frontmatter key.
+//
+//   - FYLabelByEndYear (default; `calendar_year_offset: before`) —
+//     the FY label = the calendar year the FY ENDS in. The bulk of
+//     the FY's days fall in the calendar year before the label. Used
+//     by the Australian government year, the US tax year for non-
+//     calendar fiscal periods, and most publicly traded companies.
+//   - FYLabelByStartYear (`calendar_year_offset: after`) — the FY
+//     label = the calendar year the FY STARTS in. The bulk of the
+//     FY's days fall in the calendar year after the label. Used by
+//     some companies that align their FY label to its starting CY.
+type FYLabelMode int
+
+const (
+	// FYLabelByEndYear labels each FY by the calendar year it ends in.
+	// This is the default when `calendar_year_offset` is omitted.
+	FYLabelByEndYear FYLabelMode = iota
+	// FYLabelByStartYear labels each FY by the calendar year it starts in.
+	FYLabelByStartYear
+)
+
 // NewFiscalQuarter creates a Period for the Nth fiscal quarter
-// starting from `fyStart` (the first day of FQ1). FQ1 == fyStart;
-// FQ2 = fyStart + 3 months; ... FQ4 = fyStart + 9 months.
+// starting from `fyStart` (the first day of FQ1) under the default
+// FY labeling (FYLabelByEndYear). See NewFiscalQuarterWithMode for
+// documents that declare `calendar_year_offset: after`.
+func NewFiscalQuarter(fyStart time.Time, quarter int) (*Period, error) {
+	return NewFiscalQuarterWithMode(fyStart, quarter, FYLabelByEndYear)
+}
+
+// NewFiscalQuarterWithMode creates a Period for the Nth fiscal
+// quarter starting from `fyStart` (the first day of FQ1). FQ1 ==
+// fyStart; FQ2 = fyStart + 3 months; ... FQ4 = fyStart + 9 months.
 // fyStart's day-of-month is preserved across all four quarters so a
 // July-15 fiscal start yields FQ2 = Oct 15, FQ3 = Jan 15, etc.
 // Returns an error for quarters outside [1, 4].
 //
-// Period.Year is the FY *label* (Microsoft convention: the calendar
-// year the FY ENDS in). For Jul-start FY, fyStart=Jul 1 2025 →
-// fiscal year ends Jun 30 2026 → label 2026. So FQ1 of FY2026 is
-// "Fiscal Q1 2026", not "Fiscal Q1 2025" — matching how users
-// reference the quarter in conversation. The calendar year of the
-// FQ's start (which can differ from the label, e.g. FQ1 starts in
-// 2025 but belongs to FY2026) is recoverable from Period.Start
-// when needed.
-func NewFiscalQuarter(fyStart time.Time, quarter int) (*Period, error) {
+// `mode` controls how Period.Year is labeled. Under FYLabelByEndYear
+// (the default), Jul-start FY with fyStart=Jul 1 2025 → FY ends Jun
+// 30 2026 → label 2026, so FQ1 reads "Fiscal Q1 2026". Under
+// FYLabelByStartYear, the same FQ1 reads "Fiscal Q1 2025".
+func NewFiscalQuarterWithMode(fyStart time.Time, quarter int, mode FYLabelMode) (*Period, error) {
 	if quarter < 1 || quarter > 4 {
 		return nil, fmt.Errorf("invalid fiscal quarter: FQ%d (must be 1-4)", quarter)
 	}
@@ -196,11 +223,11 @@ func NewFiscalQuarter(fyStart time.Time, quarter int) (*Period, error) {
 	startT := time.Date(startYear, startMonth, fyStart.Day(), 0, 0, 0, 0, time.UTC)
 	endT := startT.AddDate(0, 3, -1)
 
-	// FY label: year FY ends in. When FY-start month > 1, the FY
-	// straddles two calendar years and the label is start-year + 1.
-	// When FY-start month == 1 (Jan-start), label = start-year.
 	fyLabel := fyStart.Year()
-	if fyStart.Month() > time.January {
+	if mode == FYLabelByEndYear && fyStart.Month() > time.January {
+		// End-year labeling: when FY-start month > 1, the FY straddles
+		// two calendar years and the label is start-year + 1. Jan-start
+		// FY collapses both modes to the same label (start == end year).
 		fyLabel++
 	}
 	return &Period{
@@ -225,14 +252,28 @@ func NewCalendarYear(year int) *Period {
 	}
 }
 
-// NewFiscalYear creates a Period whose start is fyStartMonth /
-// fyStartDay of the calendar year (fyLabel - 1) when fyStartMonth >
-// 1, else of fyLabel itself. Microsoft convention: FY2027 with July
-// start = Jul 1 2026 -> Jun 30 2027. The Period's Year field stores
-// the FY label (the year the FY ENDS), not the start year.
+// NewFiscalYear creates a Period for the fiscal year identified by
+// fyLabel under the default labeling (FYLabelByEndYear). FY2027 with
+// July start = Jul 1 2026 → Jun 30 2027. See NewFiscalYearWithMode
+// for documents that declare `calendar_year_offset: after`.
 func NewFiscalYear(fyLabel int, fyStartMonth time.Month, fyStartDay int) *Period {
+	return NewFiscalYearWithMode(fyLabel, fyStartMonth, fyStartDay, FYLabelByEndYear)
+}
+
+// NewFiscalYearWithMode creates a Period for the fiscal year
+// identified by fyLabel. `mode` controls how the label maps to a
+// calendar-year start:
+//
+//   - FYLabelByEndYear: start is fyStartMonth/fyStartDay of (fyLabel-1)
+//     when fyStartMonth > 1, else fyLabel itself. FY2027 with July
+//     start = Jul 1 2026 → Jun 30 2027.
+//   - FYLabelByStartYear: start is fyStartMonth/fyStartDay of fyLabel
+//     itself. FY2026 with Feb 2 start = Feb 2 2026 → Feb 1 2027.
+//
+// In both modes Period.Year stores the label as-given.
+func NewFiscalYearWithMode(fyLabel int, fyStartMonth time.Month, fyStartDay int, mode FYLabelMode) *Period {
 	startYear := fyLabel
-	if fyStartMonth > time.January {
+	if mode == FYLabelByEndYear && fyStartMonth > time.January {
 		startYear = fyLabel - 1
 	}
 	startT := time.Date(startYear, fyStartMonth, fyStartDay, 0, 0, 0, 0, time.UTC)

--- a/spec/types/period.go
+++ b/spec/types/period.go
@@ -105,6 +105,13 @@ func (p *Period) String() string {
 	case PeriodFiscalYear:
 		return fmt.Sprintf("Fiscal Year %d", p.Year)
 	case PeriodNamedMonth:
+		// `this April`, `next December`, `April` (bare). Include the
+		// resolved year so the rendered value disambiguates which
+		// year the named month points to. Falls back to the bare
+		// month name when Year is unset (legacy callers).
+		if p.Year != 0 {
+			return fmt.Sprintf("%s %d", time.Month(p.Month).String(), p.Year)
+		}
 		return time.Month(p.Month).String()
 	case PeriodRelativeWeek:
 		return relativeLabel(p.Direction, "week")

--- a/spec/types/period_test.go
+++ b/spec/types/period_test.go
@@ -1,0 +1,238 @@
+package types
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// Period is the value type that period-bearing date keywords (Q1,
+// FQ1, this month, this fiscal quarter, ...) evaluate to. The
+// interpreter dispatches `end of` / `start of` by Period.Kind. This
+// test file pins the value-type contract — it does NOT test eval.
+//
+// Test design — flat struct + kind enum (per plan's Key Decision
+// mirroring spec/types/duration.go's flat shape, vs. an interface
+// hierarchy). Each test asserts a concrete kind's factory output.
+
+func TestPeriodImplementsType(t *testing.T) {
+	var _ Type = (*Period)(nil)
+}
+
+func TestPeriod_NewCalendarQuarter(t *testing.T) {
+	cases := []struct {
+		year       int
+		quarter    int
+		wantMonth  time.Month
+		wantString string
+	}{
+		{2026, 1, time.January, "Calendar Q1 2026"},
+		{2026, 2, time.April, "Calendar Q2 2026"},
+		{2026, 3, time.July, "Calendar Q3 2026"},
+		{2026, 4, time.October, "Calendar Q4 2026"},
+	}
+	for _, tc := range cases {
+		p, err := NewCalendarQuarter(tc.year, tc.quarter)
+		if err != nil {
+			t.Fatalf("NewCalendarQuarter(%d, %d): %v", tc.year, tc.quarter, err)
+		}
+		if p.Kind != PeriodCalendarQuarter {
+			t.Errorf("Kind = %v, want PeriodCalendarQuarter", p.Kind)
+		}
+		if p.QuarterIndex != tc.quarter {
+			t.Errorf("QuarterIndex = %d, want %d", p.QuarterIndex, tc.quarter)
+		}
+		if p.Year != tc.year {
+			t.Errorf("Year = %d, want %d", p.Year, tc.year)
+		}
+		if p.Start == nil {
+			t.Fatalf("Start is nil")
+		}
+		if p.Start.Time.Year() != tc.year || p.Start.Time.Month() != tc.wantMonth || p.Start.Time.Day() != 1 {
+			t.Errorf("Start = %v, want %d-%v-01", p.Start.Time, tc.year, tc.wantMonth)
+		}
+		if got := p.String(); got != tc.wantString {
+			t.Errorf("String() = %q, want %q", got, tc.wantString)
+		}
+	}
+}
+
+func TestPeriod_NewCalendarQuarter_InvalidIndex(t *testing.T) {
+	for _, q := range []int{0, 5, -1, 100} {
+		if _, err := NewCalendarQuarter(2026, q); err == nil {
+			t.Errorf("NewCalendarQuarter(2026, %d) should error; got nil", q)
+		}
+	}
+}
+
+func TestPeriod_NewFiscalQuarter(t *testing.T) {
+	// FY starts April 1; FQ1 starts April; FQ2 = July; FQ3 = October; FQ4 = next January.
+	apr1 := time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC)
+	cases := []struct {
+		quarter int
+		want    time.Time
+	}{
+		{1, time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC)},
+		{2, time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)},
+		{3, time.Date(2026, time.October, 1, 0, 0, 0, 0, time.UTC)},
+		{4, time.Date(2027, time.January, 1, 0, 0, 0, 0, time.UTC)},
+	}
+	for _, tc := range cases {
+		p, err := NewFiscalQuarter(apr1, tc.quarter)
+		if err != nil {
+			t.Fatalf("NewFiscalQuarter(Apr 1, %d): %v", tc.quarter, err)
+		}
+		if p.Kind != PeriodFiscalQuarter {
+			t.Errorf("Kind = %v, want PeriodFiscalQuarter", p.Kind)
+		}
+		if !p.Start.Time.Equal(tc.want) {
+			t.Errorf("FQ%d Start = %v, want %v", tc.quarter, p.Start.Time, tc.want)
+		}
+	}
+}
+
+func TestPeriod_NewCalendarYear(t *testing.T) {
+	p := NewCalendarYear(2026)
+	if p.Kind != PeriodCalendarYear {
+		t.Errorf("Kind = %v, want PeriodCalendarYear", p.Kind)
+	}
+	if p.Year != 2026 {
+		t.Errorf("Year = %d, want 2026", p.Year)
+	}
+	if p.Start.Time.Year() != 2026 || p.Start.Time.Month() != time.January || p.Start.Time.Day() != 1 {
+		t.Errorf("Start = %v, want 2026-Jan-01", p.Start.Time)
+	}
+	if got := p.String(); got != "Calendar Year 2026" {
+		t.Errorf("String() = %q, want %q", got, "Calendar Year 2026")
+	}
+}
+
+func TestPeriod_NewFiscalYear(t *testing.T) {
+	// FY2027 with July start = starts Jul 1, 2026. (Microsoft labeling.)
+	p := NewFiscalYear(2027, time.July, 1)
+	if p.Kind != PeriodFiscalYear {
+		t.Errorf("Kind = %v, want PeriodFiscalYear", p.Kind)
+	}
+	if p.Year != 2027 {
+		t.Errorf("Year = %d, want 2027", p.Year)
+	}
+	want := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	if !p.Start.Time.Equal(want) {
+		t.Errorf("FY2027 Start = %v, want %v", p.Start.Time, want)
+	}
+	// String must surface the FY label, not the start year.
+	if !strings.Contains(p.String(), "2027") {
+		t.Errorf("String() = %q should contain FY label 2027", p.String())
+	}
+}
+
+func TestPeriod_NewCalendarMonth(t *testing.T) {
+	p := NewCalendarMonth(2026, time.July)
+	if p.Kind != PeriodCalendarMonth {
+		t.Errorf("Kind = %v, want PeriodCalendarMonth", p.Kind)
+	}
+	if p.Month != int(time.July) {
+		t.Errorf("Month = %d, want %d", p.Month, time.July)
+	}
+	want := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	if !p.Start.Time.Equal(want) {
+		t.Errorf("Start = %v, want %v", p.Start.Time, want)
+	}
+}
+
+func TestPeriod_NewRelativeQuarter(t *testing.T) {
+	// `this quarter` / `next quarter` / `last quarter` — Direction
+	// captures the offset relative to `now`.
+	cases := []struct {
+		name      string
+		direction int
+	}{
+		{"this", 0},
+		{"next", +1},
+		{"last", -1},
+	}
+	for _, tc := range cases {
+		now := time.Date(2026, time.May, 15, 0, 0, 0, 0, time.UTC) // Q2
+		p := NewRelativeQuarter(now, tc.direction)
+		if p.Kind != PeriodRelativeQuarter {
+			t.Errorf("Kind = %v, want PeriodRelativeQuarter", p.Kind)
+		}
+		if p.Direction != tc.direction {
+			t.Errorf("%s quarter Direction = %d, want %d", tc.name, p.Direction, tc.direction)
+		}
+		// Start must align to a quarter boundary.
+		if p.Start.Time.Day() != 1 {
+			t.Errorf("%s quarter Start day = %d, want 1", tc.name, p.Start.Time.Day())
+		}
+		switch p.Start.Time.Month() {
+		case time.January, time.April, time.July, time.October:
+			// Quarter boundary.
+		default:
+			t.Errorf("%s quarter Start month = %v, want a quarter boundary", tc.name, p.Start.Time.Month())
+		}
+	}
+}
+
+func TestPeriod_NewRelativeFiscalQuarter(t *testing.T) {
+	// FY starts April 1. May 15 sits in FQ1 (Apr-Jun).
+	now := time.Date(2026, time.May, 15, 0, 0, 0, 0, time.UTC)
+	fyStartMonth := time.April
+	fyStartDay := 1
+	cases := []struct {
+		name      string
+		direction int
+		wantStart time.Time
+	}{
+		{"this", 0, time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC)},
+		{"next", +1, time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)},
+		{"last", -1, time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)},
+	}
+	for _, tc := range cases {
+		p := NewRelativeFiscalQuarter(now, fyStartMonth, fyStartDay, tc.direction)
+		if p.Kind != PeriodRelativeFiscalQuarter {
+			t.Errorf("Kind = %v, want PeriodRelativeFiscalQuarter", p.Kind)
+		}
+		if !p.Start.Time.Equal(tc.wantStart) {
+			t.Errorf("%s fiscal quarter Start = %v, want %v", tc.name, p.Start.Time, tc.wantStart)
+		}
+	}
+}
+
+// TestPeriod_StringAlwaysNonEmpty — every kind must produce a
+// readable String() output. Used in interpreter diagnostics.
+func TestPeriod_StringAlwaysNonEmpty(t *testing.T) {
+	periods := []*Period{
+		mustCalendarQuarter(t, 2026, 1),
+		mustFiscalQuarter(t, 2026, time.April, 1, 2),
+		NewCalendarYear(2026),
+		NewFiscalYear(2027, time.April, 1),
+		NewCalendarMonth(2026, time.July),
+		NewRelativeQuarter(time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC), 0),
+		NewRelativeFiscalQuarter(time.Date(2026, 5, 15, 0, 0, 0, 0, time.UTC), time.April, 1, 0),
+	}
+	for _, p := range periods {
+		if p.String() == "" {
+			t.Errorf("Period{Kind: %v} produced empty String()", p.Kind)
+		}
+	}
+}
+
+// helpers — unwrap the err for less verbose test bodies.
+func mustCalendarQuarter(t *testing.T, year, q int) *Period {
+	t.Helper()
+	p, err := NewCalendarQuarter(year, q)
+	if err != nil {
+		t.Fatalf("NewCalendarQuarter(%d, %d): %v", year, q, err)
+	}
+	return p
+}
+
+func mustFiscalQuarter(t *testing.T, year int, fyStartMonth time.Month, fyStartDay int, q int) *Period {
+	t.Helper()
+	fyStart := time.Date(year, fyStartMonth, fyStartDay, 0, 0, 0, 0, time.UTC)
+	p, err := NewFiscalQuarter(fyStart, q)
+	if err != nil {
+		t.Fatalf("NewFiscalQuarter: %v", err)
+	}
+	return p
+}

--- a/spec/types/period_test.go
+++ b/spec/types/period_test.go
@@ -107,6 +107,42 @@ func TestPeriod_NewCalendarYear(t *testing.T) {
 	}
 }
 
+// TestPeriod_NewFiscalQuarter_YearIsFYLabel — Period.Year carries
+// the FY label (year FY ends in, Microsoft convention), not the
+// calendar year of the FQ's start. So FQ1 of FY2026 (Jul-start FY)
+// starts in calendar 2025 but labels as "Fiscal Q1 2026". The
+// calendar year of the start is recoverable from Period.Start when
+// users need it.
+func TestPeriod_NewFiscalQuarter_YearIsFYLabel(t *testing.T) {
+	cases := []struct {
+		name      string
+		fyStart   time.Time
+		quarter   int
+		wantLabel int
+	}{
+		// Jul-start FY → FY2026 (Jul 2025 – Jun 2026).
+		{"Jul-start FQ1", time.Date(2025, time.July, 1, 0, 0, 0, 0, time.UTC), 1, 2026},
+		{"Jul-start FQ4", time.Date(2025, time.July, 1, 0, 0, 0, 0, time.UTC), 4, 2026},
+		// Jan-start FY → FY label = start year.
+		{"Jan-start FQ1", time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC), 1, 2026},
+		// Apr-start FY → FY2027 (Apr 2026 – Mar 2027).
+		{"Apr-start FQ1", time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC), 1, 2027},
+		{"Apr-start FQ4", time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC), 4, 2027},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := NewFiscalQuarter(tc.fyStart, tc.quarter)
+			if err != nil {
+				t.Fatalf("NewFiscalQuarter: %v", err)
+			}
+			if p.Year != tc.wantLabel {
+				t.Errorf("Year = %d, want %d (FY label per Microsoft convention)",
+					p.Year, tc.wantLabel)
+			}
+		})
+	}
+}
+
 func TestPeriod_NewFiscalYear(t *testing.T) {
 	// FY2027 with July start = starts Jul 1, 2026. (Microsoft labeling.)
 	p := NewFiscalYear(2027, time.July, 1)

--- a/spec/types/period_test.go
+++ b/spec/types/period_test.go
@@ -108,7 +108,7 @@ func TestPeriod_NewCalendarYear(t *testing.T) {
 }
 
 // TestPeriod_NewFiscalQuarter_YearIsFYLabel — Period.Year carries
-// the FY label (year FY ends in, Microsoft convention), not the
+// the FY label (year FY ends in, default labeling), not the
 // calendar year of the FQ's start. So FQ1 of FY2026 (Jul-start FY)
 // starts in calendar 2025 but labels as "Fiscal Q1 2026". The
 // calendar year of the start is recoverable from Period.Start when
@@ -136,7 +136,7 @@ func TestPeriod_NewFiscalQuarter_YearIsFYLabel(t *testing.T) {
 				t.Fatalf("NewFiscalQuarter: %v", err)
 			}
 			if p.Year != tc.wantLabel {
-				t.Errorf("Year = %d, want %d (FY label per Microsoft convention)",
+				t.Errorf("Year = %d, want %d (FY label per default end-year convention)",
 					p.Year, tc.wantLabel)
 			}
 		})
@@ -144,7 +144,10 @@ func TestPeriod_NewFiscalQuarter_YearIsFYLabel(t *testing.T) {
 }
 
 func TestPeriod_NewFiscalYear(t *testing.T) {
-	// FY2027 with July start = starts Jul 1, 2026. (Microsoft labeling.)
+	// FY2027 with July start under default labeling = starts Jul 1, 2026.
+	// Default mode (FYLabelByEndYear) labels by the year the FY ENDS in,
+	// matching the Australian government year, US tax year, and most
+	// publicly traded companies.
 	p := NewFiscalYear(2027, time.July, 1)
 	if p.Kind != PeriodFiscalYear {
 		t.Errorf("Kind = %v, want PeriodFiscalYear", p.Kind)
@@ -159,6 +162,74 @@ func TestPeriod_NewFiscalYear(t *testing.T) {
 	// String must surface the FY label, not the start year.
 	if !strings.Contains(p.String(), "2027") {
 		t.Errorf("String() = %q should contain FY label 2027", p.String())
+	}
+}
+
+// TestPeriod_NewFiscalYearWithMode_LabelByStartYear — when a document
+// declares `calendar_year_offset: after`, the FY label corresponds to
+// the calendar year the FY STARTS in (some companies use this
+// labeling). FY2026 with a Feb 2 start under start-year labeling
+// starts Feb 2, 2026 and ends Feb 1, 2027.
+func TestPeriod_NewFiscalYearWithMode_LabelByStartYear(t *testing.T) {
+	p := NewFiscalYearWithMode(2026, time.February, 2, FYLabelByStartYear)
+	if p.Kind != PeriodFiscalYear {
+		t.Errorf("Kind = %v, want PeriodFiscalYear", p.Kind)
+	}
+	if p.Year != 2026 {
+		t.Errorf("Year = %d, want 2026", p.Year)
+	}
+	wantStart := time.Date(2026, time.February, 2, 0, 0, 0, 0, time.UTC)
+	if !p.Start.Time.Equal(wantStart) {
+		t.Errorf("Start = %v, want %v", p.Start.Time, wantStart)
+	}
+	wantEnd := time.Date(2027, time.February, 1, 0, 0, 0, 0, time.UTC)
+	if !p.End.Time.Equal(wantEnd) {
+		t.Errorf("End = %v, want %v", p.End.Time, wantEnd)
+	}
+}
+
+// TestPeriod_NewFiscalYearWithMode_LabelByEndYear — explicit
+// FYLabelByEndYear matches the default factory exactly. FY2027 with
+// July start = Jul 1 2026 → Jun 30 2027.
+func TestPeriod_NewFiscalYearWithMode_LabelByEndYear(t *testing.T) {
+	p := NewFiscalYearWithMode(2027, time.July, 1, FYLabelByEndYear)
+	if p.Year != 2027 {
+		t.Errorf("Year = %d, want 2027", p.Year)
+	}
+	wantStart := time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC)
+	if !p.Start.Time.Equal(wantStart) {
+		t.Errorf("Start = %v, want %v", p.Start.Time, wantStart)
+	}
+}
+
+// TestPeriod_NewFiscalQuarterWithMode_LabelByStartYear — under
+// start-year labeling, an Apr 2026 fiscal-year-start produces FQ1
+// labeled FY2026 (not FY2027). The quarter itself spans Apr–Jun
+// 2026 either way; only the year stamped on Period.Year differs.
+func TestPeriod_NewFiscalQuarterWithMode_LabelByStartYear(t *testing.T) {
+	apr2026 := time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC)
+	p, err := NewFiscalQuarterWithMode(apr2026, 1, FYLabelByStartYear)
+	if err != nil {
+		t.Fatalf("NewFiscalQuarterWithMode: %v", err)
+	}
+	if p.Year != 2026 {
+		t.Errorf("Year = %d, want 2026 (start-year labeling)", p.Year)
+	}
+	if p.QuarterIndex != 1 {
+		t.Errorf("QuarterIndex = %d, want 1", p.QuarterIndex)
+	}
+}
+
+// TestPeriod_NewFiscalQuarterWithMode_LabelByEndYear — sanity check
+// that explicit end-year mode matches the existing default behavior.
+func TestPeriod_NewFiscalQuarterWithMode_LabelByEndYear(t *testing.T) {
+	apr2026 := time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC)
+	p, err := NewFiscalQuarterWithMode(apr2026, 1, FYLabelByEndYear)
+	if err != nil {
+		t.Fatalf("NewFiscalQuarterWithMode: %v", err)
+	}
+	if p.Year != 2027 {
+		t.Errorf("Year = %d, want 2027 (end-year labeling)", p.Year)
 	}
 }
 
@@ -343,7 +414,7 @@ func TestPeriod_NewCalendarYear_PopulatesEnd(t *testing.T) {
 }
 
 func TestPeriod_NewFiscalYear_PopulatesEnd(t *testing.T) {
-	// FY2027 with July start = Jul 1 2026 - Jun 30 2027 (Microsoft labeling).
+	// FY2027 with July start = Jul 1 2026 - Jun 30 2027 (default end-year labeling).
 	p := NewFiscalYear(2027, time.July, 1)
 	if p.End == nil {
 		t.Fatalf("End is nil")

--- a/spec/types/period_test.go
+++ b/spec/types/period_test.go
@@ -236,3 +236,251 @@ func mustFiscalQuarter(t *testing.T, year int, fyStartMonth time.Month, fyStartD
 	}
 	return p
 }
+
+// --- v2.0 contract tests ---
+//
+// The v2.0 plan requires Period to store End as a struct field
+// (rather than computing it from Kind+context at access time). End
+// must be populated by every factory at construction. This pins the
+// invariant: any code path producing a *Period must produce a
+// fully-formed [Start, End] interval.
+
+func TestPeriod_NewCalendarQuarter_PopulatesEnd(t *testing.T) {
+	cases := []struct {
+		year, quarter int
+		wantEnd       time.Time
+	}{
+		{2026, 1, time.Date(2026, time.March, 31, 0, 0, 0, 0, time.UTC)},
+		{2026, 2, time.Date(2026, time.June, 30, 0, 0, 0, 0, time.UTC)},
+		{2026, 3, time.Date(2026, time.September, 30, 0, 0, 0, 0, time.UTC)},
+		{2026, 4, time.Date(2026, time.December, 31, 0, 0, 0, 0, time.UTC)},
+	}
+	for _, tc := range cases {
+		p, err := NewCalendarQuarter(tc.year, tc.quarter)
+		if err != nil {
+			t.Fatalf("NewCalendarQuarter(%d, %d): %v", tc.year, tc.quarter, err)
+		}
+		if p.End == nil {
+			t.Fatalf("Q%d %d: End is nil — must be populated at construction", tc.quarter, tc.year)
+		}
+		if !p.End.Time.Equal(tc.wantEnd) {
+			t.Errorf("Q%d %d: End = %v, want %v", tc.quarter, tc.year, p.End.Time, tc.wantEnd)
+		}
+	}
+}
+
+func TestPeriod_NewFiscalQuarter_PopulatesEnd(t *testing.T) {
+	// FY starts April 1; FQ1 = Apr 1 - Jun 30; FQ4 = Jan 1 - Mar 31 (next cal year).
+	apr1 := time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC)
+	cases := []struct {
+		quarter int
+		wantEnd time.Time
+	}{
+		{1, time.Date(2026, time.June, 30, 0, 0, 0, 0, time.UTC)},
+		{2, time.Date(2026, time.September, 30, 0, 0, 0, 0, time.UTC)},
+		{3, time.Date(2026, time.December, 31, 0, 0, 0, 0, time.UTC)},
+		{4, time.Date(2027, time.March, 31, 0, 0, 0, 0, time.UTC)},
+	}
+	for _, tc := range cases {
+		p, err := NewFiscalQuarter(apr1, tc.quarter)
+		if err != nil {
+			t.Fatalf("NewFiscalQuarter(Apr 1, %d): %v", tc.quarter, err)
+		}
+		if p.End == nil {
+			t.Fatalf("FQ%d: End is nil", tc.quarter)
+		}
+		if !p.End.Time.Equal(tc.wantEnd) {
+			t.Errorf("FQ%d: End = %v, want %v", tc.quarter, p.End.Time, tc.wantEnd)
+		}
+	}
+}
+
+func TestPeriod_NewCalendarYear_PopulatesEnd(t *testing.T) {
+	p := NewCalendarYear(2026)
+	if p.End == nil {
+		t.Fatalf("End is nil")
+	}
+	want := time.Date(2026, time.December, 31, 0, 0, 0, 0, time.UTC)
+	if !p.End.Time.Equal(want) {
+		t.Errorf("End = %v, want %v", p.End.Time, want)
+	}
+}
+
+func TestPeriod_NewFiscalYear_PopulatesEnd(t *testing.T) {
+	// FY2027 with July start = Jul 1 2026 - Jun 30 2027 (Microsoft labeling).
+	p := NewFiscalYear(2027, time.July, 1)
+	if p.End == nil {
+		t.Fatalf("End is nil")
+	}
+	want := time.Date(2027, time.June, 30, 0, 0, 0, 0, time.UTC)
+	if !p.End.Time.Equal(want) {
+		t.Errorf("End = %v, want %v", p.End.Time, want)
+	}
+}
+
+func TestPeriod_NewCalendarMonth_PopulatesEnd(t *testing.T) {
+	cases := []struct {
+		year    int
+		month   time.Month
+		wantEnd time.Time
+	}{
+		{2026, time.January, time.Date(2026, time.January, 31, 0, 0, 0, 0, time.UTC)},
+		{2026, time.April, time.Date(2026, time.April, 30, 0, 0, 0, 0, time.UTC)},
+		{2026, time.February, time.Date(2026, time.February, 28, 0, 0, 0, 0, time.UTC)}, // non-leap
+		{2024, time.February, time.Date(2024, time.February, 29, 0, 0, 0, 0, time.UTC)}, // leap
+		{2026, time.December, time.Date(2026, time.December, 31, 0, 0, 0, 0, time.UTC)},
+	}
+	for _, tc := range cases {
+		p := NewCalendarMonth(tc.year, tc.month)
+		if p.End == nil {
+			t.Fatalf("%v %d: End is nil", tc.month, tc.year)
+		}
+		if !p.End.Time.Equal(tc.wantEnd) {
+			t.Errorf("%v %d: End = %v, want %v", tc.month, tc.year, p.End.Time, tc.wantEnd)
+		}
+	}
+}
+
+func TestPeriod_NewRelativeQuarter_PopulatesEnd(t *testing.T) {
+	// May 15 2026 sits in Q2 (Apr-Jun). this/next/last cal-quarter ends:
+	now := time.Date(2026, time.May, 15, 0, 0, 0, 0, time.UTC)
+	cases := []struct {
+		direction int
+		wantEnd   time.Time
+	}{
+		{0, time.Date(2026, time.June, 30, 0, 0, 0, 0, time.UTC)},      // this Q (Q2 2026)
+		{+1, time.Date(2026, time.September, 30, 0, 0, 0, 0, time.UTC)}, // next Q (Q3 2026)
+		{-1, time.Date(2026, time.March, 31, 0, 0, 0, 0, time.UTC)},     // last Q (Q1 2026)
+	}
+	for _, tc := range cases {
+		p := NewRelativeQuarter(now, tc.direction)
+		if p.End == nil {
+			t.Fatalf("direction=%d: End is nil", tc.direction)
+		}
+		if !p.End.Time.Equal(tc.wantEnd) {
+			t.Errorf("direction=%d: End = %v, want %v", tc.direction, p.End.Time, tc.wantEnd)
+		}
+	}
+}
+
+func TestPeriod_NewRelativeFiscalQuarter_PopulatesEnd(t *testing.T) {
+	// FY starts April 1; May 15 sits in FQ1 (Apr-Jun).
+	now := time.Date(2026, time.May, 15, 0, 0, 0, 0, time.UTC)
+	cases := []struct {
+		direction int
+		wantEnd   time.Time
+	}{
+		{0, time.Date(2026, time.June, 30, 0, 0, 0, 0, time.UTC)},        // this FQ (FQ1 = Apr-Jun)
+		{+1, time.Date(2026, time.September, 30, 0, 0, 0, 0, time.UTC)},  // next FQ (FQ2 = Jul-Sep)
+		{-1, time.Date(2026, time.March, 31, 0, 0, 0, 0, time.UTC)},      // last FQ (FQ4 of prior FY = Jan-Mar)
+	}
+	for _, tc := range cases {
+		p := NewRelativeFiscalQuarter(now, time.April, 1, tc.direction)
+		if p.End == nil {
+			t.Fatalf("direction=%d: End is nil", tc.direction)
+		}
+		if !p.End.Time.Equal(tc.wantEnd) {
+			t.Errorf("direction=%d: End = %v, want %v", tc.direction, p.End.Time, tc.wantEnd)
+		}
+	}
+}
+
+// --- NewCustomPeriod (PeriodCustom kind) ---
+//
+// User-defined periods via `between A and B` / `from A to B`. Plan
+// U1: PeriodCustom enum constant + NewCustomPeriod factory that
+// validates end >= start and stores both endpoints directly.
+
+func TestPeriod_NewCustomPeriod_HappyPath(t *testing.T) {
+	start := NewDateFromTime(time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC))
+	end := NewDateFromTime(time.Date(2026, time.April, 30, 0, 0, 0, 0, time.UTC))
+	p, err := NewCustomPeriod(start, end)
+	if err != nil {
+		t.Fatalf("NewCustomPeriod: %v", err)
+	}
+	if p.Kind != PeriodCustom {
+		t.Errorf("Kind = %v, want PeriodCustom", p.Kind)
+	}
+	if !p.Start.Time.Equal(start.Time) {
+		t.Errorf("Start = %v, want %v", p.Start.Time, start.Time)
+	}
+	if !p.End.Time.Equal(end.Time) {
+		t.Errorf("End = %v, want %v", p.End.Time, end.Time)
+	}
+}
+
+func TestPeriod_NewCustomPeriod_SameDay(t *testing.T) {
+	// A single-day period (start == end) is the minimal valid period.
+	d := NewDateFromTime(time.Date(2026, time.April, 15, 0, 0, 0, 0, time.UTC))
+	p, err := NewCustomPeriod(d, d)
+	if err != nil {
+		t.Fatalf("same-day period should be valid: %v", err)
+	}
+	if !p.Start.Time.Equal(p.End.Time) {
+		t.Errorf("same-day: Start (%v) != End (%v)", p.Start.Time, p.End.Time)
+	}
+}
+
+func TestPeriod_NewCustomPeriod_EndBeforeStart(t *testing.T) {
+	start := NewDateFromTime(time.Date(2026, time.April, 30, 0, 0, 0, 0, time.UTC))
+	end := NewDateFromTime(time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC))
+	if _, err := NewCustomPeriod(start, end); err == nil {
+		t.Errorf("expected error for end-before-start; got nil")
+	}
+}
+
+func TestPeriod_NewCustomPeriod_NilEndpoint(t *testing.T) {
+	d := NewDateFromTime(time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC))
+	if _, err := NewCustomPeriod(nil, d); err == nil {
+		t.Errorf("expected error for nil start; got nil")
+	}
+	if _, err := NewCustomPeriod(d, nil); err == nil {
+		t.Errorf("expected error for nil end; got nil")
+	}
+}
+
+func TestPeriod_PeriodCustom_StringNonEmpty(t *testing.T) {
+	start := NewDateFromTime(time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC))
+	end := NewDateFromTime(time.Date(2026, time.April, 30, 0, 0, 0, 0, time.UTC))
+	p, err := NewCustomPeriod(start, end)
+	if err != nil {
+		t.Fatalf("NewCustomPeriod: %v", err)
+	}
+	got := p.String()
+	if got == "" {
+		t.Errorf("String() must not be empty for PeriodCustom")
+	}
+	// Must surface both endpoints so diagnostics are debuggable.
+	if !strings.Contains(got, "2026") {
+		t.Errorf("String() = %q should mention the year", got)
+	}
+}
+
+// TestPeriod_AllFactoriesPopulateEnd is a single-point invariant
+// assertion: NO factory in this package may return a *Period with
+// nil End. Locks the v2.0 contract — if a future maintainer adds a
+// factory that forgets End, this test catches it.
+func TestPeriod_AllFactoriesPopulateEnd(t *testing.T) {
+	now := time.Date(2026, time.May, 15, 0, 0, 0, 0, time.UTC)
+	periods := []*Period{
+		mustCalendarQuarter(t, 2026, 1),
+		mustFiscalQuarter(t, 2026, time.April, 1, 2),
+		NewCalendarYear(2026),
+		NewFiscalYear(2027, time.July, 1),
+		NewCalendarMonth(2026, time.July),
+		NewRelativeQuarter(now, 0),
+		NewRelativeFiscalQuarter(now, time.April, 1, 0),
+	}
+	for i, p := range periods {
+		if p.End == nil {
+			t.Errorf("periods[%d] (Kind=%v): End is nil — every factory must populate End", i, p.Kind)
+		}
+		if p.Start == nil {
+			t.Errorf("periods[%d] (Kind=%v): Start is nil", i, p.Kind)
+		}
+		if p.End != nil && p.Start != nil && p.End.Time.Before(p.Start.Time) {
+			t.Errorf("periods[%d] (Kind=%v): End (%v) before Start (%v)",
+				i, p.Kind, p.End.Time, p.Start.Time)
+		}
+	}
+}

--- a/testdata/examples/datacenter-cost.cm
+++ b/testdata/examples/datacenter-cost.cm
@@ -97,20 +97,20 @@ daily_elec = $0.10/hour per day
 Operating costs don't stay flat. Assuming 4% annual inflation,
 here's where opex lands after 5 and 10 years:
 
-opex_5yr = compound $75000 by 4% over 5 years
-opex_10yr = compound $75000 by 4% over 10 years
+opex_5yr = compound $75000 by 4% over 5
+opex_10yr = compound $75000 by 4% over 10
 
 ## Equipment Depreciation
 
 Servers and networking gear lose value quickly. Using declining-balance
 depreciation at 20% per year over a 5-year refresh cycle:
 
-servers = depreciate $200000 by 20% over 5 years
+servers = depreciate $200000 by 20% over 5
 
 Cooling systems last longer but still depreciate. A $45,000 unit
 at 15% per year, with a $5,000 salvage floor:
 
-cooling_depr = depreciate $45000 by 15% over 10 years to $5000
+cooling_depr = depreciate $45000 by 15% over 10 to $5000
 
 ## Build vs. Colocation
 

--- a/testdata/examples/embedded-datacenter-cost.md
+++ b/testdata/examples/embedded-datacenter-cost.md
@@ -84,8 +84,8 @@ Operating costs don't stay flat. Assuming 4% annual inflation, here's
 where opex lands after 5 and 10 years:
 
 ```calcmark
-opex_5yr = compound $75000 by 4% over 5 years
-opex_10yr = compound $75000 by 4% over 10 years
+opex_5yr = compound $75000 by 4% over 5
+opex_10yr = compound $75000 by 4% over 10
 ```
 
 ## Equipment Depreciation
@@ -94,14 +94,14 @@ Servers lose value quickly. Declining-balance depreciation at 20%/year
 over a 5-year refresh cycle:
 
 ```cm
-servers = depreciate $200000 by 20% over 5 years
+servers = depreciate $200000 by 20% over 5
 ```
 
 Cooling systems last longer — a $45,000 unit at 15%/year with a $5,000
 salvage floor:
 
 ```cm
-cooling = depreciate $45000 by 15% over 10 years to $5000
+cooling = depreciate $45000 by 15% over 10 to $5000
 ```
 
 ## Colocation Alternative

--- a/testdata/examples/investment-growth.cm
+++ b/testdata/examples/investment-growth.cm
@@ -18,7 +18,7 @@ starting_customers = 500 customers
 monthly_growth = compound starting_customers by 15% over 24
 
 # Natural language form
-compound 1000 users by 10% over 12 months
+compound 1000 users by 10% over 12
 
 ## Linear Growth
 
@@ -26,7 +26,7 @@ compound 1000 users by 10% over 12 months
 savings_plan = grow $0 by $200 over 60
 
 # Adding 50 subscribers per week
-grow 100 subscribers by 50 over 52 weeks
+grow 100 subscribers by 50 over 52
 
 ## Asset Depreciation
 
@@ -34,7 +34,7 @@ grow 100 subscribers by 50 over 52 weeks
 car_value = depreciate $35000 by 20% over 5
 
 # Equipment with $2000 salvage floor
-depreciate $80000 by 25% over 10 years to $2000
+depreciate $80000 by 25% over 10 to $2000
 
 # Office furniture
 furniture = depreciate $15000 by 15% over 7


### PR DESCRIPTION
## Summary

The full v2.0 Period type system, ready to ship as `v2.0.0-rc.1`. 30 commits since `v1.14.0` landing the structural Period work (#140 stack), the language-feature work (between / length-of / days-in / period basis conversion / directed notation / bare month literals / fiscal aliases), the FY-labeling knob, configurable date formats, LSP discoverability, and the docs/examples/release-config follow-throughs.

Detailed release notes are in [`CHANGELOG.md`](CHANGELOG.md). The TL;DR:

- **Period as a first-class type** — `Q1`, `FY2027`, `this fiscal quarter`, `April`, etc. evaluate to `*types.Period` (carrying `Start` + `End`) instead of `Date`.
- **New language vocabulary** — `between A and B`, `from A to B`, `length of <P>`, `days in <P>`, `<P> as fiscal/calendar`, directed notation (`next FQ1`, `last CY26`), bare `fiscal quarter`/`fiscal year` aliases.
- **First-class `end of` / `start of`** operators that compose with every period kind.
- **`calendar_year_offset` frontmatter** — `before` (default — Australian government year, US tax year, most companies) or `after` (some companies). Closes the FY-labeling ambiguity reported on Apr 30.
- **Configurable `date_format` + `period_date_format`** via `cm config`, locale-aware.
- **LSP discoverability** for the new vocabulary, plus `keywordPhrases` for client-side multi-word chip highlighting.

This PR replaces the original PR-1b scope (it was rebased/built on top of); previously stacked PR #145 has been merged into this branch.

## Breaking changes

Migration guide lives at the bottom of [`CHANGELOG.md`](CHANGELOG.md#migration-notes). Headline items:

1. Period-bearing keywords now evaluate to `*types.Period`, not `Date`. Code expecting a Date must read `.Start` or use `start of <period>`.
2. `Period + Duration` extends from the END (`Q1 + 30 days = Apr 30`, not `Jan 31`). Use `start of Q1 + 30 days` to keep v1 semantics.
3. `grow` / `compound` / `depreciate` 3-arg form: `periods` is a plain Number, not a Duration. `over 5 years` → `over 5`.
4. `between` is a reserved keyword.
5. Spaces no longer permitted in identifiers.

## Release-readiness

| Gate | Status |
|---|---|
| Code-correctness (`go test ./...`) | ✓ green across every package |
| Doc examples (21 `testdata/examples/*.cm` through `calcmark.Convert`) | ✓ all 21 pass under v2 |
| LSP completion + hover for new vocabulary | ✓ wired through registry |
| Frontmatter parsing for `calendar_year_offset` | ✓ + tests for default/before/after/case-insensitive/invalid |
| Lark trial (`feat/v2-trial`) | ✓ build + tests pass against v2 |
| CHANGELOG.md | ✓ Keep-a-Changelog with explicit Breaking section |
| Homebrew tap pre-release isolation | ✓ `homebrew_casks.skip_upload: auto` |
| Lark dispatch on rc tag | ✓ `!contains(github.ref_name, '-')` already gates it off |

## After merge

1. Tag `v2.0.0-rc.1` from main; push triggers GoReleaser → GitHub Pre-release with binaries.
2. Bump calcmark-web's `go.mod` from local replace to `v2.0.0-rc.1`.
3. Bump calcmark-lark's `feat/v2-trial` branch from local replace to `v2.0.0-rc.1` (kept as draft PR).
4. Soak ~1 week. Patch with rc.2 / rc.3 if anything surfaces.
5. When clean, tag `v2.0.0` from main and merge the calcmark-web + calcmark-lark consumer PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-velocity:pr:142 -->
### Metrics

Opened by `@dvhthomas` (agent-assisted) on 2026-04-29 17:32 UTC. Merged 2026-04-30 17:59 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 1d 0h  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
