### PR TITLE
fix(modules): bump module path to /v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ formatters, and editor surfaces. The work spans 26 commits since v1.14.0.
 
 ### Breaking
 
+- **Module path is now `github.com/CalcMark/go-calcmark/v2`.** Per Go's
+  [module versioning rules](https://go.dev/ref/mod#major-version-suffixes),
+  any major version ≥ 2 must encode the major version in the module
+  path. Go consumers update their imports:
+  ```diff
+  - import "github.com/CalcMark/go-calcmark"
+  - import "github.com/CalcMark/go-calcmark/spec/types"
+  + import "github.com/CalcMark/go-calcmark/v2"
+  + import "github.com/CalcMark/go-calcmark/v2/spec/types"
+  ```
+  And bump the `require` line: `github.com/CalcMark/go-calcmark/v2 v2.0.0`.
+  Mechanical: every existing import gets a `/v2` segment after
+  `go-calcmark`. Non-Go consumers (the CLI binary, the lark playground,
+  the calcmark-web embedded server) are unaffected — only direct Go
+  module consumers need to change anything.
 - **Period-bearing keywords now evaluate to `*types.Period`, not `Date`.**
   `Q1`, `FQ2`, `CY2026`, `FY2027`, `this month`, `this fiscal quarter`, bare
   month names like `April`, etc. now produce a `Period` value instead of
@@ -146,6 +161,14 @@ to v2.0.0:
    in the 3-arg form. Replace `over 5 years` with `over 5`.
 3. Use a variable named `between`. Rename it.
 4. Have a multi-word identifier with spaces. Rename to use underscores.
+
+If your **Go code** imports go-calcmark as a library, also:
+
+5. Add `/v2` to every import path:
+   `github.com/CalcMark/go-calcmark/...` → `github.com/CalcMark/go-calcmark/v2/...`.
+   Run `gofmt -w -r '"github.com/CalcMark/go-calcmark" -> "github.com/CalcMark/go-calcmark/v2"'`
+   plus a sed pass for the sub-package paths, then `go mod tidy` against
+   `github.com/CalcMark/go-calcmark/v2 v2.0.0`.
 
 Documents that don't touch any of the above need no changes — period
 literals (`Q1`, `FY2027`) read identically; `start of <period>` was

--- a/cmd/calcmark/cmd/config.go
+++ b/cmd/calcmark/cmd/config.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config"
-	"github.com/CalcMark/go-calcmark/format"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config"
+	"github.com/CalcMark/go-calcmark/v2/format"
 	toml "github.com/pelletier/go-toml/v2"
 	"github.com/spf13/cobra"
 )

--- a/cmd/calcmark/cmd/config_test.go
+++ b/cmd/calcmark/cmd/config_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config"
 	toml "github.com/pelletier/go-toml/v2"
 )
 

--- a/cmd/calcmark/cmd/convert.go
+++ b/cmd/calcmark/cmd/convert.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/CalcMark/go-calcmark"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config"
-	"github.com/CalcMark/go-calcmark/format"
+	"github.com/CalcMark/go-calcmark/v2"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config"
+	"github.com/CalcMark/go-calcmark/v2/format"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/calcmark/cmd/eval.go
+++ b/cmd/calcmark/cmd/eval.go
@@ -10,9 +10,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/format"
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/format"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/calcmark/cmd/eval_format_test.go
+++ b/cmd/calcmark/cmd/eval_format_test.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/format"
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/format"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // evalTestDoc is a helper that creates, parses, and evaluates a CalcMark document.

--- a/cmd/calcmark/cmd/help.go
+++ b/cmd/calcmark/cmd/help.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"text/tabwriter"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/features"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/calcmark/cmd/help_test.go
+++ b/cmd/calcmark/cmd/help_test.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 )
 
 // TestHelpFunctionsOutput verifies that help functions shows all function names.

--- a/cmd/calcmark/cmd/locale_test.go
+++ b/cmd/calcmark/cmd/locale_test.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config"
-	"github.com/CalcMark/go-calcmark/format"
-	"github.com/CalcMark/go-calcmark/format/display"
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config"
+	"github.com/CalcMark/go-calcmark/v2/format"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 func TestLocaleFormatter_Default(t *testing.T) {

--- a/cmd/calcmark/cmd/lsp.go
+++ b/cmd/calcmark/cmd/lsp.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"github.com/CalcMark/go-calcmark/lsp"
+	"github.com/CalcMark/go-calcmark/v2/lsp"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/calcmark/cmd/multibyte_format_test.go
+++ b/cmd/calcmark/cmd/multibyte_format_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/format"
+	"github.com/CalcMark/go-calcmark/v2/format"
 )
 
 // TestMultibyteEvalTextFormat verifies that cm eval with text format

--- a/cmd/calcmark/cmd/remote.go
+++ b/cmd/calcmark/cmd/remote.go
@@ -7,10 +7,10 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/filecheck"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/editor/store"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/filecheck"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/editor/store"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/calcmark/cmd/root.go
+++ b/cmd/calcmark/cmd/root.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config"
-	"github.com/CalcMark/go-calcmark/format/display"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/calcmark/cmd/security.go
+++ b/cmd/calcmark/cmd/security.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/filecheck"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/filecheck"
 )
 
 // validateReadFilePath performs security checks on a file path for read-only

--- a/cmd/calcmark/cmd/tui.go
+++ b/cmd/calcmark/cmd/tui.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui"
 )
 
 // runEdit starts the editor mode, optionally with a file

--- a/cmd/calcmark/cmd/watch.go
+++ b/cmd/calcmark/cmd/watch.go
@@ -15,8 +15,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/CalcMark/go-calcmark"
-	"github.com/CalcMark/go-calcmark/format"
+	"github.com/CalcMark/go-calcmark/v2"
+	"github.com/CalcMark/go-calcmark/v2/format"
 	"github.com/fsnotify/fsnotify"
 	"github.com/spf13/cobra"
 	"golang.org/x/net/websocket"

--- a/cmd/calcmark/cmd/watch_test.go
+++ b/cmd/calcmark/cmd/watch_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CalcMark/go-calcmark"
-	"github.com/CalcMark/go-calcmark/format"
+	"github.com/CalcMark/go-calcmark/v2"
+	"github.com/CalcMark/go-calcmark/v2/format"
 	"github.com/fsnotify/fsnotify"
 )
 

--- a/cmd/calcmark/config/theme.go
+++ b/cmd/calcmark/config/theme.go
@@ -3,7 +3,7 @@ package config
 import (
 	"charm.land/lipgloss/v2"
 	"charm.land/lipgloss/v2/compat"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
 )
 
 // Styles holds pre-built lipgloss styles derived from the semantic palette.

--- a/cmd/calcmark/golden_e2e_test.go
+++ b/cmd/calcmark/golden_e2e_test.go
@@ -7,10 +7,10 @@ import (
 	"strings"
 	"testing"
 
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // testdataRoot is the path to testdata directory relative to this test file

--- a/cmd/calcmark/main.go
+++ b/cmd/calcmark/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/cmd"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/cmd"
 )
 
 // Version info set via ldflags at build time

--- a/cmd/calcmark/tui/app.go
+++ b/cmd/calcmark/tui/app.go
@@ -3,12 +3,12 @@ package tui
 import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2/compat"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/editor"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/repl"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/shared"
-	"github.com/CalcMark/go-calcmark/format/display"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/editor"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/repl"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/shared"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // initializeColorProfile sets up lipgloss color settings.

--- a/cmd/calcmark/tui/components/components_test.go
+++ b/cmd/calcmark/tui/components/components_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 func TestRenderStatusBar(t *testing.T) {

--- a/cmd/calcmark/tui/components/contextfooter.go
+++ b/cmd/calcmark/tui/components/contextfooter.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // ContextFooterHeight is the fixed height for the context footer / helper area.

--- a/cmd/calcmark/tui/components/errors.go
+++ b/cmd/calcmark/tui/components/errors.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/semantic"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/semantic"
 )
 
 // ErrorDisplayInfo contains parsed error information for display.

--- a/cmd/calcmark/tui/components/globals.go
+++ b/cmd/calcmark/tui/components/globals.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
 )
 
 // GlobalVar represents a global variable for display.

--- a/cmd/calcmark/tui/components/pinned.go
+++ b/cmd/calcmark/tui/components/pinned.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
 )
 
 // PinnedVar represents a pinned variable for display.

--- a/cmd/calcmark/tui/components/statusbar.go
+++ b/cmd/calcmark/tui/components/statusbar.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
 )
 
 // StyledPadding creates styled spaces with the given background color.

--- a/cmd/calcmark/tui/components/suggest.go
+++ b/cmd/calcmark/tui/components/suggest.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
-	"github.com/CalcMark/go-calcmark/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
 )
 
 // Suggestion is an alias for the shared suggestion type in spec/features.

--- a/cmd/calcmark/tui/editor/aligned.go
+++ b/cmd/calcmark/tui/editor/aligned.go
@@ -3,7 +3,7 @@ package editor
 import (
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/geometry"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/geometry"
 )
 
 // AlignedModel represents the computed visual line structure for both panes.

--- a/cmd/calcmark/tui/editor/aligned_empty_lines_test.go
+++ b/cmd/calcmark/tui/editor/aligned_empty_lines_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/geometry"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/geometry"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestAlignedModelWithEmptyLineAfterHeading tests that ComputeAlignedModel

--- a/cmd/calcmark/tui/editor/aligned_test.go
+++ b/cmd/calcmark/tui/editor/aligned_test.go
@@ -3,7 +3,7 @@ package editor
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/geometry"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/geometry"
 )
 
 // mockRenderCalcLine returns a simple representation for testing

--- a/cmd/calcmark/tui/editor/alignment_test.go
+++ b/cmd/calcmark/tui/editor/alignment_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestAlignment_OneToOneMapping verifies that every source line maps to exactly one preview line.

--- a/cmd/calcmark/tui/editor/arrow_navigation_test.go
+++ b/cmd/calcmark/tui/editor/arrow_navigation_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestArrowKeyNavigationAcrossLines tests that left/right arrow keys

