### PR TITLE
feat(rate): Rate × Duration and Rate × Rate with time-unit cancellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,35 @@ track every release going forward.
 
 ## [Unreleased]
 
+### Added
+
+- **`Rate × Duration` and `Rate × Rate` arithmetic with time-unit
+  cancellation.** A long-standing gap closed: rates can now be
+  multiplied by durations (and other rates) and the time dimension
+  cancels rather than erroring with "cannot multiply rate and
+  duration". Three slices ship together:
+  1. `Rate × Duration → Currency / Quantity / Number` with
+     auto-conversion of the duration into the rate's `PerUnit`.
+     `$100/hour * 3 weeks` evaluates as `3 weeks → 504 hours`,
+     then `504 × $100 = $50,400`. The result type tracks the
+     rate's numerator: `$/hour` → Currency, `40 hours/week` →
+     Quantity (e.g. `40 hours/week * 3 weeks = 120 hours`),
+     unitless-numerator → Number.
+  2. `Rate` literals can carry a `Duration` numerator. `40 hours
+     / week` now constructs a valid `Rate{Amount: 40 hours,
+     PerUnit: week}` rather than rejecting with "rate amount
+     must be a number, quantity, or currency".
+  3. `Rate × Rate` cancels matching time units across the two
+     rates: `($100/hour) * (40 hours/week) → $4,000/week`. Chained
+     forms like `$100/hour * 40 hours/week * 3 weeks` reduce to
+     `$12,000` (Currency) by left-associative cancellation.
+
+  Out of scope for this round (documented in the test file as
+  follow-ups): `3 weeks * $100/hour` (operator precedence requires
+  parentheses around the rate); `$100/hour * 5 kg` continues to
+  silently coerce via the long-standing `Rate × Quantity` rule
+  rather than erroring on dimensional mismatch.
+
 ## [2.0.0-rc.1] — 2026-04-30
 
 The 2.0 cycle promotes calendar/fiscal periods to a first-class type and

--- a/impl/interpreter/operators.go
+++ b/impl/interpreter/operators.go
@@ -364,6 +364,40 @@ func evalBinaryOperation(left, right types.Type, operator string) (types.Type, e
 				return types.NewNumber(result), nil
 			}
 		}
+		// Rate * Duration → Currency / Quantity / Number, with the
+		// duration converted to the rate's PerUnit before multiplying.
+		// `$100/hour * 3 weeks` runs as: 3 weeks → 504 hours, then
+		// 504 × $100 = $50,400. Result type tracks the rate's
+		// numerator: currency-numerator → Currency, quantity-numerator
+		// → Quantity (e.g. `40 hours/week * 3 weeks` → `120 hours`),
+		// unitless-numerator → Number.
+		if rightDur, ok := right.(*types.Duration); ok && operator == "*" {
+			result, err := rateTimesDuration(leftRate, rightDur)
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		}
+
+		// Rate * Rate → Rate (with one time unit cancelled), or fully
+		// reduced when the result has no remaining denominator. Used by
+		// chained expressions like `$100/hour * 40 hours/week`:
+		//   left.PerUnit=hour cancels right.Amount.Unit=hour
+		//   → Rate{Amount: $4000, PerUnit: week}
+		// We only attempt cancellation against the immediately
+		// adjacent factor (left.PerUnit ↔ right.Amount.Unit). The
+		// commuted case (right.PerUnit ↔ left.Amount.Unit) is handled
+		// symmetrically. Anything else falls through to the existing
+		// per-unit-equality `Rate / Rate → Number` rule above and the
+		// generic error otherwise.
+		if rightRate, ok := right.(*types.Rate); ok && operator == "*" {
+			if result, ok, err := tryRateRateCancellation(leftRate, rightRate); err != nil {
+				return nil, err
+			} else if ok {
+				return result, nil
+			}
+		}
+
 		// Rate * Quantity → Quantity (e.g., "100/second * 10 KB" = "1000 KB")
 		if rightQty, ok := right.(*types.Quantity); ok && operator == "*" {
 			result := leftRate.Amount.Value.Mul(rightQty.Value)

--- a/impl/interpreter/rate_arithmetic.go
+++ b/impl/interpreter/rate_arithmetic.go
@@ -1,0 +1,170 @@
+package interpreter
+
+import (
+	"fmt"
+
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/shopspring/decimal"
+)
+
+// Rate × Duration / Rate × Rate arithmetic with time-unit
+// cancellation. Sits next to the binary-op dispatch in operators.go.
+// The dispatch calls into these helpers when it spots a Rate on the
+// left and a Duration or Rate on the right; everything else stays in
+// operators.go where it always lived.
+
+// rateTimesDuration multiplies a Rate by a Duration. The Duration is
+// converted into the rate's PerUnit (e.g. weeks → hours when the
+// rate is `$/hour`); once both sides agree on the time unit, that
+// dimension cancels and the rate's numerator is the result type.
+//
+// Errors when:
+//   - The rate's PerUnit is not a recognised time unit (so the
+//     conversion has nowhere to land — e.g. `100 req/server * 3
+//     weeks` doesn't compose).
+//   - The Duration's unit can't convert to the PerUnit (defence in
+//     depth — Duration values from the parser already use the
+//     canonical time-unit set, but a future feature could surface a
+//     different unit name).
+func rateTimesDuration(r *types.Rate, d *types.Duration) (types.Type, error) {
+	// PerUnit must be a time unit for the conversion to be meaningful.
+	// `100 req / server * 3 weeks` is a category error; surface it.
+	if !types.IsValidDurationUnit(r.PerUnit) {
+		return nil, fmt.Errorf(
+			"cannot multiply rate (%s) by duration (%s): rate's PerUnit %q is not a time unit",
+			r, d, r.PerUnit)
+	}
+	converted, err := d.Convert(r.PerUnit)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"cannot multiply rate (%s) by duration (%s): %w",
+			r, d, err)
+	}
+	value := r.Amount.Value.Mul(converted.Value)
+	return rateNumeratorAsResult(r, value), nil
+}
+
+// tryRateRateCancellation handles `Rate × Rate` when one rate's
+// numerator unit cancels the other rate's denominator unit. Returns
+// (result, true, nil) on a successful cancellation, (nil, false, nil)
+// when no cancellation applies (caller falls through to other rules),
+// or (nil, false, err) when a cancellation was detected but the unit
+// arithmetic failed (e.g. minute↔hour conversion of an unknown unit).
+//
+// The two cancellable shapes:
+//
+//   left.PerUnit ↔ right.Amount.Unit
+//     (a / b) * (b / c) → (a / c)
+//     example: ($/hour) * (hours/week) → $/week
+//
+//   right.PerUnit ↔ left.Amount.Unit
+//     (b / c) * (a / b) → (a / c)  — commuted
+//     example: (hours/week) * ($/hour) → $/week
+//
+// In each case the cancelled time unit is converted on the
+// quantity-side rate (rightSide for the first, leftSide for the
+// second) so a `... * 60 minutes / hour` left-hand factor still
+// cancels a `... / hour` right-hand denominator.
+//
+// Result kind:
+//   - The remaining numerator is the surviving Amount (currency or
+//     quantity).
+//   - The remaining denominator is the surviving PerUnit. If the
+//     surviving PerUnit is empty (which doesn't happen today — Rate
+//     literals always carry a PerUnit), the result reduces to the
+//     Amount type itself.
+func tryRateRateCancellation(left, right *types.Rate) (types.Type, bool, error) {
+	// Shape 1: left.PerUnit ↔ right.Amount.Unit
+	if isTimeUnit(left.PerUnit) && isTimeUnit(right.Amount.Unit) {
+		// Convert right's Amount value into left.PerUnit so we can
+		// multiply against left's Amount cleanly.
+		factor, err := convertTimeValue(right.Amount.Value, right.Amount.Unit, left.PerUnit)
+		if err != nil {
+			return nil, false, fmt.Errorf(
+				"cannot cancel %q on (%s) * (%s): %w",
+				left.PerUnit, left, right, err)
+		}
+		newAmount := left.Amount.Value.Mul(factor)
+		return &types.Rate{
+			Amount: &types.Quantity{
+				Value: newAmount,
+				Unit:  left.Amount.Unit,
+			},
+			PerUnit: right.PerUnit,
+		}, true, nil
+	}
+
+	// Shape 2: left.Amount.Unit ↔ right.PerUnit (the commuted case).
+	if isTimeUnit(left.Amount.Unit) && isTimeUnit(right.PerUnit) {
+		factor, err := convertTimeValue(left.Amount.Value, left.Amount.Unit, right.PerUnit)
+		if err != nil {
+			return nil, false, fmt.Errorf(
+				"cannot cancel %q on (%s) * (%s): %w",
+				right.PerUnit, left, right, err)
+		}
+		newAmount := factor.Mul(right.Amount.Value)
+		return &types.Rate{
+			Amount: &types.Quantity{
+				Value: newAmount,
+				Unit:  right.Amount.Unit,
+			},
+			PerUnit: left.PerUnit,
+		}, true, nil
+	}
+
+	return nil, false, nil
+}
+
+// rateNumeratorAsResult reconstructs the rate's numerator as a
+// concrete result type after the denominator has been cancelled.
+// Currency-symbol numerator → Currency; non-empty unit → Quantity;
+// empty unit → Number.
+func rateNumeratorAsResult(r *types.Rate, value decimal.Decimal) types.Type {
+	unit := r.Amount.Unit
+	if unit == "" {
+		return types.NewNumber(value)
+	}
+	if _, ok := types.SymbolToCode[unit]; ok {
+		return types.NewCurrency(value, unit)
+	}
+	// ISO codes (USD, EUR, ...) live in the symbol→code map values
+	// AND can appear as Amount.Unit when the user wrote "100 USD/day"
+	// rather than "$100/day". Reverse-lookup catches them.
+	if isCurrencyCode(unit) {
+		return types.NewCurrency(value, unit)
+	}
+	return &types.Quantity{Value: value, Unit: unit}
+}
+
+// isTimeUnit reports whether s is a recognised duration unit.
+// Convenience wrapper to keep the call sites readable.
+func isTimeUnit(s string) bool {
+	return types.IsValidDurationUnit(s)
+}
+
+// convertTimeValue scales a numeric value from one time unit into
+// another. Wraps types.Duration.Convert so callers don't have to
+// build a Duration just to do the arithmetic.
+func convertTimeValue(value decimal.Decimal, fromUnit, toUnit string) (decimal.Decimal, error) {
+	if fromUnit == toUnit {
+		return value, nil
+	}
+	d := &types.Duration{Value: value, Unit: fromUnit}
+	converted, err := d.Convert(toUnit)
+	if err != nil {
+		return decimal.Zero, err
+	}
+	return converted.Value, nil
+}
+
+// isCurrencyCode reports whether s appears as an ISO currency code
+// in the SymbolToCode map (e.g. "USD"). Symbols like "$" are matched
+// directly by membership; codes are matched via the values side.
+func isCurrencyCode(s string) bool {
+	for _, code := range types.SymbolToCode {
+		if code == s {
+			return true
+		}
+	}
+	return false
+}