--- a/cmd/calcmark/tui/editor/autocomplete.go
+++ b/cmd/calcmark/tui/editor/autocomplete.go
@@ -3,10 +3,10 @@ package editor
 import (
 	"sort"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/components"
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/components"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
 )
 
 // implementedFunctionNames returns a set of function names that have interpreter

--- a/cmd/calcmark/tui/editor/autocomplete_handler.go
+++ b/cmd/calcmark/tui/editor/autocomplete_handler.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/components"
-	"github.com/CalcMark/go-calcmark/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/components"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
 )
 
 // minAutocompletePrefix is the minimum number of characters needed to trigger autosuggest.

--- a/cmd/calcmark/tui/editor/autocomplete_test.go
+++ b/cmd/calcmark/tui/editor/autocomplete_test.go
@@ -6,9 +6,9 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/components"
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/components"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
 	"github.com/shopspring/decimal"
 )
 

--- a/cmd/calcmark/tui/editor/block_render.go
+++ b/cmd/calcmark/tui/editor/block_render.go
@@ -3,7 +3,7 @@ package editor
 import (
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // BlockRenderResult maps rendered preview lines back to their source lines for alignment.

--- a/cmd/calcmark/tui/editor/block_render_test.go
+++ b/cmd/calcmark/tui/editor/block_render_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestRenderTextBlockSimple_OrderedList verifies that ordered lists render with correct numbering

--- a/cmd/calcmark/tui/editor/catwalk_context_footer_test.go
+++ b/cmd/calcmark/tui/editor/catwalk_context_footer_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 	"github.com/cockroachdb/datadriven"
 )
 

--- a/cmd/calcmark/tui/editor/catwalk_diagnostic_line_test.go
+++ b/cmd/calcmark/tui/editor/catwalk_diagnostic_line_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 	"github.com/cockroachdb/datadriven"
 )
 

--- a/cmd/calcmark/tui/editor/catwalk_error_recovery_test.go
+++ b/cmd/calcmark/tui/editor/catwalk_error_recovery_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 	"github.com/cockroachdb/datadriven"
 )
 

--- a/cmd/calcmark/tui/editor/catwalk_test.go
+++ b/cmd/calcmark/tui/editor/catwalk_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/format/display"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 	"github.com/cockroachdb/datadriven"
 )
 

--- a/cmd/calcmark/tui/editor/catwalk_type_mismatch_test.go
+++ b/cmd/calcmark/tui/editor/catwalk_type_mismatch_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 	"github.com/cockroachdb/datadriven"
 )
 

--- a/cmd/calcmark/tui/editor/catwalk_wrapping_test.go
+++ b/cmd/calcmark/tui/editor/catwalk_wrapping_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 	"github.com/cockroachdb/datadriven"
 )
 