--- a/impl/interpreter/rate_duration_arithmetic_test.go
+++ b/impl/interpreter/rate_duration_arithmetic_test.go
@@ -1,0 +1,172 @@
+package interpreter
+
+import (
+	"testing"
+
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+)
+
+// Rate × Duration / Rate × Rate arithmetic with time-unit cancellation
+// and conversion. The motivating use case (user 2026-04-30):
+//
+//   cost = $100 / hour
+//   work = 3 weeks
+//   fee  = cost * work          # → $50,400 (3 weeks → 504 hours, × $100)
+//
+// Plus the chained form the user actually preferred:
+//
+//   rate    = $100 / hour
+//   density = 40 hours / week
+//   weeks   = 3 weeks
+//   fee     = rate * density * weeks   # → $12,000
+//
+// And the simplest case that was also failing pre-change:
+//
+//   $100 / hour * 1 hour     # → $100  (units already match — no conversion)
+//
+// All three failed pre-change with "cannot multiply rate (...) and
+// duration (...)". Tests are concrete value assertions to lock the
+// numeric semantics.
+
+func evalSingleResult(t *testing.T, src string) types.Type {
+	t.Helper()
+	interp := NewInterpreter()
+	nodes, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatalf("no result")
+	}
+	return results[len(results)-1]
+}
+
+func TestRateDuration_CurrencyRateMatchingUnit(t *testing.T) {
+	// $100/hour × 1 hour → $100. No conversion needed; just multiply
+	// values and drop the cancelled unit. Currency comes back out
+	// because the rate's amount was a Currency at construction.
+	res := evalSingleResult(t, "$100 / hour * 1 hour\n")
+	cur, ok := res.(*types.Currency)
+	if !ok {
+		t.Fatalf("want *types.Currency, got %T (%v)", res, res)
+	}
+	if got := cur.Value.String(); got != "100" {
+		t.Errorf("value = %s, want 100", got)
+	}
+}
+
+func TestRateDuration_CurrencyRateMatchingUnitFiveHours(t *testing.T) {
+	res := evalSingleResult(t, "$100 / hour * 5 hours\n")
+	cur, ok := res.(*types.Currency)
+	if !ok {
+		t.Fatalf("want *types.Currency, got %T", res)
+	}
+	if got := cur.Value.String(); got != "500" {
+		t.Errorf("value = %s, want 500", got)
+	}
+}
+
+func TestRateDuration_CurrencyRateConvertedFromWeeks(t *testing.T) {
+	// $100/hour × 3 weeks → 3 × 7 × 24 × $100 = $50,400.
+	// The duration's unit (weeks) is converted to the rate's PerUnit
+	// (hours) before multiplication.
+	res := evalSingleResult(t, "$100 / hour * 3 weeks\n")
+	cur, ok := res.(*types.Currency)
+	if !ok {
+		t.Fatalf("want *types.Currency, got %T", res)
+	}
+	if got := cur.Value.String(); got != "50400" {
+		t.Errorf("value = %s, want 50400", got)
+	}
+}
+
+func TestRateDuration_QuantityRateConstruction(t *testing.T) {
+	// `40 hours / week` must construct a valid Rate with a
+	// Duration-shaped numerator. Pre-change: rejected with "rate
+	// amount must be a number, quantity, or currency, got
+	// *types.Duration".
+	res := evalSingleResult(t, "40 hours / week\n")
+	rate, ok := res.(*types.Rate)
+	if !ok {
+		t.Fatalf("want *types.Rate, got %T (%v)", res, res)
+	}
+	if rate.PerUnit != "week" {
+		t.Errorf("PerUnit = %q, want 'week'", rate.PerUnit)
+	}
+	if rate.Amount.Unit != "hour" {
+		t.Errorf("Amount.Unit = %q, want 'hour' (canonical singular)",
+			rate.Amount.Unit)
+	}
+	if got := rate.Amount.Value.String(); got != "40" {
+		t.Errorf("Amount.Value = %s, want 40", got)
+	}
+}
+
+func TestRateDuration_QuantityRateTimesDuration(t *testing.T) {
+	// 40 hours/week × 3 weeks → 120 hours. Time unit on the rate's
+	// numerator stays as the result's unit; the PerUnit cancels with
+	// the multiplier's unit.
+	res := evalSingleResult(t, "40 hours / week * 3 weeks\n")
+	qty, ok := res.(*types.Quantity)
+	if !ok {
+		t.Fatalf("want *types.Quantity, got %T (%v)", res, res)
+	}
+	if qty.Unit != "hour" {
+		t.Errorf("Unit = %q, want 'hour'", qty.Unit)
+	}
+	if got := qty.Value.String(); got != "120" {
+		t.Errorf("Value = %s, want 120", got)
+	}
+}
+
+func TestRateDuration_ChainedCancellation(t *testing.T) {
+	// $100/hour × 40 hours/week × 3 weeks = $12,000.
+	// Left-associative parse: ((rate × density) × weeks).
+	//   ($100/hour × 40 hours/week) → cancel hour → $4,000/week
+	//   ($4,000/week × 3 weeks)     → cancel week → $12,000 (Currency)
+	res := evalSingleResult(t, "$100 / hour * 40 hours / week * 3 weeks\n")
+	cur, ok := res.(*types.Currency)
+	if !ok {
+		t.Fatalf("want *types.Currency, got %T (%v)", res, res)
+	}
+	if got := cur.Value.String(); got != "12000" {
+		t.Errorf("Value = %s, want 12000", got)
+	}
+}
+
+func TestRateDuration_ChainedIntermediateRate(t *testing.T) {
+	// Intermediate: ($100/hour × 40 hours/week) by itself is a Rate
+	// of $4000/week — a useful expression in its own right (annual
+	// salary at 40 hr/wk * 52 weeks).
+	res := evalSingleResult(t, "$100 / hour * 40 hours / week\n")
+	rate, ok := res.(*types.Rate)
+	if !ok {
+		t.Fatalf("want *types.Rate, got %T (%v)", res, res)
+	}
+	if rate.PerUnit != "week" {
+		t.Errorf("PerUnit = %q, want 'week'", rate.PerUnit)
+	}
+	// $4000/week — Amount.Unit is the currency symbol "$" (the
+	// existing convention from rate_eval.go for currency-numerator
+	// rates). The numeric value is what we lock here.
+	if got := rate.Amount.Value.String(); got != "4000" {
+		t.Errorf("Amount.Value = %s, want 4000", got)
+	}
+}
+
+// Out-of-scope for this round (documented for the follow-up):
+//
+//   - `3 weeks * $100 / hour` (duration on the left). Operator
+//     precedence parses this as `((3 weeks) * $100) / hour` rather
+//     than `(3 weeks) * ($100/hour)`, so it requires explicit
+//     parentheses around the rate. The natural form is rate-on-left
+//     and we lock that one above.
+//   - `$100 / hour * 5 kg` should error with a dimensional-mismatch
+//     diagnostic. Today the existing Rate × Quantity branch silently
+//     coerces the result to `500 kg` — pre-existing behavior we
+//     don't tighten in this PR to keep the soak window stable.

--- a/impl/interpreter/rate_eval.go
+++ b/impl/interpreter/rate_eval.go
@@ -34,8 +34,19 @@ func (interp *Interpreter) evalRateLiteral(node *ast.RateLiteral) (types.Type, e
 			Value: v.Value,
 			Unit:  v.Symbol,
 		}
+	case *types.Duration:
+		// Duration as rate amount (e.g., "40 hours / week", "30 minutes
+		// per session"). Stored as Quantity{value, time-unit} so the
+		// Rate × Duration / Rate × Rate arithmetic in operators.go can
+		// detect time-unit cancellation against the PerUnit. The
+		// Duration value is already canonicalised by the parser, so
+		// `40 hours` and `40 hour` both land here as Unit="hour".
+		amountQty = &types.Quantity{
+			Value: v.Value,
+			Unit:  v.Unit,
+		}
 	default:
-		return nil, fmt.Errorf("rate amount must be a number, quantity, or currency, got %T", amountVal)
+		return nil, fmt.Errorf("rate amount must be a number, quantity, currency, or duration, got %T", amountVal)
 	}
 
 	// Create the Rate

--- a/spec/document/literal_eval.go
+++ b/spec/document/literal_eval.go
@@ -199,7 +199,7 @@ func evalRateLiteral(n *ast.RateLiteral) (types.Type, error) {
 		return nil, fmt.Errorf("rate amount evaluation failed: %w", err)
 	}
 