--- a/cmd/calcmark/tui/editor/command_menu_test.go
+++ b/cmd/calcmark/tui/editor/command_menu_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 func TestAllCommandMenuActionsViaUpdate(t *testing.T) {

--- a/cmd/calcmark/tui/editor/context_footer_render_test.go
+++ b/cmd/calcmark/tui/editor/context_footer_render_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestContextFooterShowsVariableReferences verifies that the context footer

--- a/cmd/calcmark/tui/editor/cursor_context.go
+++ b/cmd/calcmark/tui/editor/cursor_context.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // CursorContext describes what the cursor is positioned on/in.

--- a/cmd/calcmark/tui/editor/cursor_context_test.go
+++ b/cmd/calcmark/tui/editor/cursor_context_test.go
@@ -3,7 +3,7 @@ package editor
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 func TestGetCursorContext(t *testing.T) {

--- a/cmd/calcmark/tui/editor/cut_paste_test.go
+++ b/cmd/calcmark/tui/editor/cut_paste_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // --- helpers ----------------------------------------------------------------

--- a/cmd/calcmark/tui/editor/delete_last_char_bug_test.go
+++ b/cmd/calcmark/tui/editor/delete_last_char_bug_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestDeleteLastCharThenType reproduces the exact bug:

--- a/cmd/calcmark/tui/editor/delete_line_test.go
+++ b/cmd/calcmark/tui/editor/delete_line_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestDeleteLineDeletesCurrentLine verifies Ctrl+K deletes the line the cursor is on.

--- a/cmd/calcmark/tui/editor/delete_single_char_test.go
+++ b/cmd/calcmark/tui/editor/delete_single_char_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestDeleteSingleChar_TypeThenDelete verifies that DELETE key can delete

--- a/cmd/calcmark/tui/editor/divider_position_test.go
+++ b/cmd/calcmark/tui/editor/divider_position_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestDividerPositionConsistency verifies that the divider appears at a consistent

--- a/cmd/calcmark/tui/editor/dynamic_footer_height_test.go
+++ b/cmd/calcmark/tui/editor/dynamic_footer_height_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestFooterShowsFullHintOnErrorLine verifies that when the cursor is on an

--- a/cmd/calcmark/tui/editor/edit_line_selection_test.go
+++ b/cmd/calcmark/tui/editor/edit_line_selection_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // selectionBgCode returns the ANSI TrueColor background code for the selection

--- a/cmd/calcmark/tui/editor/edit_mode_test.go
+++ b/cmd/calcmark/tui/editor/edit_mode_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/components"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/components"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 func TestEnterExitEditMode(t *testing.T) {

--- a/cmd/calcmark/tui/editor/edit_nav_test.go
+++ b/cmd/calcmark/tui/editor/edit_nav_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 func TestEditModeEnterCreatesNewLine(t *testing.T) {

--- a/cmd/calcmark/tui/editor/edit_redefinition_bug_test.go
+++ b/cmd/calcmark/tui/editor/edit_redefinition_bug_test.go
@@ -3,8 +3,8 @@ package editor
 import (
 	"testing"
 
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestEditingVariableShowsFalseRedefinition reproduces the user's bug:

--- a/cmd/calcmark/tui/editor/editing.go
+++ b/cmd/calcmark/tui/editor/editing.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	tea "charm.land/bubbletea/v2"
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // handleRuneInput handles character input - regular typing only.

--- a/cmd/calcmark/tui/editor/empty_editor_test.go
+++ b/cmd/calcmark/tui/editor/empty_editor_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestEmptyDocumentStructure tests what structure an empty document has

--- a/cmd/calcmark/tui/editor/enter_key_test.go
+++ b/cmd/calcmark/tui/editor/enter_key_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestDocumentBlockStructure verifies how different document contents create blocks

--- a/cmd/calcmark/tui/editor/error_display_test.go
+++ b/cmd/calcmark/tui/editor/error_display_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/components"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/components"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 func TestParseErrorForDisplay(t *testing.T) {

--- a/cmd/calcmark/tui/editor/error_line_display_test.go
+++ b/cmd/calcmark/tui/editor/error_line_display_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestErrorLineDisplaysAtCorrectPosition verifies that errors display

--- a/cmd/calcmark/tui/editor/error_wrong_line_test.go
+++ b/cmd/calcmark/tui/editor/error_wrong_line_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestErrorAppearsOnWrongLine tests if an error about variable 'b'

--- a/cmd/calcmark/tui/editor/export_overlay.go
+++ b/cmd/calcmark/tui/editor/export_overlay.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
 )
 
 // ExportOverlayState holds the state for the export format selection overlay.

--- a/cmd/calcmark/tui/editor/file_operations.go
+++ b/cmd/calcmark/tui/editor/file_operations.go
@@ -8,10 +8,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/filecheck"
-	"github.com/CalcMark/go-calcmark/format"
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/filecheck"
+	"github.com/CalcMark/go-calcmark/v2/format"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // saveFile saves the document to a file.

--- a/cmd/calcmark/tui/editor/file_operations_test.go
+++ b/cmd/calcmark/tui/editor/file_operations_test.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/format"
-	"github.com/CalcMark/go-calcmark/format/display"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/format"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 func TestSaveFile(t *testing.T) {

--- a/cmd/calcmark/tui/editor/filepicker.go
+++ b/cmd/calcmark/tui/editor/filepicker.go
@@ -6,7 +6,7 @@ import (
 
 	"charm.land/bubbles/v2/filepicker"
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
 )
 
 // FilePickerFocus indicates which part of the file dialog has focus.

--- a/cmd/calcmark/tui/editor/first_line_bump_test.go
+++ b/cmd/calcmark/tui/editor/first_line_bump_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestFirstLineBumpWhenTyping reproduces the bug where the first line

--- a/cmd/calcmark/tui/editor/frontmatter_delimiter_test.go
+++ b/cmd/calcmark/tui/editor/frontmatter_delimiter_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // simulateDebounce simulates the debounce timer firing by sending an

--- a/cmd/calcmark/tui/editor/frontmatter_preview_jump_test.go
+++ b/cmd/calcmark/tui/editor/frontmatter_preview_jump_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestFrontmatterCursorMovePreviewStability verifies that moving the cursor

--- a/cmd/calcmark/tui/editor/frontmatter_preview_stale_test.go
+++ b/cmd/calcmark/tui/editor/frontmatter_preview_stale_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestPreviewStale_MissingClosingDelimiter tests that when the closing ---

--- a/cmd/calcmark/tui/editor/frontmatter_test.go
+++ b/cmd/calcmark/tui/editor/frontmatter_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 	"github.com/cockroachdb/datadriven"
 )
 

--- a/cmd/calcmark/tui/editor/function_help_test.go
+++ b/cmd/calcmark/tui/editor/function_help_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/components"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/components"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestFunctionHelp_AfterAutocompleteAccept verifies that function parameter help

--- a/cmd/calcmark/tui/editor/function_result_display_test.go
+++ b/cmd/calcmark/tui/editor/function_result_display_test.go
@@ -3,8 +3,8 @@ package editor
 import (
 	"testing"
 
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestFunctionResultDisplay verifies that function calls display results in preview.

--- a/cmd/calcmark/tui/editor/help_overlay.go
+++ b/cmd/calcmark/tui/editor/help_overlay.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
 )
 
 // HelpItemKind distinguishes actionable items (selectable, executable)

--- a/cmd/calcmark/tui/editor/insert_line_bug_test.go
+++ b/cmd/calcmark/tui/editor/insert_line_bug_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestInsertLineAtStartPreservesContent verifies that pressing Enter at the

--- a/cmd/calcmark/tui/editor/insert_line_test.go
+++ b/cmd/calcmark/tui/editor/insert_line_test.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 func TestInsertLineBelow_CursorPosition(t *testing.T) {

--- a/cmd/calcmark/tui/editor/interactive_alignment_test.go
+++ b/cmd/calcmark/tui/editor/interactive_alignment_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestInteractive_OrderedListThenBlankThenHeading simulates the user's reported bug:

--- a/cmd/calcmark/tui/editor/layout_success_criteria_test.go
+++ b/cmd/calcmark/tui/editor/layout_success_criteria_test.go
@@ -6,8 +6,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/geometry"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/geometry"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 	"github.com/mattn/go-runewidth"
 )
 

--- a/cmd/calcmark/tui/editor/linemodel.go
+++ b/cmd/calcmark/tui/editor/linemodel.go
@@ -1,6 +1,6 @@
 package editor
 
-import "github.com/CalcMark/go-calcmark/cmd/calcmark/tui/geometry"
+import "github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/geometry"
 
 // LineModel computes the visual line layout for source and preview panes.
 // This is a pure computation - no rendering, no side effects.

--- a/cmd/calcmark/tui/editor/linemodel_test.go
+++ b/cmd/calcmark/tui/editor/linemodel_test.go
@@ -3,7 +3,7 @@ package editor
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/geometry"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/geometry"
 )
 
 func TestWrapText(t *testing.T) {

--- a/cmd/calcmark/tui/editor/markdown.go
+++ b/cmd/calcmark/tui/editor/markdown.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2/compat"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/glamour/ansi"
 )

--- a/cmd/calcmark/tui/editor/mode_transitions.go
+++ b/cmd/calcmark/tui/editor/mode_transitions.go
@@ -8,9 +8,9 @@ package editor
 
 import (
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/components"
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/components"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // exitOverlay returns to StateDefault, resetting overlay-specific fields.

--- a/cmd/calcmark/tui/editor/model.go
+++ b/cmd/calcmark/tui/editor/model.go
@@ -28,13 +28,13 @@ import (
 
 	"charm.land/bubbles/v2/filepicker"
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/components"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/shared"
-	"github.com/CalcMark/go-calcmark/format/display"
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/components"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/shared"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // ========================================

--- a/cmd/calcmark/tui/editor/model_basics_test.go
+++ b/cmd/calcmark/tui/editor/model_basics_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 func TestNew(t *testing.T) {

--- a/cmd/calcmark/tui/editor/navigation.go
+++ b/cmd/calcmark/tui/editor/navigation.go
@@ -6,7 +6,7 @@ import (
 	"unicode"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/components"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/components"
 )
 
 // ========================================

--- a/cmd/calcmark/tui/editor/navigation_eval_test.go
+++ b/cmd/calcmark/tui/editor/navigation_eval_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestArrowUpEvaluatesLine tests that pressing arrow up saves and evaluates the current line.

--- a/cmd/calcmark/tui/editor/open_from_overlay.go
+++ b/cmd/calcmark/tui/editor/open_from_overlay.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
 )
 
 // handleOpenFromOverlayKey processes keys when the Open From Gist overlay is visible.

--- a/cmd/calcmark/tui/editor/ordered_list_bug_test.go
+++ b/cmd/calcmark/tui/editor/ordered_list_bug_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestCalculationBeforeOrderedList verifies that a calculation result

--- a/cmd/calcmark/tui/editor/overlay_style.go
+++ b/cmd/calcmark/tui/editor/overlay_style.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
 )
 
 // OverlayStyle holds the shared rendering primitives for all modal overlays

--- a/cmd/calcmark/tui/editor/preview_alignment_integration_test.go
+++ b/cmd/calcmark/tui/editor/preview_alignment_integration_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/geometry"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/geometry"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestPreviewAlignmentIntegration is a comprehensive integration test that verifies

--- a/cmd/calcmark/tui/editor/preview_empty_lines_test.go
+++ b/cmd/calcmark/tui/editor/preview_empty_lines_test.go
@@ -3,7 +3,7 @@ package editor
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestPreviewWithEmptyLineAfterHeading tests that empty lines between blocks

--- a/cmd/calcmark/tui/editor/preview_pane_jump_test.go
+++ b/cmd/calcmark/tui/editor/preview_pane_jump_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestPreviewPaneStability_CursorOnWrappingCalcLine verifies that the preview

--- a/cmd/calcmark/tui/editor/redefinition_display_test.go
+++ b/cmd/calcmark/tui/editor/redefinition_display_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestRedefinitionErrorDisplayLine tests that redefinition errors show on the correct line

--- a/cmd/calcmark/tui/editor/redefinition_error_test.go
+++ b/cmd/calcmark/tui/editor/redefinition_error_test.go
@@ -3,8 +3,8 @@ package editor
 import (
 	"testing"
 
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestRedefinitionErrorLineNumber tests that variable redefinition errors

--- a/cmd/calcmark/tui/editor/redefinition_line_number_test.go
+++ b/cmd/calcmark/tui/editor/redefinition_line_number_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestRedefinitionErrorAppearsOnCorrectLine tests that redefinition errors

--- a/cmd/calcmark/tui/editor/results.go
+++ b/cmd/calcmark/tui/editor/results.go
@@ -3,10 +3,10 @@ package editor
 import (
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/semantic"
-	"github.com/CalcMark/go-calcmark/spec/transform"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/semantic"
+	"github.com/CalcMark/go-calcmark/v2/spec/transform"
 )
 
 // LineResult represents a line's evaluation result.

--- a/cmd/calcmark/tui/editor/results_regression_test.go
+++ b/cmd/calcmark/tui/editor/results_regression_test.go
@@ -13,7 +13,7 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestRegressionGetLineReferencesBasic verifies that getLineReferences returns

--- a/cmd/calcmark/tui/editor/results_test.go
+++ b/cmd/calcmark/tui/editor/results_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestLineResultReferencedVars verifies that GetLineResults populates

--- a/cmd/calcmark/tui/editor/scale_preview_test.go
+++ b/cmd/calcmark/tui/editor/scale_preview_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestScaleChangeViaDebounce verifies that editing a frontmatter value

--- a/cmd/calcmark/tui/editor/selection.go
+++ b/cmd/calcmark/tui/editor/selection.go
@@ -5,7 +5,7 @@ import (
 	"unicode/utf8"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // HasSelection returns true if there is an active text selection.

--- a/cmd/calcmark/tui/editor/selection_highlighting_test.go
+++ b/cmd/calcmark/tui/editor/selection_highlighting_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestSelectionHighlighting_WrappedLineFullyHighlighted verifies that

--- a/cmd/calcmark/tui/editor/selection_test.go
+++ b/cmd/calcmark/tui/editor/selection_test.go
@@ -3,7 +3,7 @@ package editor
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 func TestHasSelection(t *testing.T) {

--- a/cmd/calcmark/tui/editor/share_overlay.go
+++ b/cmd/calcmark/tui/editor/share_overlay.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
 )
 
 // handleShareOverlayKey processes keys when the Share To Gist overlay is visible.

--- a/cmd/calcmark/tui/editor/sidebyside.go
+++ b/cmd/calcmark/tui/editor/sidebyside.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
 )
 
 // SideBySide renders two panes side-by-side with a vertical divider and guaranteed

--- a/cmd/calcmark/tui/editor/sidebyside_test.go
+++ b/cmd/calcmark/tui/editor/sidebyside_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 func TestSideBySide_BasicRendering(t *testing.T) {

--- a/cmd/calcmark/tui/editor/state.go
+++ b/cmd/calcmark/tui/editor/state.go
@@ -1,8 +1,8 @@
 package editor
 
 import (
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // EditorState represents the core editing state of the editor.

--- a/cmd/calcmark/tui/editor/status_bar_bug_test.go
+++ b/cmd/calcmark/tui/editor/status_bar_bug_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestStatusBarNoShellContamination verifies that the status bar

--- a/cmd/calcmark/tui/editor/store_commands.go
+++ b/cmd/calcmark/tui/editor/store_commands.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/editor/store"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/editor/store"
 	"github.com/atotto/clipboard"
 )
 

--- a/cmd/calcmark/tui/editor/testmain_test.go
+++ b/cmd/calcmark/tui/editor/testmain_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config"
 )
 
 // TestMain ensures all editor tests run with default config (dark mode),

--- a/cmd/calcmark/tui/editor/undo_frontmatter_test.go
+++ b/cmd/calcmark/tui/editor/undo_frontmatter_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // sendKey simulates a key press and returns the updated model.

--- a/cmd/calcmark/tui/editor/undo_operations.go
+++ b/cmd/calcmark/tui/editor/undo_operations.go
@@ -5,7 +5,7 @@ package editor
 
 import (
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // handleUndo handles Ctrl+Z - undo last edit batch.

--- a/cmd/calcmark/tui/editor/undo_test.go
+++ b/cmd/calcmark/tui/editor/undo_test.go
@@ -6,7 +6,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestEditOperation_Reverse tests that operations reverse correctly.

--- a/cmd/calcmark/tui/editor/view.go
+++ b/cmd/calcmark/tui/editor/view.go
@@ -5,10 +5,10 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/components"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/geometry"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/components"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/geometry"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // alignedPanes holds pre-computed line structures for both panes.

--- a/cmd/calcmark/tui/editor/view_alignment_test.go
+++ b/cmd/calcmark/tui/editor/view_alignment_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/geometry"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/geometry"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestViewAlignment_EditMode tests that source and preview panes

--- a/cmd/calcmark/tui/editor/view_empty_lines_test.go
+++ b/cmd/calcmark/tui/editor/view_empty_lines_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestViewWithEmptyLinesAfterHeading tests the full View() rendering

--- a/cmd/calcmark/tui/editor/view_footer.go
+++ b/cmd/calcmark/tui/editor/view_footer.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/components"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/components"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // renderContextFooter renders the context footer showing errors or referenced variables.

--- a/cmd/calcmark/tui/editor/view_lines.go
+++ b/cmd/calcmark/tui/editor/view_lines.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/geometry"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/geometry"
 )
 
 // selectionStyle returns the lipgloss style for selected text.

--- a/cmd/calcmark/tui/editor/view_overlays.go
+++ b/cmd/calcmark/tui/editor/view_overlays.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
 )
 
 // renderAutocompletePopup renders the autocomplete popup box using manual borders

--- a/cmd/calcmark/tui/editor/view_panes.go
+++ b/cmd/calcmark/tui/editor/view_panes.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/components"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/components"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // readingMarginWidth is the left gutter width in Reading mode for visual breathing room.

--- a/cmd/calcmark/tui/editor/view_rendering_test.go
+++ b/cmd/calcmark/tui/editor/view_rendering_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 func TestView(t *testing.T) {

--- a/cmd/calcmark/tui/editor/view_state.go
+++ b/cmd/calcmark/tui/editor/view_state.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/components"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/geometry"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/components"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/geometry"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // getGlobalsCount returns the number of global variables.

--- a/cmd/calcmark/tui/editor/view_util.go
+++ b/cmd/calcmark/tui/editor/view_util.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/components"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/geometry"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/components"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/geometry"
 )
 
 // padToWidth pads a string to exactly width visual columns (no truncation).

--- a/cmd/calcmark/tui/editor/viewport_height_test.go
+++ b/cmd/calcmark/tui/editor/viewport_height_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestViewportDoesNotExceedHeight verifies that the View() output

--- a/cmd/calcmark/tui/editor/visual_alignment_test.go
+++ b/cmd/calcmark/tui/editor/visual_alignment_test.go
@@ -5,7 +5,7 @@ package editor
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 func TestSourceToVisualMapping_BasicCase(t *testing.T) {

--- a/cmd/calcmark/tui/editor/visual_layout_test.go
+++ b/cmd/calcmark/tui/editor/visual_layout_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestVisualLayout_GutterSpace verifies that there is a space between line numbers and content

--- a/cmd/calcmark/tui/editor/visual_state_test.go
+++ b/cmd/calcmark/tui/editor/visual_state_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestVisualStateAfterTypingAndEnter verifies that after typing and pressing ENTER,

--- a/cmd/calcmark/tui/editor/word_nav_dispatch_test.go
+++ b/cmd/calcmark/tui/editor/word_nav_dispatch_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestWordNavigationDispatch verifies that Ctrl+Left/Right, Alt+Left/Right,

--- a/cmd/calcmark/tui/repl/model.go
+++ b/cmd/calcmark/tui/repl/model.go
@@ -6,13 +6,13 @@ import (
 
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/shared"
-	"github.com/CalcMark/go-calcmark/format/display"
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/features"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/shared"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // Model represents the Simple REPL mode state.

--- a/cmd/calcmark/tui/repl/model_test.go
+++ b/cmd/calcmark/tui/repl/model_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/shared"
-	"github.com/CalcMark/go-calcmark/format/display"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/shared"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 func init() {

--- a/cmd/calcmark/tui/repl/view.go
+++ b/cmd/calcmark/tui/repl/view.go
@@ -6,9 +6,9 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/config/theme"
-	"github.com/CalcMark/go-calcmark/cmd/calcmark/tui/shared"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/config/theme"
+	"github.com/CalcMark/go-calcmark/v2/cmd/calcmark/tui/shared"
 )
 
 // View implements tea.Model.

--- a/cmd/calcmark/tui/shared/state.go
+++ b/cmd/calcmark/tui/shared/state.go
@@ -1,7 +1,7 @@
 package shared
 
 import (
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // Mode represents the current TUI mode.

--- a/cmd/doceval/main.go
+++ b/cmd/doceval/main.go
@@ -25,10 +25,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/format"
-	"github.com/CalcMark/go-calcmark/format/display"
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/format"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // BlockResult holds the evaluated results for a single ```calcmark code block.

--- a/cmd/docgen/main.go
+++ b/cmd/docgen/main.go
@@ -10,7 +10,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
 )
 
 // JSONFeature is the JSON representation of a single feature.

--- a/cmd/docgen/main_test.go
+++ b/cmd/docgen/main_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
 )
 
 func TestKebabCase(t *testing.T) {

--- a/convert.go
+++ b/convert.go
@@ -11,11 +11,11 @@ import (
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
 
-	"github.com/CalcMark/go-calcmark/format"
-	"github.com/CalcMark/go-calcmark/format/display"
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/impl/embedded"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/format"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/impl/embedded"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // Mode selects the conversion pipeline.

--- a/eval.go
+++ b/eval.go
@@ -21,11 +21,11 @@ package calcmark
 import (
 	"fmt"
 
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/semantic"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/semantic"
 )
 
 // Eval evaluates a CalcMark expression or document and returns the result.

--- a/format/align.go
+++ b/format/align.go
@@ -3,8 +3,8 @@ package format
 import (
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // AlignedStatement maps a source line to its evaluated result.

--- a/format/align_test.go
+++ b/format/align_test.go
@@ -3,8 +3,8 @@ package format
 import (
 	"testing"
 
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 func TestAlignResults(t *testing.T) {

--- a/format/calcmark_formatter.go
+++ b/format/calcmark_formatter.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // CalcMarkFormatter formats CalcMark documents back to CalcMark format.

--- a/format/calcmark_formatter_test.go
+++ b/format/calcmark_formatter_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestCalcMarkFormatterSimple tests basic CalcMark output

--- a/format/display/annotation_test.go
+++ b/format/display/annotation_test.go
@@ -3,8 +3,8 @@ package display
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 	"github.com/shopspring/decimal"
 )
 

--- a/format/display/date_format_dsl_test.go
+++ b/format/display/date_format_dsl_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"golang.org/x/text/language"
 )
 

--- a/format/display/date_locale_test.go
+++ b/format/display/date_locale_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"golang.org/x/text/language"
 )
 

--- a/format/display/display.go
+++ b/format/display/display.go
@@ -9,7 +9,7 @@
 //
 // Usage:
 //
-//	import "github.com/CalcMark/go-calcmark/format/display"
+//	import "github.com/CalcMark/go-calcmark/v2/format/display"
 //
 //	// Package-level (en-US default):
 //	fmt.Println(display.Format(result))  // "100K users"
@@ -22,7 +22,7 @@ package display
 import (
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/format/display/display_test.go
+++ b/format/display/display_test.go
@@ -3,7 +3,7 @@ package display
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/format/display/explicit_quantity_test.go
+++ b/format/display/explicit_quantity_test.go
@@ -3,7 +3,7 @@ package display
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/format/display/formatter.go
+++ b/format/display/formatter.go
@@ -5,8 +5,8 @@ import (
 	"math"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 	"github.com/goodsign/monday"
 	"github.com/shopspring/decimal"
 )

--- a/format/display/fraction_unicode.go
+++ b/format/display/fraction_unicode.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // unicodeFractions maps numerator/denominator pairs to Unicode Number Forms characters.

--- a/format/display/fraction_unicode_test.go
+++ b/format/display/fraction_unicode_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 func TestFormatFractionUnicode(t *testing.T) {

--- a/format/display/locale_test.go
+++ b/format/display/locale_test.go
@@ -3,7 +3,7 @@ package display
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/format/display/period_test.go
+++ b/format/display/period_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"golang.org/x/text/language"
 )
 

--- a/format/formatter.go
+++ b/format/formatter.go
@@ -3,8 +3,8 @@ package format
 import (
 	"io"
 
-	"github.com/CalcMark/go-calcmark/format/display"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // Formatter formats CalcMark documents for output.

--- a/format/formatter_test.go
+++ b/format/formatter_test.go
@@ -3,7 +3,7 @@ package format
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestFormatterInterface ensures all formatters implement the interface correctly

--- a/format/html_formatter.go
+++ b/format/html_formatter.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/CalcMark/go-calcmark/format/display"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 	"github.com/microcosm-cc/bluemonday"
 )
 

--- a/format/html_formatter_test.go
+++ b/format/html_formatter_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestHTMLFormatterSimple tests basic HTML output

--- a/format/json_formatter.go
+++ b/format/json_formatter.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"maps"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // JSONFormatter formats CalcMark documents as JSON.

--- a/format/json_formatter_test.go
+++ b/format/json_formatter_test.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/format/display"
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // helper creates a document, evaluates it, and formats it as JSON.

--- a/format/json_period_test.go
+++ b/format/json_period_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // U14 — JSON formatter populates period_start, period_end, and

--- a/format/markdown_formatter.go
+++ b/format/markdown_formatter.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // MarkdownFormatter formats CalcMark documents as Markdown.

--- a/format/markdown_formatter_test.go
+++ b/format/markdown_formatter_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestMarkdownFormatterSimple tests basic Markdown output

--- a/format/multibyte_test.go
+++ b/format/multibyte_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // multibyteSource is the test document used across all format round-trip tests.

--- a/format/registry_test.go
+++ b/format/registry_test.go
@@ -6,7 +6,7 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestGetFormatterExplicit tests explicit format selection

--- a/format/text_formatter.go
+++ b/format/text_formatter.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TextFormatter formats CalcMark documents as plain text.

--- a/format/text_formatter_test.go
+++ b/format/text_formatter_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestTextFormatterSimple tests basic text formatting

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/CalcMark/go-calcmark
+module github.com/CalcMark/go-calcmark/v2
 
 go 1.25.1
 

--- a/impl/document/diagnostic.go
+++ b/impl/document/diagnostic.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/lexer"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // DiagnosticSeverity indicates the severity of a diagnostic.

--- a/impl/document/diagnostic_test.go
+++ b/impl/document/diagnostic_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
 )
 
 func TestLooksLikeFailedCalculation(t *testing.T) {

--- a/impl/document/evaluator.go
+++ b/impl/document/evaluator.go
@@ -6,14 +6,14 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/format/display"
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/semantic"
-	"github.com/CalcMark/go-calcmark/spec/transform"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/semantic"
+	"github.com/CalcMark/go-calcmark/v2/spec/transform"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/document/evaluator_benchmark_test.go
+++ b/impl/document/evaluator_benchmark_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // BenchmarkEvaluate_ValidDocument benchmarks full document evaluation

--- a/impl/document/evaluator_test.go
+++ b/impl/document/evaluator_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestDocumentEvaluation tests the full evaluation pipeline.

--- a/impl/document/interpolation.go
+++ b/impl/document/interpolation.go
@@ -4,10 +4,10 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/format/display"
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/transform"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/transform"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // interpolationPattern matches {{variable_name}}, {{@scale}}, or {{@globals.field}}

--- a/impl/document/interpolation_test.go
+++ b/impl/document/interpolation_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/format/display"
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/document/multibyte_test.go
+++ b/impl/document/multibyte_test.go
@@ -3,7 +3,7 @@ package document
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestMultibyteDocumentEvaluation validates that a CalcMark document containing

--- a/impl/interpreter/all_features_test.go
+++ b/impl/interpreter/all_features_test.go
@@ -3,8 +3,8 @@ package interpreter_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestAllInterpreterFeatures provides comprehensive coverage of all interpreter capabilities

--- a/impl/interpreter/arbitrary_units_test.go
+++ b/impl/interpreter/arbitrary_units_test.go
@@ -3,8 +3,8 @@ package interpreter_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestArbitraryUnits verifies arbitrary user-defined units work

--- a/impl/interpreter/availability_functions.go
+++ b/impl/interpreter/availability_functions.go
@@ -3,8 +3,8 @@ package interpreter
 import (
 	"fmt"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/availability_functions_test.go
+++ b/impl/interpreter/availability_functions_test.go
@@ -3,7 +3,7 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/canonical_identifiers_test.go
+++ b/impl/interpreter/canonical_identifiers_test.go
@@ -4,7 +4,7 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/identifiers"
+	"github.com/CalcMark/go-calcmark/v2/spec/identifiers"
 )
 
 // TestNetworkMapsMatchCanonicalIdentifiers verifies bidirectional consistency:

--- a/impl/interpreter/capacity_at_test.go
+++ b/impl/interpreter/capacity_at_test.go
@@ -3,8 +3,8 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/capacity_functions.go
+++ b/impl/interpreter/capacity_functions.go
@@ -5,8 +5,8 @@ import (
 	"math"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/comparison_test.go
+++ b/impl/interpreter/comparison_test.go
@@ -3,8 +3,8 @@ package interpreter_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestComparisonOperations tests if comparison operators work

--- a/impl/interpreter/compound_units_test.go
+++ b/impl/interpreter/compound_units_test.go
@@ -3,8 +3,8 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // TestCompoundUnits verifies that compound units (rates) like MB/s, km/h, req/s

--- a/impl/interpreter/comprehensive_test.go
+++ b/impl/interpreter/comprehensive_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestComprehensiveFeatures tests all implemented features with valid inputs

--- a/impl/interpreter/compression_functions.go
+++ b/impl/interpreter/compression_functions.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/identifiers"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/identifiers"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/compression_functions_test.go
+++ b/impl/interpreter/compression_functions_test.go
@@ -3,7 +3,7 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/conversion_result_test.go
+++ b/impl/interpreter/conversion_result_test.go
@@ -3,8 +3,8 @@ package interpreter_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestConversionExpressionReturnsResult verifies that conversion expressions return results

--- a/impl/interpreter/currency_number_test.go
+++ b/impl/interpreter/currency_number_test.go
@@ -3,8 +3,8 @@ package interpreter_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestCurrencyNumberOperations verifies currency +/-/* /÷ number operations.

--- a/impl/interpreter/data_rate_test.go
+++ b/impl/interpreter/data_rate_test.go
@@ -3,9 +3,9 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 )
 
 // TestDataRateUnitConversions tests that all data rate unit variations work correctly.

--- a/impl/interpreter/date_test.go
+++ b/impl/interpreter/date_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // ---------------------------------------------------------------------------

--- a/impl/interpreter/datetime.go
+++ b/impl/interpreter/datetime.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // Date and time literal evaluation.

--- a/impl/interpreter/directive_test.go
+++ b/impl/interpreter/directive_test.go
@@ -3,8 +3,8 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/downtime_integration_test.go
+++ b/impl/interpreter/downtime_integration_test.go
@@ -3,7 +3,7 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // TestDowntimeFunctionIntegration - tests the full downtime() function via interpreter

--- a/impl/interpreter/duration_quantity_test.go
+++ b/impl/interpreter/duration_quantity_test.go
@@ -3,7 +3,7 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/edge_cases_test.go
+++ b/impl/interpreter/edge_cases_test.go
@@ -3,8 +3,8 @@ package interpreter_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestUnitEdgeCases tests edge cases for new unit categories

--- a/impl/interpreter/end_of_runtime_test.go
+++ b/impl/interpreter/end_of_runtime_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // TestEndOfExpr_VariableBoundWorks — v2.0 R9 (variables-as-periods).

--- a/impl/interpreter/environment.go
+++ b/impl/interpreter/environment.go
@@ -4,7 +4,7 @@ import (
 	"maps"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/environment_test.go
+++ b/impl/interpreter/environment_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/evaluate.go
+++ b/impl/interpreter/evaluate.go
@@ -1,7 +1,7 @@
 package interpreter
 
 import (
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // Evaluate is a convenience wrapper for parsing and evaluating CalcMark source.

--- a/impl/interpreter/explicit_unit_test.go
+++ b/impl/interpreter/explicit_unit_test.go
@@ -3,9 +3,9 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/format/display"
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // TestExplicitUnitConversionDisplay verifies that explicit unit conversions

--- a/impl/interpreter/fraction_ops.go
+++ b/impl/interpreter/fraction_ops.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/fraction_ops_test.go
+++ b/impl/interpreter/fraction_ops_test.go
@@ -3,7 +3,7 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/function_consistency_test.go
+++ b/impl/interpreter/function_consistency_test.go
@@ -3,8 +3,8 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/features"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // TestFunctionSpecConsistency verifies that FunctionSpecs (spec layer) and

--- a/impl/interpreter/functions.go
+++ b/impl/interpreter/functions.go
@@ -6,9 +6,9 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/functions_comprehensive_test.go
+++ b/impl/interpreter/functions_comprehensive_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestAllStandardFunctions systematically tests every function in BuiltinFunctions.

--- a/impl/interpreter/functions_test.go
+++ b/impl/interpreter/functions_test.go
@@ -3,8 +3,8 @@ package interpreter_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 func TestFunctionEvaluation(t *testing.T) {

--- a/impl/interpreter/golden_eval_test.go
+++ b/impl/interpreter/golden_eval_test.go
@@ -6,10 +6,10 @@ import (
 	"strings"
 	"testing"
 
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestEvalFilesEvaluate tests that eval/success files not only parse but also evaluate successfully.

--- a/impl/interpreter/growth_function_types_test.go
+++ b/impl/interpreter/growth_function_types_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // Intent of each growth function's parameter types — captured here so

--- a/impl/interpreter/growth_functions.go
+++ b/impl/interpreter/growth_functions.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/growth_functions_test.go
+++ b/impl/interpreter/growth_functions_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/format/display"
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/in_unit_test.go
+++ b/impl/interpreter/in_unit_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestInUnitSyntax tests explicit unit conversion with "in" keyword

--- a/impl/interpreter/interpreter.go
+++ b/impl/interpreter/interpreter.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/interpreter_test.go
+++ b/impl/interpreter/interpreter_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/literals.go
+++ b/impl/interpreter/literals.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/logical_test.go
+++ b/impl/interpreter/logical_test.go
@@ -3,9 +3,9 @@ package interpreter_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // TestLogicalOperators tests AND, OR, NOT operators

--- a/impl/interpreter/multibyte_test.go
+++ b/impl/interpreter/multibyte_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestMultibyteVariableAssignment validates that multi-byte UTF-8 identifiers

--- a/impl/interpreter/multipliers_test.go
+++ b/impl/interpreter/multipliers_test.go
@@ -3,8 +3,8 @@ package interpreter_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestMultipliers verifies number multipliers work (with and without units)

--- a/impl/interpreter/napkin_eval.go
+++ b/impl/interpreter/napkin_eval.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/CalcMark/go-calcmark/format/display"
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/napkin_eval_test.go
+++ b/impl/interpreter/napkin_eval_test.go
@@ -3,9 +3,9 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/format/display"
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/format/display"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // TestNapkinTypePreservation verifies that napkin conversion preserves the input type.

--- a/impl/interpreter/napkin_unary_test.go
+++ b/impl/interpreter/napkin_unary_test.go
@@ -3,7 +3,7 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestNapkinWithNegativeNumbers tests that negative numbers work correctly with napkin conversion

--- a/impl/interpreter/natural_syntax_test.go
+++ b/impl/interpreter/natural_syntax_test.go
@@ -3,8 +3,8 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 func TestNaturalSyntaxInterpreter(t *testing.T) {

--- a/impl/interpreter/network_functions.go
+++ b/impl/interpreter/network_functions.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/identifiers"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/identifiers"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/network_functions_test.go
+++ b/impl/interpreter/network_functions_test.go
@@ -3,7 +3,7 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/new_units_test.go
+++ b/impl/interpreter/new_units_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // TestTemperatureConversions tests temperature unit conversions

--- a/impl/interpreter/nl_equivalence_test.go
+++ b/impl/interpreter/nl_equivalence_test.go
@@ -3,8 +3,8 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // TestNLFunctionEquivalence verifies that plain language syntax produces

--- a/impl/interpreter/nl_functions_comprehensive_test.go
+++ b/impl/interpreter/nl_functions_comprehensive_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestNaturalLanguageForms verifies that natural language function forms

--- a/impl/interpreter/nl_functions_test.go
+++ b/impl/interpreter/nl_functions_test.go
@@ -3,8 +3,8 @@ package interpreter_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestNaturalLanguageFunctions verifies "average of" and "square root of" syntax

--- a/impl/interpreter/number_function_test.go
+++ b/impl/interpreter/number_function_test.go
@@ -3,9 +3,9 @@ package interpreter_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/operator_benchmark_test.go
+++ b/impl/interpreter/operator_benchmark_test.go
@@ -3,7 +3,7 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/operators.go
+++ b/impl/interpreter/operators.go
@@ -6,9 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/operators_test.go
+++ b/impl/interpreter/operators_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/percentage_of_eval.go
+++ b/impl/interpreter/percentage_of_eval.go
@@ -3,8 +3,8 @@ package interpreter
 import (
 	"fmt"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/percentage_test.go
+++ b/impl/interpreter/percentage_test.go
@@ -3,8 +3,8 @@ package interpreter_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestPercentageCalculations tests percentage operations

--- a/impl/interpreter/percentage_units_test.go
+++ b/impl/interpreter/percentage_units_test.go
@@ -3,8 +3,8 @@ package interpreter_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestPercentageWithUnits tests if percentages work with units

--- a/impl/interpreter/period_basis_conversion_test.go
+++ b/impl/interpreter/period_basis_conversion_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // Period basis conversion: `<period> as fiscal` / `<period> as

--- a/impl/interpreter/period_eval.go
+++ b/impl/interpreter/period_eval.go
@@ -17,8 +17,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/period_eval_test.go
+++ b/impl/interpreter/period_eval_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // U10 — period-bearing keywords evaluate to *types.Period.

--- a/impl/interpreter/period_operators_eval_test.go
+++ b/impl/interpreter/period_operators_eval_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/period_test_helpers_test.go
+++ b/impl/interpreter/period_test_helpers_test.go
@@ -3,7 +3,7 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // resultStartDate returns the start Date from a result that's

--- a/impl/interpreter/plural_units_test.go
+++ b/impl/interpreter/plural_units_test.go
@@ -3,8 +3,8 @@ package interpreter_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestPluralUnitMismatch documents that plural forms are treated as different units

--- a/impl/interpreter/precise_eval.go
+++ b/impl/interpreter/precise_eval.go
@@ -3,8 +3,8 @@ package interpreter
 import (
 	"fmt"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // evalPreciseConversion evaluates a precise conversion expression.

--- a/impl/interpreter/quantity_number_test.go
+++ b/impl/interpreter/quantity_number_test.go
@@ -3,8 +3,8 @@ package interpreter_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestQuantityNumberOperations verifies number * quantity operations

--- a/impl/interpreter/rate_arbitrary_units_test.go
+++ b/impl/interpreter/rate_arbitrary_units_test.go
@@ -3,8 +3,8 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 func TestRatesWithArbitraryUnits(t *testing.T) {

--- a/impl/interpreter/rate_eval.go
+++ b/impl/interpreter/rate_eval.go
@@ -3,8 +3,8 @@ package interpreter
 import (
 	"fmt"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // evalRateLiteral evaluates a rate literal and returns a Rate type.

--- a/impl/interpreter/rate_eval_test.go
+++ b/impl/interpreter/rate_eval_test.go
@@ -3,8 +3,8 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 func TestRateEvaluation(t *testing.T) {

--- a/impl/interpreter/rate_functions.go
+++ b/impl/interpreter/rate_functions.go
@@ -3,7 +3,7 @@ package interpreter
 import (
 	"fmt"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/rate_functions_test.go
+++ b/impl/interpreter/rate_functions_test.go
@@ -3,7 +3,7 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/rate_widening_test.go
+++ b/impl/interpreter/rate_widening_test.go
@@ -8,8 +8,8 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 func TestRateWidening_NumberTimesRate(t *testing.T) {

--- a/impl/interpreter/registry.go
+++ b/impl/interpreter/registry.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/CalcMark/go-calcmark/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
 )
 
 // FunctionInfo contains metadata about a CalcMark function for help output.

--- a/impl/interpreter/speed_bridge.go
+++ b/impl/interpreter/speed_bridge.go
@@ -3,8 +3,8 @@ package interpreter
 import (
 	"fmt"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 )
 
 // coerceSpeedToRate converts a Speed quantity (e.g., "60 mph") to a Rate (e.g., 60 mi/h).

--- a/impl/interpreter/storage_functions.go
+++ b/impl/interpreter/storage_functions.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/identifiers"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/identifiers"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/storage_functions_test.go
+++ b/impl/interpreter/storage_functions_test.go
@@ -3,7 +3,7 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/type_audit_test.go
+++ b/impl/interpreter/type_audit_test.go
@@ -3,8 +3,8 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/unit_benchmark_test.go
+++ b/impl/interpreter/unit_benchmark_test.go
@@ -3,7 +3,7 @@ package interpreter
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/unit_conversion.go
+++ b/impl/interpreter/unit_conversion.go
@@ -3,8 +3,8 @@ package interpreter
 import (
 	"fmt"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/unit_conversion_eval.go
+++ b/impl/interpreter/unit_conversion_eval.go
@@ -3,9 +3,9 @@ package interpreter
 import (
 	"fmt"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 	"github.com/shopspring/decimal"
 )
 

--- a/impl/interpreter/unit_conversion_test.go
+++ b/impl/interpreter/unit_conversion_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestUnitConversionAccuracy tests that unit conversions are mathematically correct

--- a/impl/interpreter/unit_roundtrip_test.go
+++ b/impl/interpreter/unit_roundtrip_test.go
@@ -5,8 +5,8 @@ import (
 	"math"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestUnitRoundtrip verifies that unit conversions are accurate within float64 tolerance.

--- a/impl/interpreter/variables.go
+++ b/impl/interpreter/variables.go
@@ -3,8 +3,8 @@ package interpreter
 import (
 	"fmt"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // Variable and identifier evaluation.

--- a/lsp/acceptance_test.go
+++ b/lsp/acceptance_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/semantic"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/semantic"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 

--- a/lsp/argctx.go
+++ b/lsp/argctx.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/CalcMark/go-calcmark/spec/features"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // argumentContext describes where a cursor sits relative to an enclosing

--- a/lsp/code_actions.go
+++ b/lsp/code_actions.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/semantic"
+	"github.com/CalcMark/go-calcmark/v2/spec/semantic"
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )

--- a/lsp/completion.go
+++ b/lsp/completion.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/features"
-	"github.com/CalcMark/go-calcmark/spec/lexer"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )

--- a/lsp/completion_data.go
+++ b/lsp/completion_data.go
@@ -3,7 +3,7 @@ package lsp
 import (
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 

--- a/lsp/completion_test.go
+++ b/lsp/completion_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/identifiers"
+	"github.com/CalcMark/go-calcmark/v2/spec/identifiers"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 

--- a/lsp/consistency_test.go
+++ b/lsp/consistency_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
 )
 
 // TestEveryFeatureProducesValidCompletion verifies that every feature in the

--- a/lsp/diagnostics.go
+++ b/lsp/diagnostics.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	specDoc "github.com/CalcMark/go-calcmark/spec/document"
+	specDoc "github.com/CalcMark/go-calcmark/v2/spec/document"
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )

--- a/lsp/frontmatter_completion.go
+++ b/lsp/frontmatter_completion.go
@@ -3,7 +3,7 @@ package lsp
 import (
 	"sort"
 
-	specDoc "github.com/CalcMark/go-calcmark/spec/document"
+	specDoc "github.com/CalcMark/go-calcmark/v2/spec/document"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 

--- a/lsp/frontmatter_hover.go
+++ b/lsp/frontmatter_hover.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	specDoc "github.com/CalcMark/go-calcmark/spec/document"
+	specDoc "github.com/CalcMark/go-calcmark/v2/spec/document"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 

--- a/lsp/frontmatter_symbols.go
+++ b/lsp/frontmatter_symbols.go
@@ -3,8 +3,8 @@ package lsp
 import (
 	"sort"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	specDoc "github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	specDoc "github.com/CalcMark/go-calcmark/v2/spec/document"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 

--- a/lsp/frontmatter_symbols_test.go
+++ b/lsp/frontmatter_symbols_test.go
@@ -3,8 +3,8 @@ package lsp
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	specDoc "github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	specDoc "github.com/CalcMark/go-calcmark/v2/spec/document"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 

--- a/lsp/hover.go
+++ b/lsp/hover.go
@@ -7,10 +7,10 @@ import (
 	"text/template"
 	"unicode"
 
-	specDoc "github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/features"
-	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	specDoc "github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )

--- a/lsp/lexicon.go
+++ b/lsp/lexicon.go
@@ -3,10 +3,10 @@ package lsp
 import (
 	"sort"
 
-	"github.com/CalcMark/go-calcmark/spec/features"
-	"github.com/CalcMark/go-calcmark/spec/lexer"
-	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 )
 
 // LexiconResult is the wire shape returned by `calcmark/lexicon`.

--- a/lsp/position.go
+++ b/lsp/position.go
@@ -4,7 +4,7 @@
 package lsp
 
 import (
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 

--- a/lsp/semantic_tokens.go
+++ b/lsp/semantic_tokens.go
@@ -3,7 +3,7 @@ package lsp
 import (
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )

--- a/lsp/semantic_tokens_test.go
+++ b/lsp/semantic_tokens_test.go
@@ -3,7 +3,7 @@ package lsp
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
 )
 
 // --- Token type mapping tests ---

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/format"
-	implDoc "github.com/CalcMark/go-calcmark/impl/document"
-	specDoc "github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/format"
+	implDoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	specDoc "github.com/CalcMark/go-calcmark/v2/spec/document"
 	"github.com/gorilla/websocket"
 	"github.com/tliron/commonlog"
 	"github.com/tliron/glsp"

--- a/lsp/server_test.go
+++ b/lsp/server_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )
 

--- a/lsp/signature.go
+++ b/lsp/signature.go
@@ -5,8 +5,8 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/features"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/tliron/glsp"
 	protocol "github.com/tliron/glsp/protocol_3_16"
 )

--- a/lsp/signature_test.go
+++ b/lsp/signature_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/identifiers"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/identifiers"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // TestSignatureHelp_ActiveParameterClampedForVariadic asserts that activeParameter

--- a/lsp/typemap.go
+++ b/lsp/typemap.go
@@ -1,6 +1,6 @@
 package lsp
 
-import "github.com/CalcMark/go-calcmark/spec/types"
+import "github.com/CalcMark/go-calcmark/v2/spec/types"
 
 // runtimeTypeToArgType maps a concrete evaluator runtime type to the ArgType
 // string used by ParamSpec. Unknown or nil values collapse to ArgTypeAny.

--- a/lsp/typemap_test.go
+++ b/lsp/typemap_test.go
@@ -3,7 +3,7 @@ package lsp
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/result.go
+++ b/result.go
@@ -1,7 +1,7 @@
 package calcmark
 
 import (
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // Result contains the evaluation results and any diagnostics.

--- a/session.go
+++ b/session.go
@@ -1,7 +1,7 @@
 package calcmark
 
 import (
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
 )
 
 // Session maintains state for live editor use.

--- a/spec/boundary_test.go
+++ b/spec/boundary_test.go
@@ -12,7 +12,7 @@ import (
 // This prevents the language specification from coupling to its implementation.
 func TestSpecNeverImportsImpl(t *testing.T) {
 	// Use the module path, not relative path, since test cwd may vary.
-	cmd := exec.Command("go", "list", "-json", "github.com/CalcMark/go-calcmark/spec/...")
+	cmd := exec.Command("go", "list", "-json", "github.com/CalcMark/go-calcmark/v2/spec/...")
 	out, err := cmd.Output()
 	if err != nil {
 		t.Fatalf("go list failed: %v", err)
@@ -29,7 +29,7 @@ func TestSpecNeverImportsImpl(t *testing.T) {
 		}
 
 		for _, imp := range pkg.Imports {
-			if strings.HasPrefix(imp, "github.com/CalcMark/go-calcmark/impl/") {
+			if strings.HasPrefix(imp, "github.com/CalcMark/go-calcmark/v2/impl/") {
 				t.Errorf("spec package %s imports impl package %s — this violates the spec/impl boundary", pkg.ImportPath, imp)
 			}
 		}

--- a/spec/classifier/classifier.go
+++ b/spec/classifier/classifier.go
@@ -6,11 +6,11 @@ import (
 	"sync"
 	"unicode"
 
-	"github.com/CalcMark/go-calcmark/constants"
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/features"
-	"github.com/CalcMark/go-calcmark/spec/lexer"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/constants"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // nlTriggerKeywords is the set of NL function trigger keywords, derived from

--- a/spec/classifier/classifier_function_fixed_test.go
+++ b/spec/classifier/classifier_function_fixed_test.go
@@ -3,8 +3,8 @@ package classifier
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/impl/types"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/impl/types"
 )
 
 func TestFunctionCallClassification(t *testing.T) {

--- a/spec/classifier/classifier_test.go
+++ b/spec/classifier/classifier_test.go
@@ -4,9 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/constants"
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/impl/types"
+	"github.com/CalcMark/go-calcmark/v2/constants"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/impl/types"
 )
 
 // Helper function to wrap ClassifyLine calls in tests

--- a/spec/document/ast_debug_test.go
+++ b/spec/document/ast_debug_test.go
@@ -3,8 +3,8 @@ package document
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestASTStructure debugs the actual AST structure.

--- a/spec/document/block.go
+++ b/spec/document/block.go
@@ -12,8 +12,8 @@ package document
 import (
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // BlockType identifies the type of block.

--- a/spec/document/deps.go
+++ b/spec/document/deps.go
@@ -5,8 +5,8 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // DependencyAnalyzer extracts variable dependencies from CalcBlocks.

--- a/spec/document/deps_test.go
+++ b/spec/document/deps_test.go
@@ -4,8 +4,8 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestDependencyExtraction validates that we correctly extract dependencies.

--- a/spec/document/detector.go
+++ b/spec/document/detector.go
@@ -3,9 +3,9 @@ package document
 import (
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/features"
-	"github.com/CalcMark/go-calcmark/spec/lexer"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/features"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // Detector analyzes source text and splits it into blocks.

--- a/spec/document/detector_classifier_parity_test.go
+++ b/spec/document/detector_classifier_parity_test.go
@@ -3,7 +3,7 @@ package document
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/classifier"
+	"github.com/CalcMark/go-calcmark/v2/spec/classifier"
 )
 
 // testResolver is a simple IdentifierResolver for parity tests.

--- a/spec/document/detector_test.go
+++ b/spec/document/detector_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
 )
 
 func TestBlockDetection(t *testing.T) {

--- a/spec/document/diagnostic_line_debug_test.go
+++ b/spec/document/diagnostic_line_debug_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestDiagnosticLineNumberDebug helps debug where the error line number comes from.

--- a/spec/document/document.go
+++ b/spec/document/document.go
@@ -3,7 +3,7 @@ package document
 import (
 	"fmt"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/google/uuid"
 	"github.com/shopspring/decimal"
 )

--- a/spec/document/eval_flow_debug_test.go
+++ b/spec/document/eval_flow_debug_test.go
@@ -9,9 +9,9 @@ package document_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/impl/interpreter"
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/semantic"
+	"github.com/CalcMark/go-calcmark/v2/impl/interpreter"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/semantic"
 )
 
 // TestEvalFlowWithTwoBlocks simulates the exact flow that happens when evaluating

--- a/spec/document/eval_result_test.go
+++ b/spec/document/eval_result_test.go
@@ -3,8 +3,8 @@ package document_test
 import (
 	"testing"
 
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestDocumentEvaluationStoresResults verifies document evaluation stores LastValue

--- a/spec/document/frontmatter.go
+++ b/spec/document/frontmatter.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 	"github.com/shopspring/decimal"
 	"gopkg.in/yaml.v3"
 )

--- a/spec/document/fuzz_test.go
+++ b/spec/document/fuzz_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // FuzzNewDocument tests that the document constructor never panics on

--- a/spec/document/globals.go
+++ b/spec/document/globals.go
@@ -4,9 +4,9 @@ package document
 import (
 	"fmt"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/parser"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // ParsedGlobals contains parsed global variable values ready for injection

--- a/spec/document/globals_test.go
+++ b/spec/document/globals_test.go
@@ -3,7 +3,7 @@ package document
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/spec/document/literal_eval.go
+++ b/spec/document/literal_eval.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/spec/document/redefinition_across_blocks_test.go
+++ b/spec/document/redefinition_across_blocks_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestRedefinitionAcrossBlocks tests that redefinition is detected even when

--- a/spec/document/redefinition_diagnostic_test.go
+++ b/spec/document/redefinition_diagnostic_test.go
@@ -3,8 +3,8 @@ package document_test
 import (
 	"testing"
 
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestRedefinitionDiagnosticLineNumber verifies that redefinition diagnostics

--- a/spec/document/semantic_test.go
+++ b/spec/document/semantic_test.go
@@ -3,8 +3,8 @@ package document_test
 import (
 	"testing"
 
-	impldoc "github.com/CalcMark/go-calcmark/impl/document"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	impldoc "github.com/CalcMark/go-calcmark/v2/impl/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // TestVariableRedefinitionRejectedInDocument tests that the document

--- a/spec/features/completion.go
+++ b/spec/features/completion.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 )
 
 // FunctionSuggestions returns function suggestions matching prefix.

--- a/spec/features/registry.go
+++ b/spec/features/registry.go
@@ -9,9 +9,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/spec/identifiers"
-	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/identifiers"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 )
 
 // Category represents a type of CalcMark feature.

--- a/spec/lexer/date_tokenizer_test.go
+++ b/spec/lexer/date_tokenizer_test.go
@@ -3,7 +3,7 @@ package lexer_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
 )
 
 // TestDateKeywordTokenization tests that date keywords are recognized

--- a/spec/lexer/fuzz_test.go
+++ b/spec/lexer/fuzz_test.go
@@ -3,7 +3,7 @@ package lexer_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
 )
 
 // FuzzLexerTokenize tests that the lexer never panics on arbitrary input.

--- a/spec/lexer/lexer.go
+++ b/spec/lexer/lexer.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"unicode"
 
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 )
 
 // BooleanKeywords defines the valid boolean keyword values (case-insensitive).

--- a/spec/lexer/period_keywords_test.go
+++ b/spec/lexer/period_keywords_test.go
@@ -3,7 +3,7 @@ package lexer_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
 )
 
 // U6 — new period-operator keywords for v2.0:

--- a/spec/number_multipliers_test.go
+++ b/spec/number_multipliers_test.go
@@ -3,7 +3,7 @@ package spec_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestNumberMultipliers tests number multiplier suffixes (k, M, B, T) and scientific notation

--- a/spec/parser/adapter.go
+++ b/spec/parser/adapter.go
@@ -1,7 +1,7 @@
 package parser
 
 import (
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // Parse parses CalcMark source code into an AST

--- a/spec/parser/benchmark_test.go
+++ b/spec/parser/benchmark_test.go
@@ -3,7 +3,7 @@ package parser_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // Benchmark simple expression parsing

--- a/spec/parser/capacity_at_test.go
+++ b/spec/parser/capacity_at_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // TestCapacityAtSyntax tests the new "X at Y per UNIT" capacity planning syntax.

--- a/spec/parser/date_test.go
+++ b/spec/parser/date_test.go
@@ -3,7 +3,7 @@ package parser_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestDateParsing tests date literal parsing

--- a/spec/parser/debug_test.go
+++ b/spec/parser/debug_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/lexer"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestTokenization verifies the lexer produces tokens correctly

--- a/spec/parser/end_of_expr_test.go
+++ b/spec/parser/end_of_expr_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // parseFirstStmt extracts the first statement's expression body

--- a/spec/parser/fraction_test.go
+++ b/spec/parser/fraction_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // unwrapExpr extracts the inner node from an Expression wrapper if present.

--- a/spec/parser/function_range_test.go
+++ b/spec/parser/function_range_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // TestAllFunctionCallsHaveRange verifies that every FunctionCall node produced

--- a/spec/parser/fuzz_test.go
+++ b/spec/parser/fuzz_test.go
@@ -3,7 +3,7 @@ package parser_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // FuzzParserParse tests that the parser never panics on arbitrary input.

--- a/spec/parser/golden_test.go
+++ b/spec/parser/golden_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestSpecFiles tests parsing against specification files.

--- a/spec/parser/growth_parser_test.go
+++ b/spec/parser/growth_parser_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // TestGrowthFunctionBasicParsing tests that growth functions parse as standard function calls.

--- a/spec/parser/logical_parse_test.go
+++ b/spec/parser/logical_parse_test.go
@@ -3,7 +3,7 @@ package parser_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestLogicalOperatorParsing tests that logical operators parse correctly

--- a/spec/parser/multiplicative.go
+++ b/spec/parser/multiplicative.go
@@ -3,10 +3,10 @@ package parser
 import (
 	"fmt"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/lexer"
-	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 )
 
 // parseMultiplicative parses multiplication, division, modulus, and unit conversions.

--- a/spec/parser/multiword_units_test.go
+++ b/spec/parser/multiword_units_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // TestMultiWordUnitParsing tests parsing of multi-word units like "nautical mile" and "metric ton"

--- a/spec/parser/napkin_test.go
+++ b/spec/parser/napkin_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // TestNapkinFormat tests the napkin conversion syntax parsing

--- a/spec/parser/natural_syntax_test.go
+++ b/spec/parser/natural_syntax_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 func TestNaturalSyntaxRateFunctions(t *testing.T) {

--- a/spec/parser/nl_functions.go
+++ b/spec/parser/nl_functions.go
@@ -3,8 +3,8 @@ package parser
 import (
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
 )
 
 // parseNaturalLanguageFunction parses natural language function syntax.

--- a/spec/parser/nl_growth_functions.go
+++ b/spec/parser/nl_growth_functions.go
@@ -3,8 +3,8 @@ package parser
 import (
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
 )
 
 // parseNLCompoundFunction parses: compound <principal> by <rate> [per <period> | compounded <freq>] over <duration>

--- a/spec/parser/nl_read_compress_transfer_test.go
+++ b/spec/parser/nl_read_compress_transfer_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // TestNLReadFunction tests "read <quantity> from <storage>" syntax.

--- a/spec/parser/nl_test.go
+++ b/spec/parser/nl_test.go
@@ -3,7 +3,7 @@ package parser_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
 )
 
 // TestNaturalLanguageTokenization checks how "average of" is tokenized

--- a/spec/parser/parser_directive_test.go
+++ b/spec/parser/parser_directive_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 func TestDirectiveRef_AtScale(t *testing.T) {

--- a/spec/parser/parser_function_test.go
+++ b/spec/parser/parser_function_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // TestParseFunctionCallsStandalone tests that standalone function calls parse correctly

--- a/spec/parser/period_literal_test.go
+++ b/spec/parser/period_literal_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // U5 — bare month names parse to a Period-bearing AST.

--- a/spec/parser/primary.go
+++ b/spec/parser/primary.go
@@ -5,10 +5,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/lexer"
-	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 )
 
 // parseExponent parses exponentiation (right-associative).

--- a/spec/parser/quantity_test.go
+++ b/spec/parser/quantity_test.go
@@ -3,7 +3,7 @@ package parser_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestQuantityParsing tests number + unit combinations

--- a/spec/parser/rate_helpers.go
+++ b/spec/parser/rate_helpers.go
@@ -1,8 +1,8 @@
 package parser
 
 import (
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
 )
 
 // parseCapacityValue parses a capacity value for "at ... per UNIT" syntax.

--- a/spec/parser/rate_multiplier_test.go
+++ b/spec/parser/rate_multiplier_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 func TestRateWithMultipliers(t *testing.T) {

--- a/spec/parser/rate_test.go
+++ b/spec/parser/rate_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 func TestRateParsing(t *testing.T) {

--- a/spec/parser/rate_time_units_test.go
+++ b/spec/parser/rate_time_units_test.go
@@ -3,7 +3,7 @@ package parser
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 func TestRateWithTimeUnitSynonyms(t *testing.T) {

--- a/spec/parser/rdparser.go
+++ b/spec/parser/rdparser.go
@@ -4,10 +4,10 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/lexer"
-	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 )
 
 // RecursiveDescentParser implements a recursive descent parser for CalcMark.

--- a/spec/parser/rdparser_test.go
+++ b/spec/parser/rdparser_test.go
@@ -3,7 +3,7 @@ package parser_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestRecursiveDescentBasics tests the basic functionality of the new parser.

--- a/spec/parser/security_test.go
+++ b/spec/parser/security_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestSecurityNestingDepthLimit tests that deeply nested expressions are rejected

--- a/spec/parser/spec_invalid_test.go
+++ b/spec/parser/spec_invalid_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestSpecInvalidFilesActuallyFailParse verifies that spec/invalid files fail to parse.

--- a/spec/semantic/checker.go
+++ b/spec/semantic/checker.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 )
 
 // findSimilarNames returns variable names similar to the given name.

--- a/spec/semantic/checker_test.go
+++ b/spec/semantic/checker_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // TestEnvironment tests the Environment type

--- a/spec/semantic/currency.go
+++ b/spec/semantic/currency.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 	"golang.org/x/text/currency"
 )
 

--- a/spec/semantic/date_validation.go
+++ b/spec/semantic/date_validation.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/lexer"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
 )
 
 // checkDateLiteral validates date literals

--- a/spec/semantic/date_validation_test.go
+++ b/spec/semantic/date_validation_test.go
@@ -3,8 +3,8 @@ package semantic_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/semantic"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/semantic"
 )
 
 // TestDateValidation_February30 tests that February 30 produces an error

--- a/spec/semantic/diagnostics.go
+++ b/spec/semantic/diagnostics.go
@@ -3,7 +3,7 @@ package semantic
 import (
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // Severity represents the severity level of a diagnostic.

--- a/spec/semantic/directive_test.go
+++ b/spec/semantic/directive_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // mockFrontmatter implements FrontmatterInfo for testing.

--- a/spec/semantic/end_of_check.go
+++ b/spec/semantic/end_of_check.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // isPeriodKeyword reports whether the given RelativeDateLiteral

--- a/spec/semantic/end_of_check_test.go
+++ b/spec/semantic/end_of_check_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // runChecker parses + checks the input and returns its diagnostics.

--- a/spec/semantic/environment.go
+++ b/spec/semantic/environment.go
@@ -3,8 +3,8 @@ package semantic
 import (
 	"maps"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/spec/semantic/frontmatter_check.go
+++ b/spec/semantic/frontmatter_check.go
@@ -5,8 +5,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 )
 
 // CheckFrontmatter validates the populated CalcMark fields of a Frontmatter

--- a/spec/semantic/frontmatter_check_test.go
+++ b/spec/semantic/frontmatter_check_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 	"github.com/shopspring/decimal"
 )
 

--- a/spec/semantic/period_operator_checks.go
+++ b/spec/semantic/period_operator_checks.go
@@ -14,7 +14,7 @@ package semantic
 import (
 	"fmt"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // checkLengthOfInner validates the inner expression of `length of

--- a/spec/semantic/redefinition_line_test.go
+++ b/spec/semantic/redefinition_line_test.go
@@ -3,7 +3,7 @@ package semantic
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 )
 
 // TestRedefinitionDiagnosticLineNumber verifies that when a variable is redefined,

--- a/spec/semantic/types.go
+++ b/spec/semantic/types.go
@@ -3,8 +3,8 @@ package semantic
 import (
 	"fmt"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 )
 
 // TypeInfo represents type information for a node.

--- a/spec/semantic/unit_validation_test.go
+++ b/spec/semantic/unit_validation_test.go
@@ -3,8 +3,8 @@ package semantic_test
 import (
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
-	"github.com/CalcMark/go-calcmark/spec/semantic"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/semantic"
 )
 
 // TestUnitCompatibility_IncompatibleUnits tests that incompatible units produce errors

--- a/spec/semantic/units.go
+++ b/spec/semantic/units.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/ast"
+	"github.com/CalcMark/go-calcmark/v2/spec/ast"
 )
 
 // QuantityType represents the type of a physical quantity

--- a/spec/transform/transform.go
+++ b/spec/transform/transform.go
@@ -6,9 +6,9 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/types"
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 )
 
 // Apply applies scale and convert_to transforms to an evaluation result.

--- a/spec/transform/transform_test.go
+++ b/spec/transform/transform_test.go
@@ -4,8 +4,8 @@ import (
 	"math"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/document"
-	"github.com/CalcMark/go-calcmark/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
 	"github.com/shopspring/decimal"
 )
 

--- a/spec/types/param_types.go
+++ b/spec/types/param_types.go
@@ -1,6 +1,6 @@
 package types
 
-import "github.com/CalcMark/go-calcmark/spec/identifiers"
+import "github.com/CalcMark/go-calcmark/v2/spec/identifiers"
 
 // ArgType represents the semantic type expected for a function argument.
 // This defines what kinds of values are valid for each parameter position.

--- a/spec/types/param_types_test.go
+++ b/spec/types/param_types_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/identifiers"
+	"github.com/CalcMark/go-calcmark/v2/spec/identifiers"
 )
 
 func TestCompoundFunctionSpec_HasPeriodParam(t *testing.T) {

--- a/spec/units/canonical_test.go
+++ b/spec/units/canonical_test.go
@@ -4,7 +4,7 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/CalcMark/go-calcmark/spec/units"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
 )
 
 // TestNormalizeUnitName_Comprehensive tests all unit mappings


### PR DESCRIPTION
## Summary

The shipped `v2.0.0-rc.1` was incomplete: per [Go module versioning rules](https://go.dev/ref/mod#major-version-suffixes), any major version ≥ 2 must encode the major version in the module path. `github.com/CalcMark/go-calcmark` without `/v2` would force consumers into `+incompatible` workarounds — the wrong shape for a project that's been on Go modules since v1.0.

This PR is the mechanical fix: module path → `github.com/CalcMark/go-calcmark/v2`, plus the corresponding import sweep across the codebase.

## Changes

- `go.mod`: `module github.com/CalcMark/go-calcmark/v2`
- **657 import lines across 367 `.go` files** rewritten:
  `github.com/CalcMark/go-calcmark/...` → `github.com/CalcMark/go-calcmark/v2/...`
  (654 sub-package imports + 3 bare-package imports of the root `calcmark` package)
- `CHANGELOG.md`: module-path migration is now the first entry under Breaking, with the exact `gofmt -r` + sed recipe under Migration step 5

## Verification

- `go build ./...` clean
- `go test ./...` green across every package
- No behavior changes — pure mechanical sweep

## After merge

1. Delete the existing `v2.0.0-rc.1` tag + GitHub release (the artifacts carry the wrong module path internally).
2. Re-tag `v2.0.0-rc.1` from the post-merge main commit.
3. Push the new tag — GoReleaser fires fresh.
4. Then bump consumers (calcmark-web, calcmark-lark `feat/v2-trial`) to the `/v2` import path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-velocity:pr:147 -->
### Metrics

Opened by `@dvhthomas` (agent-assisted) on 2026-04-30 18:40 UTC. Merged 2026-04-30 18:40 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 8s  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