-	// Convert amount to Quantity
+	// Convert amount to Quantity (mirrors impl/interpreter/rate_eval.go)
 	var amountQty *types.Quantity
 	switch v := amountVal.(type) {
 	case *types.Quantity:
@@ -214,8 +214,14 @@ func evalRateLiteral(n *ast.RateLiteral) (types.Type, error) {
 			Value: v.Value,
 			Unit:  v.Symbol,
 		}
+	case *types.Duration:
+		// Duration as rate amount (e.g., "40 hours / week").
+		amountQty = &types.Quantity{
+			Value: v.Value,
+			Unit:  v.Unit,
+		}
 	default:
-		return nil, fmt.Errorf("rate amount must be a number, quantity, or currency, got %T", amountVal)
+		return nil, fmt.Errorf("rate amount must be a number, quantity, currency, or duration, got %T", amountVal)
 	}
 
 	return types.NewRate(amountQty, n.PerUnit), nil


### PR DESCRIPTION
## Summary

Closes a long-standing gap in the language: rates couldn't be multiplied by durations. Pre-change, the user's natural-language formula failed with "cannot multiply rate (100 \$/h) and duration (3 week)":

```calcmark
cost = $100 / hour
work = 3 weeks
fee  = cost * work          # → $50,400 (3 weeks → 504 hours, × $100)
```

Plus the chained form the user actually preferred:

```calcmark
rate    = $100 / hour
density = 40 hours / week
weeks   = 3 weeks
salary  = rate * density * weeks   # → $12,000
```

## Three slices ship together

1. **`Rate × Duration` arithmetic.** Duration is auto-converted into the rate's `PerUnit`, then multiplied. The result type tracks the rate's numerator: `$/hour` → Currency, `40 hours/week` → Quantity (`hours/week × weeks = hours`), unitless-numerator → Number.

2. **Rate literals accept a Duration numerator.** `40 hours / week` was previously rejected with "rate amount must be a number, quantity, or currency"; now stored as `Quantity{Value: 40, Unit: "hour"}` so it composes uniformly with the rest of rate arithmetic.

3. **`Rate × Rate` cancels matching time units.** `(\$/hour) * (hours/week) → \$/week`; chained forms reduce left-associatively to `Currency` when the last factor exhausts the denominator.

## Out of scope (documented in the test file as follow-ups)

- `3 weeks * \$100 / hour` (duration on left). Operator precedence parses as `((3 weeks) * \$100) / hour`; natural form is rate-on-left and we lock that one.
- `\$100/hour * 5 kg` should error on dimensional mismatch. The long-standing `Rate × Quantity` rule silently coerces to `500 kg` — pre-existing behavior we don't tighten here to keep the v2.0 soak window stable. Tracked separately.

## Verification

- `go build ./...` clean
- `go test ./...` green across every package
- 7 new concrete value assertions in `impl/interpreter/rate_duration_arithmetic_test.go`:
  - Matching units (1 hour, 5 hours)
  - Cross-unit conversion (3 weeks → 504 hours)
  - Duration-numerator rate construction
  - `hours/week × weeks → hours` (Quantity result)
  - Chained cancellation through to Currency
  - Intermediate Rate × Rate → Rate result

## After merge

Suggest cutting `v2.0.0-rc.2` so the rate-duration feature lands in the soak window (consumers can validate against rc.2). Single-line bump on calcmark-web PR #66 + calcmark-lark PR #14 from `rc.1` → `rc.2`. CHANGELOG entry already lives under `[Unreleased]` ready to be promoted to `[2.0.0-rc.2]` at tag time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)