### PR TITLE
feat(rate): same-dimension cancellation across all units (v2.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,56 @@ track every release going forward.
 
 ## [Unreleased]
 
+### Added
+
+- **`Rate × Duration`, `Rate × Quantity`, and `Rate × Rate` arithmetic
+  with same-dimension unit cancellation across every category.** A
+  long-standing gap closed: rates can now be multiplied by durations,
+  cancellable quantities, and other rates, and the dimension cancels
+  rather than erroring or silently coercing. The user-facing
+  principle: *CalcMark works when a normal human reading the
+  expression aloud would expect it to work — and refuses with a
+  clear message when they wouldn't.* Concretely:
+  - `cost = $100/hour; work = 3 weeks; fee = cost * work` → `$50,400`
+    (the duration is auto-converted to the rate's `PerUnit`).
+  - `$100/hour * 40 hours/week * 3 weeks` → `$12,000` (chained
+    cancellation through Rate × Rate).
+  - `100 MB/s * 10 seconds` → `1000 MB` (data-rate × time → data).
+  - `60 mph * 2 hours` → `120 miles` (Speed-quantity widens to its
+    underlying rate, then the cancellation engine handles it).
+  - Rate literals can carry a Duration numerator: `40 hours / week`.
+  - Currency identity is preserved through the pipeline: `100 USD/hour
+    × 3 weeks → 50,400 USD` (Code preserved); `€50/hour × 8 hours →
+    €400` (Symbol/Code both populated from `NewCurrency`).
+
+### Changed
+
+- **Retired the long-standing too-permissive `Rate × Quantity →
+  Quantity` rule** (`100/second * 10 KB → 1000 KB`, ignoring the
+  rate's `PerUnit`). It silently produced dimensionally-wrong results.
+  Replaced with same-category cancellation: `100 MB/s * 10 seconds →
+  1000 MB` cancels cleanly, but `100/second * 10 KB` (cross-category)
+  now errors with a friendly message naming both operands and
+  explaining the non-cancellation. Documents that exercised the old
+  rule will see new errors and need updating; the [migration note in
+  rates.cm](testdata/eval/success/features/rates.cm) shows the
+  pattern.
+
+### Internal
+
+- New helpers in `impl/interpreter/rate_arithmetic.go`:
+  `categoryOf(unit)`, `convertWithinCategory(value, from, to)`,
+  `tryRateCancellation(rate, value, unit)`, `cancellable(a, b)`,
+  `coerceSpeedQuantityToRate(qty)`, `rateMismatchError(left, right)`,
+  `categoryPhrase(unit, category)`. Foundation generalised from
+  PR #148's time-only first slice.
+
+## [2.0.0] — 2026-04-30
+
+Promoted from 2.0.0-rc.1; same content. Tagged stable after the soak
+window closed without surfacing issues. See the 2.0.0-rc.1 section
+below for full release notes, breaking changes, and migration guidance.
+
 ## [2.0.0-rc.1] — 2026-04-30
 
 The 2.0 cycle promotes calendar/fiscal periods to a first-class type and
@@ -175,5 +225,6 @@ literals (`Q1`, `FY2027`) read identically; `start of <period>` was
 always the explicit form; the new `between` / `length of` / `days in`
 keywords are net-new vocabulary.
 
-[Unreleased]: https://github.com/CalcMark/go-calcmark/compare/v2.0.0-rc.1...HEAD
+[Unreleased]: https://github.com/CalcMark/go-calcmark/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/CalcMark/go-calcmark/compare/v1.14.0...v2.0.0
 [2.0.0-rc.1]: https://github.com/CalcMark/go-calcmark/compare/v1.14.0...v2.0.0-rc.1

--- a/docs/plans/2026-04-30-001-feat-rate-arithmetic-least-surprise-plan.md
+++ b/docs/plans/2026-04-30-001-feat-rate-arithmetic-least-surprise-plan.md
@@ -1,0 +1,449 @@
+---
+title: "feat: Rate arithmetic — same-dimension cancellation across all units"
+type: feat
+status: active
+date: 2026-04-30
+origin: docs/brainstorms/2026-04-30-rate-arithmetic-least-surprise-requirements.md
+---
+
+# Rate Arithmetic — Same-Dimension Cancellation Across All Units
+
+## Overview
+
+Generalize PR #148's time-only rate-cancellation engine to work across every unit category CalcMark already supports. The user-facing principle (from the origin brainstorm): **"CalcMark works when a normal human reading the expression aloud would expect it to work — and refuses with a clear message when they wouldn't."**
+
+When this lands, `$100/hour × 3 weeks`, `100 cakes/box × 5 boxes`, `60 mph × 2 hours`, and `$100/hour × 40 hours/week × 3 weeks` all produce the obviously-correct answer; `$100/hour × 5 kg` errors with a message naming both operands and explaining the non-cancellation; the long-standing too-permissive `Rate × Quantity → Quantity` rule is replaced by an explicit cancellation check.
+
+Ships as `v2.1.0` post `v2.0.0` stable.
+
+---
+
+## Problem Frame
+
+The Rate type is half-built. Multiplying a rate by a duration or a cancellable quantity errors today (`cannot multiply rate (...) and duration (...)`) or silently coerces (the line-367 `Rate × Quantity` rule that ignores `PerUnit`). Users typing the most natural-language thing they can think of hit a wall.
+
+The shipped `v2.0.0-rc.1` inherits this gap from v1; the rate type doesn't behave the way humans expect across multiple domains (wages, recipes, capacity planning, physical math). PR #148 implemented a time-only first slice and was paused for design. The brainstorm settled the design (Approach B: same-dimension cancellation across all categories, refuse on dimensional mismatch). This plan turns that into U-IDs.
+
+(see origin: `docs/brainstorms/2026-04-30-rate-arithmetic-least-surprise-requirements.md`)
+
+---
+
+## Requirements Trace
+
+- R1. Rate × Duration must compute when the rate's denominator is a time unit (with auto-conversion).
+- R2. Rate × Quantity must compute when the rate's denominator matches the quantity's unit (or converts within the same category).
+- R3. Rate literals accept a Duration numerator (`40 hours / week`).
+- R4. Rate × Rate cancels matching units across the two factors (chained reduction).
+- R5. Rate × Number stays as scaling — no implicit duration coercion (existing behaviour, locked).
+- R6. Inconsistent quantity types must error with a clear message naming both operands and explaining the non-cancellation.
+- R7. Result-type reconstruction preserves currency identity (`100 USD/hour × 3 weeks → 50,400 USD`, not normalised away).
+
+**Origin acceptance examples:**
+- AE1 (covers R1, R7) — `cost = $100/hour; work = 3 weeks; fee = cost * work` → `$50,400`.
+- AE2 (covers R1, R3, R4) — chained `rate * density * weeks` → `$12,000`; intermediate `rate * density` → `$4,000/week`.
+- AE3 (covers R2) — `100 cakes/box × 5 boxes` → `500 cakes`.
+- AE4 (covers R2) — `60 mph × 2 hours` → `120 miles` (existing speed↔rate bridge co-exists with the new engine; see Decision 5).
+- AE5 (covers R6) — `$100/hour × 5 kg` errors, message names both operands + units.
+- AE6 (covers R5) — `$100/hour × 2` → `$200/hour` (Rate, scaled), NOT `$200`.
+
+---
+
+## Scope Boundaries
+
+**In scope:**
+- Same-dimension cancellation across every category in `spec/units/conversion.go` plus time units (which live in `spec/types/duration.go`).
+- Custom units (e.g., `cakes`, `boxes`) cancel by exact-string equality; no conversion.
+- Duration-numerator rates (R3 — already in PR #148, kept).
+- Two-rate cancellation in left-associative chains (R4 — generalised from PR #148's time-only).
+- Currency-symbol-or-ISO-code preservation in reconstructed Currency results (R7).
+- Refusal-with-message for dimensional mismatches (R6) — replaces the existing line-367 silent-coercion rule.
+- Pre-existing widening at `operators.go:107-122` (Rate-on-RIGHT) extended to refuse on dimensional mismatch instead of silently dropping the rate's denominator.
+
+**Deferred to Follow-Up Work:**
+- Operator precedence for `3 weeks × $/hour` (origin scope, deferred). Rate-on-left is canonical.
+- Inverse division `work / rate = duration` (origin scope, deferred).
+- Rate addition with different denominators `$100/hour + $50/day` (origin scope, deferred).
+- `Rate / Rate` cross-PerUnit cancellation with conversion (`100/hour / 50/minute → 0.0333`). The existing same-PerUnit rule at `operators.go:362` uses string-equality; extending to category-equality is a natural follow-up but out of scope here (see Decision 8). Pre-existing `docs/solutions/feature-gaps/rate-type-arithmetic-widening.md` flagged the gap.
+
+**Outside this product's identity:**
+- Full dimensional algebra (no `m²/s²`, no `kg·m/s² → newton` reduction). CalcMark is a calculation notebook, not a CAS.
+- Implicit unit inference (bare numbers stay bare numbers).
+- Currency × Currency arithmetic (refused with R6-style message).
+
+---
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `spec/types/rate.go` — `Rate{Amount *Quantity, PerUnit string}`. Note: `Amount` is always `*Quantity` (currency identity is normalized to symbol on construction). `NormalizeTimeUnit` (line 209) canonicalizes time-unit aliases. `IsTimeUnit(unit)` and `TimeUnitToSeconds(unit)` are public helpers.
+- `spec/types/currency.go` — `SymbolToCode` (line 20), `CodeToSymbol` (line 77), `IsCurrencyCode` (line 85). `NewCurrency(value, symbolOrCode)` already canonicalizes both directions — pass either `"$"` or `"USD"` and it computes the missing field.
+- `spec/types/duration.go` — `Duration.Convert(targetUnit)` (line 100). `IsValidDurationUnit(unit)` (line 60). Time units live here, NOT in `spec/units/conversionRegistry`.
+- `spec/units/conversion.go` — `Convert(value, fromUnit, toUnit) (decimal.Decimal, error)` (line 34). Already enforces "same category required" with the diagnostic `"different categories: %s vs %s"` (lines 49-52). `CategoryForUnit(unitName) string` (line 68) returns canonical category and falls back to `CategoryCustom` for unknown.
+- `impl/interpreter/operators.go:339-372` — Rate-on-the-LEFT dispatch (canonical fix site). Line 367-371 is the silent-coercion `Rate × Quantity` rule this plan replaces.
+- `impl/interpreter/operators.go:107-122` — Rate-on-the-RIGHT widening. Currently strips `.Amount` and recurses; `Number * Rate` works because of this. Plan extends it to refuse on dimensional mismatch (rather than silently drop the denominator).
+- `impl/interpreter/rate_eval.go:33-36` and `spec/document/literal_eval.go:212-216` — twin rate-construction sites. Both reduce `*Currency` to `Quantity{Value, Unit: v.Symbol}` today. Both get the `case *types.Duration:` arm from PR #148.
+- PR #148 (`origin/feat/rate-duration-arithmetic`, commit `25019d9`) — time-only first slice. 5 helpers (`rateTimesDuration`, `tryRateRateCancellation`, `rateNumeratorAsResult`, `isTimeUnit`, `convertTimeValue`, `isCurrencyCode`) live in `impl/interpreter/rate_arithmetic.go`. The 7 value tests in `impl/interpreter/rate_duration_arithmetic_test.go` survive the generalisation rebase unchanged.
+- Test idiom — inline `evalSingleResult(t, src) → types.Type` helper from PR #148's test file. Use this for value assertions; use the table-driven pattern from `rate_eval_test.go` for shape assertions on Rate construction.
+
+### Institutional Learnings
+
+- `docs/solutions/feature-gaps/rate-type-arithmetic-widening.md` — establishes existing dispatch table and the asymmetric-widening rule. Flags two specific gotchas this plan inherits the opportunity to fix: (a) `Rate / Rate` with mismatched PerUnits silently falls to a generic error, and (b) currency rates currently widen to `Quantity` not `Currency` (R7 fixes this for cancellation results).
+- `docs/solutions/logic-errors/adding-new-type-fraction-cross-layer-checklist.md` — operator-dispatch trap pattern: when a type meets Currency/Duration/Rate, normalize and fall through; do not add N×M combinations. The same discipline applies here — the cancellation engine sits at the existing dispatch site, not as a parallel one.
+- `docs/solutions/ui-bugs/display-formatter-overrides-explicit-unit-conversion.md` — `IsExplicit` flag pattern for arithmetic results. **Decision deferred** to implementation: cancellation results will inherit the existing default (no `IsExplicit`), matching PR #148's choice. Revisit if display auto-scaling produces surprising output during execution.
+- `docs/solutions/logic-errors/currency-synonym-symbol-vs-code-comparison.md` — `IsSameCurrency()` over `.Symbol` comparison. Not directly invoked by this plan, but result-construction's reverse-lookup must use `IsCurrencyCode` (which compares Code) rather than `Symbol == "$"` style checks.
+
+### External References
+
+None — local patterns are sufficient. The `units` package converter API is uniform; the `Duration.Convert` API is well-understood; the rate dispatch site is well-mapped. External research would not add value.
+
+---
+
+## Key Technical Decisions
+
+1. **Cancellation predicate is "shared category".** Two units cancel when (a) they're identical strings, OR (b) `categoryOf(left) == categoryOf(right) && categoryOf is convertible`. Identical-string case handles Custom units (`box == box` regardless of plurality, assuming the lexer normalizes); category-match handles cross-unit conversion within a category.
+   *Rationale:* Honors the brainstorm's principle ("would a human say this?") for every domain CalcMark already supports. Custom units cancel only when literally the same string because there's no converter for them.
+
+2. **Time-units live in their own bucket; everything else uses `units.Convert`.** A new `categoryOf(string) string` helper checks `IsValidDurationUnit` first (returns `"time"`), falls through to `units.CategoryForUnit` (returns `Length / Mass / DataSize / Custom / etc.`). A new `convertWithinCategory(value, fromUnit, toUnit) (decimal.Decimal, error)` helper dispatches `time → Duration.Convert`, everything else → `units.Convert`.
+   *Rationale:* The two converter packages aren't unified today and unifying them is a bigger change with no other motivation. A 30-line shim is cheaper.
+
+3. **Currency identity preservation via reverse-lookup at result time** (user choice from planning).
+   At result construction (`rateNumeratorAsResult`), if the surviving Amount.Unit string is in `SymbolToCode` keys OR satisfies `IsCurrencyCode`, return `NewCurrency(value, unit)` (which canonicalizes Symbol vs Code automatically). Otherwise return Quantity. No data-shape change to `Rate`.
+   *Rationale:* Simpler than threading `Currency.Code` through `Rate.Amount`; matches PR #148's existing `rateNumeratorAsResult` shape; avoids touching every test that builds rates manually.
+
+4. **The line-367 silent-coercion rule is replaced, not preserved.** PR #148 left it untouched as a soak-window safety net; this plan removes it. Any `Rate × Quantity` that doesn't cancel via the new engine errors with R6's contract.
+   *Rationale:* Brainstorm Success Criteria 3 explicitly retires this rule. Soak window for v2.1 is the right place to land the cleanup. (PR #148's parked draft remains discoverable but is replaced, not merged-as-is.)
+
+5. **Speed↔rate bridge needs explicit invocation in `evalBinaryOperation` for AE4.** Doc review caught the original assumption: `coerceSpeedToRate` exists in `impl/interpreter/speed_bridge.go` but is only invoked by `unit_conversion_eval.go:41` (the `as`-conversion path), NOT by binary-op dispatch. So `60 mph × 2 hours` (AE4) does NOT work today — `Quantity{60, "mph"} × Duration{2, "hour"}` falls through with no handler.
+   *Plan resolution:* U6 adds a left-side Quantity-coercion branch that recognises Speed-shaped units, calls `coerceSpeedToRate`, and re-dispatches as `Rate × Duration` through the engine from U2. Mirrors the existing right-side rate-widening at `operators.go:107-122` (which the plan already extends in U4).
+   *Rationale:* Reuses existing speed-bridge code rather than building parallel logic. Keeps AE4 in scope as the brainstorm intended without introducing general `Quantity × Quantity` dimensional analysis (which is explicitly out-of-identity).
+
+6. **Refusal-message contract is substring-match, not verbatim** (resolves origin G5).
+   Tests assert that the error contains:
+   - The left rate's display string (or its component units)
+   - The right operand's display string (or its component units)
+   - At minimum one of: a category name (`mass`, `time`), the offending unit name (`kg`, `hour`), or the phrase `cancel`.
+   Tests do NOT assert the exact verbatim format of the message.
+   *Rationale:* Locks the user-facing contract without freezing wording. Implementer can refine phrasing without breaking tests.
+
+7. **PR #148 disposition: rebase-and-extend, not close-and-replace.** The 5 helpers are correctly named and shaped. Generalisation is mechanical: `isTimeUnit` becomes `categoryOf` equality; `convertTimeValue` becomes `convertWithinCategory`. The 7 value tests survive unchanged. New tests added for AE3/AE4/AE5/AE6.
+
+8. **`Rate / Rate` cross-PerUnit cancellation is deferred.** The existing rule at `operators.go:362` (`Rate / Rate` same-PerUnit → Number ratio) uses string-equality on `PerUnit`. Extending it to category-equality with conversion (`100/hour / 50/minute → 0.0333` after converting minute → hour) is a natural extension of the principle but is NOT in scope for this plan. The brainstorm's R1-R7 cover multiplication forms; division-with-cancellation is a follow-up. Documented in Scope Boundaries as `Deferred to Follow-Up Work`.
+   *Rationale:* Keeps the plan tight. The `learnings/rate-type-arithmetic-widening.md` doc flagged this as a known gotcha but the brainstorm didn't pick it up; this plan honours the brainstorm's scope.
+
+---
+
+## Open Questions
+
+### Resolved During Planning
+
+- **G1 (Duration-numerator rate × non-time operand).** Resolved: Duration-numerator rates behave identically to Quantity-numerator rates for type reconstruction. `40 hours/week × 5` (R5 scaling) → `200 hours/week` (Rate). Same dispatch path; no special case needed because the Quantity stored at construction time already encodes the time-unit numerator as a unit string.
+- **G2 (currency code preservation through chains).** Resolved by Decision 3: the reverse-lookup happens at every result-construction call site, so a chained `100 USD/hour × 40 hours/week × 3 weeks` flows USD-symboled Quantities through every intermediate, then reconstructs as Currency at the end via `NewCurrency(value, "USD")`.
+- **G3 (unknown-symbol currency-numerator detection).** Resolved by Decision 3: only units in `SymbolToCode` keys or passing `IsCurrencyCode` reconstruct as Currency; everything else falls through to Quantity. A custom currency-shaped unit not registered in SymbolToCode produces a Quantity result, not a runtime panic.
+- **G5 (error-message format contract).** Resolved by Decision 6: substring-match contract, not verbatim.
+- **G9 (speed-bridge coexistence).** Resolved by Decision 5: existing speed↔rate bridge stays; cancellation engine sees the post-coerced Rate × Duration form. Test asserts AE4 still works.
+
+### Deferred to Implementation
+
+- **G4 (zero/negative/fractional duration).** Decision will fall out of `decimal.Decimal` arithmetic naturally — zero gives zero, negative gives negative, fractional works. If the implementer hits a surprising case, surface it in PR review rather than predicting it here.
+- **G6 (refusal-message readability for nested operands).** Use `formatTypeForError` for operand display — already handles Rate as `rate (...)`. If the message becomes unreadable in chained-failure cases, adjust during implementation; not a planning-time decision.
+- **G7 (empty PerUnit on a Rate).** Refuse with a "rate has no denominator unit" message. Concretely: `categoryOf("")` returns `""`; the cancellation predicate fails; R6 refusal fires. Trust the dispatch.
+- **G8 (unknown time-unit like `fortnight`).** `Duration.Convert` errors with `"invalid duration unit"`; the error wraps cleanly in the R6 message. No special handling needed.
+- **G10 (currency × currency message).** Same R6 contract — name both operands, explain non-cancellation, substring-match test. Implementer chooses wording only; this is NOT a structurally distinct error path. The brainstorm scope says "Currency × Currency arithmetic — refuse always" (Outside this product's identity); R6's contract applies.
+- **G11 (rate-on-right deferred form).** No new tests required — the existing parse-precedence behavior continues. Document the workaround in the user guide as part of U5 if the implementer notices a natural place.
+- **`IsExplicit` flag policy on cancellation results.** Inherit PR #148's choice (no flag). Revisit if display auto-scaling produces surprising output during execution.
+
+---
+
+## Implementation Units
+
+- U1. **Generic category and conversion helpers**
+
+**Goal:** Replace PR #148's `isTimeUnit` + `convertTimeValue` with category-aware versions that work across time, units-package categories, and Custom (exact-string) units. Foundation for U2/U3/U4/U6.
+
+**Requirements:** R1, R2, R3, R4 (foundation — every cancellation path uses these helpers)
+
+**Dependencies:** None.
+
+**Files:**
+- Modify: `impl/interpreter/rate_arithmetic.go` (rename and rewrite `isTimeUnit` and `convertTimeValue`; preserve helper-list shape)
+- Test: `impl/interpreter/rate_arithmetic_test.go` (new — tests the helpers in isolation)
+
+**Approach:**
+- New helper `categoryOf(unit string) string`. Returns `"time"` if `types.IsValidDurationUnit(unit)`. Otherwise returns `units.CategoryForUnit(unit)` (which gives `"Length"` / `"Mass"` / `"DataSize"` / `"Custom"` / etc.). Empty input returns `""`.
+- New helper `convertWithinCategory(value decimal.Decimal, fromUnit, toUnit string) (decimal.Decimal, error)`. If `fromUnit == toUnit`, return `value` unchanged. Else dispatch by category: time uses `Duration.Convert`; everything else uses `units.Convert`. Custom-category units only succeed when `fromUnit == toUnit`; otherwise return an error naming both units.
+- Keep `isCurrencyCode` (currency reconstruction support — used in U3) untouched; it's correctly named and category-orthogonal.
+
+**Patterns to follow:**
+- PR #148's `rate_arithmetic.go` shape — small helpers with focused responsibilities.
+- `spec/units/conversion.go:34-66` — error message format for cross-category attempts.
+
+**Test scenarios:**
+- *Happy path:* `categoryOf("hour")` → `"time"`. `categoryOf("kg")` → `"Mass"`. `categoryOf("box")` → `"Custom"`. `categoryOf("")` → `""`.
+- *Happy path:* `convertWithinCategory(3, "week", "hour")` → `504, nil`. `convertWithinCategory(5, "kg", "g")` → `5000, nil`.
+- *Edge case:* `convertWithinCategory(5, "box", "box")` → `5, nil` (same-string Custom).
+- *Error path:* `convertWithinCategory(5, "box", "boxes")` → error if lexer doesn't normalize plurals to identical strings — verify behavior, document expectation.
+- *Error path:* `convertWithinCategory(5, "kg", "hour")` → error mentioning both units (cross-category).
+- *Error path:* `convertWithinCategory(5, "fortnight", "hour")` → error from `Duration.Convert` propagates cleanly.
+
+**Verification:**
+- The two helpers replace `isTimeUnit` and `convertTimeValue` at every call site in `rate_arithmetic.go`.
+- All helper tests pass.
+- `go build ./...` clean.
+
+---
+
+- U2. **Generalize the cancellation engine + retire the line-367 silent-coercion rule**
+
+**Goal:** Make `Rate × Duration`, `Rate × Quantity`, and `Rate × Rate` use the same cancellation engine driven by U1's `categoryOf` predicate. Replace `operators.go:367-371`'s permissive `Rate × Quantity → Quantity` rule with the new engine + R6 refusal arm.
+
+**Requirements:** R1, R2, R3, R4, R6
+
+**Dependencies:** U1
+
+**Files:**
+- Modify: `impl/interpreter/rate_arithmetic.go` (rewrite `tryRateRateCancellation` to use category equality; rewrite `rateTimesDuration` to call `convertWithinCategory`; add `rateTimesQuantity` for the cross-Quantity case)
+- Modify: `impl/interpreter/operators.go` (remove the line-367 silent-coercion branch; the new dispatch routes Rate × {Duration, Quantity, Rate} through the engine and falls through to R6 refusal in U4)
+- Test: `impl/interpreter/rate_duration_arithmetic_test.go` (extend with AE3 cakes/box test, AE4 mph test for non-regression, R5 unchanged-scaling test)
+
+**Approach:**
+- Predicate: cancellation applies when `left.SomeUnit == right.SomeUnit` OR `categoryOf(left.SomeUnit) == categoryOf(right.SomeUnit)` AND that category supports conversion.
+- For `Rate × Duration`: cancel `rate.PerUnit ↔ duration.Unit`. Multiply `rate.Amount.Value × convertedDuration.Value`. Reconstruct via `rateNumeratorAsResult` (untouched in this unit; U3 extends it).
+- For `Rate × Quantity`: cancel `rate.PerUnit ↔ quantity.Unit`. Same multiply + reconstruct path.
+- For `Rate × Rate`: two cancellation shapes from PR #148's `tryRateRateCancellation` (Shape 1: `left.PerUnit ↔ right.Amount.Unit`; Shape 2: `left.Amount.Unit ↔ right.PerUnit`). Both predicates generalize to `categoryOf` equality. Shape 1 produces `Rate{Amount: left.Amount × converted_right.Amount, PerUnit: right.PerUnit}` (cancellation reduces left's denominator); Shape 2 mirrors.
+- Sequencing inside `evalBinaryOperation`'s rate-on-left branch:
+  1. Rate × Number → Rate (existing, scale)
+  2. Rate / Number → Rate (existing, scale)
+  3. Rate / Rate same-PerUnit → Number (existing, ratio — left untouched per Decision 8)
+  4. **Rate × Duration → cancellation engine** (NEW, generalized)
+  5. **Rate × Rate → cancellation engine** (NEW, generalized)
+  6. **Rate × Quantity → cancellation engine** (REPLACES old line-367 silent rule)
+  7. Falls through to R6 refusal (U4 wires the message)
+- **Predicate-matched-but-conversion-failed routing.** When the cancellation predicate matches (`categoryOf(left) == categoryOf(right)`) but `convertWithinCategory` returns an error (e.g., `cake × box` — both `Custom` but not equal strings), the engine treats this as a refusal case, NOT a generic error leak. The engine returns `(nil, false, nil)` (predicate didn't actually cancel) so dispatch falls through to U4's R6 contract message naming both operands. The convert-error string is dropped; the user-facing message is R6's friendly form. This avoids leaking internal `"cannot convert cake to box"` strings as user-facing errors.
+
+**Execution note:** Test-first for the new acceptance examples (AE3, AE4, AE5, AE6). Each test names a specific input, action, and expected outcome.
+
+**Patterns to follow:**
+- PR #148's `tryRateRateCancellation` structure — the two-shape cancellation pattern is correctly factored.
+- `spec/units/conversion.go` — error wrapping idiom (`fmt.Errorf("...: %w", err)`).
+
+**Test scenarios:**
+- *Happy path — Covers AE3.* `100 cakes / box * 5 boxes` → `Quantity{500, "cake"}` (or `"cakes"` depending on lexer normalization; assert via Value.String() and Unit field).
+- *Happy path — Covers AE6.* `$100 / hour * 2` → `Rate{Amount: $200, PerUnit: hour}` (NOT a currency `$200`). Existing PR #148 test for this case stays.
+- *Happy path:* `$100 / hour * 1 hour` → `$100` (Currency). Existing PR #148 test.
+- *Happy path:* `$100 / hour * 3 weeks` → `$50,400` (Currency). Existing PR #148 test, verifies time-conversion path through `convertWithinCategory`.
+- *Edge case:* `100 cakes/box * 0 boxes` → `0 cakes`. Numeric edges fall out of decimal arithmetic.
+- *Integration:* `$100/hour * 40 hours/week * 3 weeks` → `$12,000` (Currency, chained reduction). Existing PR #148 test stays; verifies left-associative reduction through the generalized engine.
+- *Error path — pre-condition for U4.* `$100 / hour * 5 kg` → returns no result and no panic from this unit; the operators.go fall-through routes to U4's refusal arm. Validate by asserting an error fires (exact message contract is U4's test scenarios).
+
+**Verification:**
+- All 7 PR #148 tests still pass.
+- New AE3/AE4/AE5-pre/AE6 tests pass.
+- `operators.go:367-371` silent-coercion rule is gone (grep returns no match).
+- `go test ./...` clean.
+
+---
+
+- U3. **Currency identity preservation in result construction**
+
+**Goal:** When the cancellation engine produces a Currency-shaped result, return a `*types.Currency` with both Symbol and Code populated correctly — not a `*types.Quantity` with the symbol stuck in `Unit`.
+
+**Requirements:** R7
+
+**Dependencies:** U2
+
+**Files:**
+- Modify: `impl/interpreter/rate_arithmetic.go` (`rateNumeratorAsResult` — extend with `IsCurrencyCode` check)
+- Test: `impl/interpreter/rate_duration_arithmetic_test.go` (extend with R7 currency-preservation tests)
+
+**Approach:**
+- `rateNumeratorAsResult(rate, value)` already checks `unit ∈ SymbolToCode keys` and returns `Currency`. Extend to also call `types.IsCurrencyCode(unit)` (which checks the Code-side of the map). If either matches, call `types.NewCurrency(value, unit)` — `NewCurrency` already canonicalizes Symbol vs Code (line 30-44 in `currency.go`).
+- Empty unit → Number (existing behavior, locked).
+- Otherwise → Quantity (existing behavior).
+- No data-shape change to `Rate`. Decision 3 in this plan.
+
+**Patterns to follow:**
+- `spec/types/currency.go:30-44` — `NewCurrency` is the canonical constructor; trust its bidirectional logic.
+- `docs/solutions/logic-errors/currency-synonym-symbol-vs-code-comparison.md` — never compare `.Symbol` directly; use `IsCurrencyCode` and `IsSameCurrency`.
+
+**Test scenarios:**
+- *Happy path — Covers AE1.* `cost = $100/hour; work = 3 weeks; fee = cost * work`. Result is `*types.Currency`. `result.Symbol == "$"`, `result.Code == "USD"`, `result.Value.String() == "50400"`.
+- *Happy path:* `100 USD / hour * 3 weeks` → `*types.Currency`. `result.Symbol == "USD"`, `result.Code == "USD"`, `result.Value.String() == "50400"`. (User wrote ISO code; preserves it.)
+- *Happy path:* `€50 / hour * 8 hours` → `*types.Currency`. `result.Symbol == "€"`, `result.Code == "EUR"`, `result.Value.String() == "400"`.
+- *Happy path — Covers AE2 chain.* `100 USD/hour * 40 hours/week * 3 weeks` → `*types.Currency` with Code `"USD"`, value `"12000"`. Tests USD survives every intermediate.
+- *Edge case:* Quantity-numerator rate (`40 hours/week × 3 weeks`) → `*types.Quantity` with `Unit == "hour"`, NOT Currency. Confirms the IsCurrencyCode branch doesn't false-positive on non-currency units.
+- *Edge case:* unitless-numerator rate (`60 / second × 5 seconds`) → `*types.Number` with value `300`. Empty-unit branch.
+
+**Verification:**
+- Every Currency-rate-times-cancellable acceptance case returns `*types.Currency`, not `*types.Quantity`.
+- `result.Symbol` matches the user's typed form ($, €, USD, EUR, etc.).
+- `result.Code` is correctly canonicalized in every case.
+- Existing rate tests in `rate_eval_test.go` still pass (no regression on rate construction).
+
+---
+
+- U4. **R6 refusal contract — explicit dimensional-mismatch errors**
+
+**Goal:** When the cancellation engine doesn't fire, replace the old silent-coercion / generic-error fall-through with an explicit refusal that names both operands and explains the non-cancellation. Locks the substring contract from Decision 6.
+
+**Requirements:** R6
+
+**Dependencies:** U2 (provides the dispatch slot where U4's refusal lives)
+
+**Files:**
+- Modify: `impl/interpreter/rate_arithmetic.go` (new helper `rateMismatchError(left, right, reason) error`)
+- Modify: `impl/interpreter/operators.go` (Rate-on-the-LEFT fall-through emits R6 refusal; Rate-on-the-RIGHT widening at lines 107-122 also gates on cancellability — silent-drop becomes refusal when the right rate's PerUnit doesn't cancel anything on the left)
+- Test: `impl/interpreter/rate_duration_arithmetic_test.go` (refusal tests with substring assertions)
+
+**Approach:**
+- New helper `rateMismatchError(left *types.Rate, right types.Type, leftCat, rightCat string) error`. Returns an error message that includes:
+  - `formatTypeForError(left)` — gives `"rate (100 $/h)"` or similar (existing utility).
+  - `formatTypeForError(right)` — gives `"duration (5 kg)"` etc.
+  - Both unit strings explicitly.
+  - The category names when known (`"kg is a mass unit"`, `"hour is a time unit"`).
+  - The phrase `"cancel"` so the test substring contract has an anchor.
+- Special-case currency × currency: a different template explaining that multiplying two currencies has no meaning.
+- Special-case empty PerUnit on a rate: a "rate has no denominator unit" message.
+- Wire into operators.go at two sites:
+  1. Rate-on-left fall-through (after U2's branches don't match).
+  2. Rate-on-right widening (lines 107-122): if `left` isn't a number/quantity-that-cancels, refuse instead of silent-drop.
+
+**Patterns to follow:**
+- `impl/interpreter/operators.go:894-899` — existing `cannot multiply X by Y directly` template style.
+- `formatTypeForError` (line ~916) — operand display utility.
+
+**Test scenarios:**
+- *Error path — Covers AE5.* `$100 / hour * 5 kg` → error. Substring contract: error contains `"5 kg"` (or `"kg"`), contains `"hour"` (or `"time"`), contains `"cancel"`. Does NOT match the verbatim message format (allows refinement).
+- *Error path:* `5 kg * 3 seconds` → error. Substring contract: contains both `"kg"` and `"seconds"` (or both unit names + categories).
+- *Error path:* `$100 * $50` → error mentioning both currencies; uses the currency-×-currency template, not the cancellation template.
+- *Error path:* `$100 / hour * 100 cakes` → error (Custom unit doesn't share category with time). Substring contract: `"cakes"` and `"hour"` mentioned.
+- *Edge case:* Empty PerUnit (constructed in test directly, not via parser). Error message names "rate has no denominator unit" or equivalent.
+- *Integration:* In a chained expression `$/hour * hours/week * 5 kg`, the first multiplication succeeds (gives `$/week`), the second fails. Error message names the intermediate `$/week` rate as the left operand (verifies `formatTypeForError` handles intermediate rates).
+
+**Verification:**
+- Every refusal test asserts via `strings.Contains` on the error message, not equality.
+- No silent coercion remains. Grep `impl/interpreter/operators.go` for the old line-367 pattern returns nothing.
+- `go test ./...` clean.
+- Documents at `docs/solutions/feature-gaps/rate-type-arithmetic-widening.md` flag (Rate/Rate mismatched-PerUnit silent-error) is now closed by U2+U4 — can be updated in U5 if motivated.
+
+---
+
+- U5. **Documentation, registry, and regression goldens**
+
+**Goal:** Update user-facing documentation to describe the new behavior, register the cancellation feature in the features registry, refresh the rates regression golden file, and stage the CHANGELOG entry for v2.1.
+
+**Requirements:** Cross-cutting (every R is touched).
+
+**Dependencies:** U2, U3, U4, U6 (all behavioral changes must exist before docs describe them).
+
+**Files:**
+- Modify: `CHANGELOG.md` — replace the current `[Unreleased]` rate-arithmetic stub (which describes time-only) with the generalized story matching this plan's scope.
+- Modify: `spec/features/registry.go` — add or update the rate-arithmetic feature entry. Description names cross-domain cancellation, not just time. *(Mechanical: this is the registry that drives LSP completion + `cm features` output; unregistered feature → no completion hint for users typing `Rate × Duration`. Not origin-mandated, but operationally required for the feature to be discoverable.)*
+- Modify: `site/content/docs/language-reference.md` (if it discusses Rate × Quantity behavior — verify in implementation; update if so).
+- Modify: `site/content/docs/user-guide/units.md` (or equivalent — verify location during implementation; add a worked example for AE1, AE3, AE5).
+- Modify: `testdata/eval/success/features/rates.cm` — add new test cases covering AE1-AE6. This is a regression golden; run `go test` to update expected output.
+
+**Approach:**
+- The CHANGELOG entry currently in `[Unreleased]` is a draft from PR #148's branch. Update its phrasing to match this plan's scope (cross-domain cancellation, R6 refusal contract, R7 currency identity).
+- Features-registry entry: locate the existing rate-related entry (if any) and add a new one or extend it. Description should mention cancellation across categories.
+- Regression golden in `testdata/eval/success/features/rates.cm`: append new cases. Each case is a calc line that exercises one acceptance example. Run the relevant test (likely `go test ./impl/document/...` or similar) to regenerate the expected output file if pattern-matching used.
+
+**Test scenarios:**
+- Test expectation: none — pure documentation and registration. The implementation work in U2/U3/U4 carries the behavioral test coverage. CHANGELOG and docs-site changes don't have unit tests; the docgen test verifies feature-registry shape after entries are added.
+
+**Verification:**
+- `go test ./spec/features/...` passes (registry shape stays valid).
+- `go test ./impl/document/...` passes (regression goldens still match).
+- `task check` (or equivalent) passes — confirms docs build and lint.
+- A user reading `CHANGELOG.md` understands what shipped without needing to read the brainstorm doc.
+
+---
+
+- U6. **Quantity-with-speed-unit coercion enables `mph × hours` (AE4)**
+
+**Goal:** Make `60 mph × 2 hours → 120 miles` work by coercing the left-side Speed-Quantity to a Rate before the cancellation engine sees the operands. Mirrors the existing right-side rate-widening at `operators.go:107-122`.
+
+**Requirements:** R2 (specifically AE4 — the cross-domain physical-math case the brainstorm called out as canonical).
+
+**Dependencies:** U2 (the Rate × Duration cancellation engine must exist for the coerced form to land somewhere).
+
+**Files:**
+- Modify: `impl/interpreter/operators.go` (add a left-side widening branch ahead of the rate-on-left dispatch — specifically: when `left` is `*types.Quantity` with a Speed unit and `right` is `*types.Duration` and `operator == "*"`, call `coerceSpeedToRate(left)` and recurse with the coerced Rate as the new left)
+- Test: `impl/interpreter/rate_duration_arithmetic_test.go` (add the AE4 test that this unit unblocks)
+
+**Approach:**
+- Use the existing `coerceSpeedToRate` function in `impl/interpreter/speed_bridge.go`. It already handles `mph → miles/hour`, `kph → km/hour`, `mps → m/s`, `knots → nautical-miles/hour`. No new conversion logic.
+- Branch placement: BEFORE the existing rate-on-left dispatch (so the coerced form flows through U2's engine). Likely between operators.go's existing widening blocks (around line 122-156 area).
+- Symmetric coercion for `Duration × Quantity-with-speed-unit` is NOT in scope (operator precedence + existing widening handles `Number × Rate` widening; speed-quantity-on-right would need a parallel branch). The brainstorm puts rate-on-left as canonical; AE4 is `60 mph × 2 hours` (rate-shaped on left). Leave the commuted form as a follow-up if a real use case appears.
+- Out of scope: any other `Quantity × Duration` cancellation. Only Speed-shaped Quantities widen here. `5 kg × 3 hours` does not widen (no compound-rate interpretation); falls through to U4's R6 refusal.
+
+**Patterns to follow:**
+- `impl/interpreter/operators.go:107-122` — existing right-side widening is the structural twin.
+- `impl/interpreter/speed_bridge.go` — `coerceSpeedToRate` signature and behavior.
+
+**Test scenarios:**
+- *Happy path — Covers AE4.* `60 mph * 2 hours` → `Quantity{120, "mile"}` (or `"miles"` per lexer normalization). Assert via Value.String() and Unit field.
+- *Happy path:* `100 kph * 30 minutes` → `Quantity{50, "km"}` (after coercion: `100 km/hour * 30 minutes` → cancel `hour` ↔ `minutes` via U2 → `50 km`).
+- *Edge case:* `5 kg * 3 hours` → ERROR (kg is not a Speed unit; coercion doesn't fire; falls through to U4's R6 refusal). Confirms U6 is narrow.
+- *Edge case:* `60 mph * 2 hours in km` → `120 miles in km` evaluates correctly through both U6's coercion and the existing `as`-conversion path.
+- *Integration:* Verify the existing `60 mph in km/hour` (the speed-bridge's primary use case) still works — no regression on the `as` path.
+
+**Verification:**
+- AE4 test passes.
+- The existing `testdata/eval/success/features/speed_rate_bridge.cm` continues to pass (no regression on the `as` path).
+- `go test ./...` clean.
+
+---
+
+## System-Wide Impact
+
+- **Interaction graph:** `evalBinaryOperation` is the single dispatch site. Three branches are touched: Rate-on-left dispatch (`operators.go:339-372`, replaced by U2's engine + U4's refusal), Rate-on-right widening (`operators.go:107-122`, gated by U4 to refuse on dimensional mismatch), and a new left-side Quantity-with-Speed-unit widening (added by U6, ahead of the rate branches). No callbacks, observers, or middleware involved.
+- **Error propagation:** R6 refusals bubble up through the existing diagnostic path. No new error types; messages compose into the standard "evaluation error" wrapper.
+- **State lifecycle risks:** None. Pure functions throughout; no persistence, no caching.
+- **API surface parity:** `impl/interpreter/rate_eval.go` (the runtime evaluator) and `spec/document/literal_eval.go` (the frontmatter-globals lite evaluator) both have rate-construction switches. Both already get the `case *types.Duration:` arm from PR #148. R3 is verified twice.
+- **Integration coverage:** AE2's chained reduction (`rate * density * weeks`) is the integration scenario par excellence — it touches Rate × Rate (intermediate) and Rate × Duration (final) in a single expression. AE5 + the chained-failure test in U4 verify error propagation through intermediates.
+- **Unchanged invariants:**
+  - The `Rate` struct shape (`{Amount *Quantity, PerUnit string}`) is NOT changed. Decision 3 (reverse-lookup) avoids the data-shape change.
+  - PR #148's helper-list shape in `rate_arithmetic.go` is preserved (rebase, not rewrite).
+  - The speed↔rate bridge in operators.go is untouched (Decision 5).
+  - `Rate × Number → Rate` (R5 scaling) is locked unchanged.
+  - The 7 existing PR #148 value tests survive unchanged.
+
+---
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| Custom-unit cancellation depends on the lexer normalizing plurals (`box` vs `boxes`). If it doesn't, AE3 would fail with a "cannot convert box to boxes" error. | U1's test scenarios explicitly verify this assumption. If the lexer doesn't normalize, surface in PR review and either (a) add normalization in `categoryOf` for Custom units, or (b) document the limitation. |
+| Replacing line-367's permissive `Rate × Quantity` rule may break tests outside the rate-arithmetic suite that depended on the silent coercion. | U2's test sweep runs `go test ./...` — any regression surfaces immediately. The pre-existing learnings doc flags the rule as a gotcha; production callers depending on it are unlikely. |
+| Currency-code preservation through chains assumes every intermediate Rate's Amount.Unit carries the user's typed Symbol/Code string. Verified by reading PR #148's `rate_eval.go` change but worth re-confirming during U2 implementation. | U3's test scenarios include both `$` and `USD` chains; if either drops the identity, the test fails. |
+| The pre-existing Rate-on-RIGHT widening at operators.go:107-122 silently drops the rate's denominator. U4 changes this to a refusal. May break surprising existing tests. | Run `go test ./...` after U4. If a legitimate use case surfaces (e.g., `Number × Rate` for scaling), keep the widening for that case and refuse only when the right Rate's denominator can't cancel anything. |
+| `IsExplicit` flag policy on cancellation results is deferred. Display auto-scaling could produce surprising output (e.g., `120 hours` displayed as `5 days`). | Implementer flags this as a follow-up if it surfaces. Not blocking for v2.1. |
+
+---
+
+## Documentation / Operational Notes
+
+- v2.1.0 release notes (CHANGELOG entry) mention the breaking change from line-367's silent coercion to refusal. Users with documents that exercised the old `Rate × Quantity` silent rule will see new errors. Migration: if the user wrote `100 X/server * 5 servers` expecting it to compose, this still works (server unit cancellation). If they wrote `$/hour * 5 kg` expecting `500 kg`, they'll now see a clear error directing them to fix the expression.
+- No rollout, monitoring, or feature-flag concerns — pure language semantics; no production state.
+- The brainstorm doc and this plan together form the v2.1.0 design record. Linkable from the CHANGELOG entry.
+
+---
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-04-30-rate-arithmetic-least-surprise-requirements.md`
+- **Reference PR:** `feat/rate-duration-arithmetic` branch (commit `25019d9`) — time-only first slice; rebase target.
+- **Related code:**
+  - `impl/interpreter/operators.go` — dispatch site
+  - `impl/interpreter/rate_arithmetic.go` (PR #148; absorbed and extended here)
+  - `spec/types/rate.go`, `spec/types/duration.go`, `spec/types/currency.go`
+  - `spec/units/conversion.go` — generic converter
+  - `impl/interpreter/rate_eval.go`, `spec/document/literal_eval.go` — twin construction sites
+- **Related learnings:**
+  - `docs/solutions/feature-gaps/rate-type-arithmetic-widening.md`
+  - `docs/solutions/logic-errors/adding-new-type-fraction-cross-layer-checklist.md`
+  - `docs/solutions/ui-bugs/display-formatter-overrides-explicit-unit-conversion.md`
+  - `docs/solutions/logic-errors/currency-synonym-symbol-vs-code-comparison.md`
+- **Related PRs/issues:** #148 (parked draft, time-only first slice — to be rebased onto this plan or closed-and-replaced).

--- a/impl/interpreter/compound_units_test.go
+++ b/impl/interpreter/compound_units_test.go
@@ -630,31 +630,60 @@ func TestNumberTimesRate(t *testing.T) {
 	})
 }
 
-// TestRateTimesQuantity verifies Rate * Quantity → Quantity and Quantity * Rate → Quantity.
+// TestRateTimesQuantity verifies Rate × Quantity dispatch under the
+// v2.1 cancellation engine. Pre-v2.1, this exercised the now-retired
+// silent-coercion rule that ignored the rate's PerUnit and just
+// multiplied the values (`100/second * 10 KB → 1000 KB`); that rule
+// was a long-standing dimensional-correctness gap and is replaced by
+// same-category cancellation only.
+//
+// New semantics:
+//   - Same-category Rate × Quantity → cancels, produces the rate's
+//     numerator type (`100 MB/s × 10 s → 1000 MB`).
+//   - Cross-category Rate × Quantity → errors (no cancellation).
+//   - Quantity × Rate (commuted) — still goes through the existing
+//     rate-on-right widening at operators.go:107-122; U4 will gate
+//     this on the same cancellation predicate, but until then the
+//     widening continues to silently strip the rate's denominator.
 func TestRateTimesQuantity(t *testing.T) {
 	tests := []struct {
-		name          string
-		input         string
-		expectedUnit  string
-		expectNonZero bool
+		name           string
+		input          string
+		expectError    bool
+		expectedUnit   string
+		expectNonZero  bool
+		expectedString string
 	}{
 		{
-			name:          "rate * quantity",
-			input:         "r = 100/second\nresult = r * 10 KB\n",
-			expectedUnit:  "KB",
-			expectNonZero: true,
+			// Same category (DataSize × time-rate where the time
+			// cancels): the canonical "rate × quantity that cancels"
+			// shape. Replaces the old "rate × unrelated quantity"
+			// case below.
+			name:           "rate × matching-category quantity (cancels)",
+			input:          "r = 100 MB/s\nresult = r * 10 seconds\n",
+			expectError:    false,
+			expectedUnit:   "MB",
+			expectNonZero:  true,
+			expectedString: "1000",
 		},
 		{
-			name:          "quantity * rate (commutative)",
+			// Cross-category: data-rate × DataSize doesn't cancel
+			// (rate's PerUnit is `s` (time), quantity's unit is `KB`
+			// (DataSize)). Pre-v2.1 silently produced `1000 KB`;
+			// v2.1 errors so the user can spot the dimensional bug.
+			name:        "rate × cross-category quantity (refuses)",
+			input:       "r = 100/second\nresult = r * 10 KB\n",
+			expectError: true,
+		},
+		{
+			// Commuted form still works via the existing rate-on-right
+			// widening (operators.go:107-122). U4 will gate this; for
+			// now it continues to silently strip the rate.
+			name:          "quantity × rate (commuted, widening still applies)",
 			input:         "r = 100/second\nresult = 10 KB * r\n",
+			expectError:   false,
 			expectedUnit:  "KB",
 			expectNonZero: true,
-		},
-		{
-			name:          "zero rate * quantity",
-			input:         "r = 0/second\nresult = r * 10 KB\n",
-			expectedUnit:  "KB",
-			expectNonZero: false,
 		},
 	}
 
@@ -666,6 +695,12 @@ func TestRateTimesQuantity(t *testing.T) {
 			}
 			interp := NewInterpreter()
 			results, err := interp.Eval(nodes)
+			if tt.expectError {
+				if err == nil {
+					t.Fatalf("expected error, got result %v", results[len(results)-1])
+				}
+				return
+			}
 			if err != nil {
 				t.Fatalf("Eval error: %v", err)
 			}
@@ -679,6 +714,9 @@ func TestRateTimesQuantity(t *testing.T) {
 			}
 			if tt.expectNonZero && qty.Value.IsZero() {
 				t.Error("Result value should not be zero")
+			}
+			if tt.expectedString != "" && qty.Value.String() != tt.expectedString {
+				t.Errorf("Expected value %q, got %q", tt.expectedString, qty.Value.String())
 			}
 		})
 	}

--- a/impl/interpreter/operators.go
+++ b/impl/interpreter/operators.go
@@ -408,7 +408,20 @@ func evalBinaryOperation(left, right types.Type, operator string) (types.Type, e
 			if result, cancelled, _ := rateTimesQuantity(leftRate, rightQty); cancelled {
 				return result, nil
 			}
-			// No cancellation — fall through to R6 refusal.
+			// No cancellation — fall through to R6 refusal at the end
+			// of the leftRate block (a few lines below).
+		}
+
+		// U4 — R6 refusal contract for dimensional mismatch on
+		// multiplication. When none of the Rate × X branches above
+		// matched (or a cancellation was attempted and refused), the
+		// operation has no sensible interpretation. Emit a friendly
+		// "those don't compose" message that names both operands and
+		// explains why, replacing the generic fallback at the bottom
+		// of evalBinaryOperation. Division and other operators on Rate
+		// still fall through to the generic error path.
+		if operator == "*" {
+			return nil, rateMismatchError(leftRate, right)
 		}
 	}
 

--- a/impl/interpreter/operators.go
+++ b/impl/interpreter/operators.go
@@ -364,6 +364,40 @@ func evalBinaryOperation(left, right types.Type, operator string) (types.Type, e
 				return types.NewNumber(result), nil
 			}
 		}
+		// Rate * Duration → Currency / Quantity / Number, with the
+		// duration converted to the rate's PerUnit before multiplying.
+		// `$100/hour * 3 weeks` runs as: 3 weeks → 504 hours, then
+		// 504 × $100 = $50,400. Result type tracks the rate's
+		// numerator: currency-numerator → Currency, quantity-numerator
+		// → Quantity (e.g. `40 hours/week * 3 weeks` → `120 hours`),
+		// unitless-numerator → Number.
+		if rightDur, ok := right.(*types.Duration); ok && operator == "*" {
+			result, err := rateTimesDuration(leftRate, rightDur)
+			if err != nil {
+				return nil, err
+			}
+			return result, nil
+		}
+
+		// Rate * Rate → Rate (with one time unit cancelled), or fully
+		// reduced when the result has no remaining denominator. Used by
+		// chained expressions like `$100/hour * 40 hours/week`:
+		//   left.PerUnit=hour cancels right.Amount.Unit=hour
+		//   → Rate{Amount: $4000, PerUnit: week}
+		// We only attempt cancellation against the immediately
+		// adjacent factor (left.PerUnit ↔ right.Amount.Unit). The
+		// commuted case (right.PerUnit ↔ left.Amount.Unit) is handled
+		// symmetrically. Anything else falls through to the existing
+		// per-unit-equality `Rate / Rate → Number` rule above and the
+		// generic error otherwise.
+		if rightRate, ok := right.(*types.Rate); ok && operator == "*" {
+			if result, ok, err := tryRateRateCancellation(leftRate, rightRate); err != nil {
+				return nil, err
+			} else if ok {
+				return result, nil
+			}
+		}
+
 		// Rate * Quantity → Quantity (e.g., "100/second * 10 KB" = "1000 KB")
 		if rightQty, ok := right.(*types.Quantity); ok && operator == "*" {
 			result := leftRate.Amount.Value.Mul(rightQty.Value)

--- a/impl/interpreter/operators.go
+++ b/impl/interpreter/operators.go
@@ -104,6 +104,27 @@ func evalBinaryOperation(left, right types.Type, operator string) (types.Type, e
 		right = fractionToNumber(rightFrac)
 	}
 
+	// Speed-quantity left-side widening (U6, AE4). When the left
+	// operand is a Speed-shaped Quantity (e.g., `60 mph`, `100 kph`)
+	// and the right is a Duration, coerce the speed to its underlying
+	// Rate (`60 mph` → `60 mi/hour`) and recurse through the
+	// cancellation engine. The result is the distance:
+	// `60 mph × 2 hours` → coerce → `60 mi/hour × 2 hours` → cancel
+	// hour → `120 mi` (Quantity).
+	//
+	// Mirrors the rate-on-RIGHT widening below in shape but fires
+	// only for `Quantity × Duration` where the Quantity is a known
+	// Speed unit. Anything else falls through to standard dispatch.
+	if operator == "*" {
+		if leftQty, ok := left.(*types.Quantity); ok {
+			if _, rightIsDur := right.(*types.Duration); rightIsDur {
+				if coercedRate, isSpeed := coerceSpeedQuantityToRate(leftQty); isSpeed {
+					return evalBinaryOperation(coercedRate, right, operator)
+				}
+			}
+		}
+	}
+
 	// Rate arithmetic widening: when a Rate appears on the RIGHT side of
 	// * or /, extract the rate's Amount (a Quantity) and drop the time
 	// denominator. This makes "2 * (2 posts/week)" yield "4 posts".

--- a/impl/interpreter/operators.go
+++ b/impl/interpreter/operators.go
@@ -372,11 +372,11 @@ func evalBinaryOperation(left, right types.Type, operator string) (types.Type, e
 		// → Quantity (e.g. `40 hours/week * 3 weeks` → `120 hours`),
 		// unitless-numerator → Number.
 		if rightDur, ok := right.(*types.Duration); ok && operator == "*" {
-			result, err := rateTimesDuration(leftRate, rightDur)
-			if err != nil {
-				return nil, err
+			if result, cancelled, _ := rateTimesDuration(leftRate, rightDur); cancelled {
+				return result, nil
 			}
-			return result, nil
+			// No cancellation — fall through to R6 refusal below.
+			// (U4 wires the message at the rate-on-left fall-through.)
 		}
 
 		// Rate * Rate → Rate (with one time unit cancelled), or fully
@@ -398,10 +398,17 @@ func evalBinaryOperation(left, right types.Type, operator string) (types.Type, e
 			}
 		}
 
-		// Rate * Quantity → Quantity (e.g., "100/second * 10 KB" = "1000 KB")
+		// Rate × Quantity — same-category cancellation (U2). Replaces
+		// the long-standing too-permissive rule that silently dropped
+		// the rate's PerUnit (`100/second × 10 KB → 1000 KB`). Now:
+		// only cancels when units share a category (or are the same
+		// Custom string). No cancellation → falls through to U4's
+		// R6 refusal below.
 		if rightQty, ok := right.(*types.Quantity); ok && operator == "*" {
-			result := leftRate.Amount.Value.Mul(rightQty.Value)
-			return &types.Quantity{Value: result, Unit: rightQty.Unit}, nil
+			if result, cancelled, _ := rateTimesQuantity(leftRate, rightQty); cancelled {
+				return result, nil
+			}
+			// No cancellation — fall through to R6 refusal.
 		}
 	}
 

--- a/impl/interpreter/rate_arithmetic.go
+++ b/impl/interpreter/rate_arithmetic.go
@@ -175,13 +175,23 @@ func rateNumeratorAsResult(r *types.Rate, value decimal.Decimal) types.Type {
 	if unit == "" {
 		return types.NewNumber(value)
 	}
+	// Currency-symbol numerator (e.g. "$100/hour") → Currency.
+	// `types.SymbolToCode` keys are the user-typed symbols ("$",
+	// "€", "£", "¥"); membership means the unit string is a
+	// recognised currency symbol.
 	if _, ok := types.SymbolToCode[unit]; ok {
+		// `NewCurrency` accepts either symbol or code and computes
+		// the missing field, so passing the symbol back round-trips
+		// to a Currency with both Symbol and Code populated.
 		return types.NewCurrency(value, unit)
 	}
-	// ISO codes (USD, EUR, ...) live in the symbol→code map values
-	// AND can appear as Amount.Unit when the user wrote "100 USD/day"
-	// rather than "$100/day". Reverse-lookup catches them.
-	if isCurrencyCode(unit) {
+	// ISO-code numerator (e.g. "100 USD/day" — the user wrote the
+	// code, not the symbol). `types.IsCurrencyCode` checks both
+	// directions of the code↔symbol maps, so it covers any
+	// recognised code regardless of which side of the map it lives
+	// in. R7 contract: preserve the user's typed form — pass the
+	// code through verbatim and let NewCurrency canonicalise.
+	if types.IsCurrencyCode(unit) {
 		return types.NewCurrency(value, unit)
 	}
 	return &types.Quantity{Value: value, Unit: unit}

--- a/impl/interpreter/rate_arithmetic.go
+++ b/impl/interpreter/rate_arithmetic.go
@@ -23,35 +23,64 @@ import (
 // categoryOf + convertWithinCategory helpers below paper over that
 // split so the cancellation engine itself doesn't have to care.
 
-// rateTimesDuration multiplies a Rate by a Duration. The Duration is
-// converted into the rate's PerUnit (e.g. weeks → hours when the
-// rate is `$/hour`); once both sides agree on the time unit, that
-// dimension cancels and the rate's numerator is the result type.
+// tryRateCancellation attempts to cancel the rate's PerUnit against
+// the unit on a scalar operand (a Duration's Unit, a Quantity's Unit).
+// Used by `Rate × Duration` and `Rate × Quantity` dispatch.
 //
-// Errors when:
-//   - The rate's PerUnit is not a recognised time unit (so the
-//     conversion has nowhere to land — e.g. `100 req/server * 3
-//     weeks` doesn't compose).
-//   - The Duration's unit can't convert to the PerUnit (defence in
-//     depth — Duration values from the parser already use the
-//     canonical time-unit set, but a future feature could surface a
-//     different unit name).
-func rateTimesDuration(r *types.Rate, d *types.Duration) (types.Type, error) {
-	// PerUnit must be a time unit for the conversion to be meaningful.
-	// `100 req / server * 3 weeks` is a category error; surface it.
-	if !types.IsValidDurationUnit(r.PerUnit) {
-		return nil, fmt.Errorf(
-			"cannot multiply rate (%s) by duration (%s): rate's PerUnit %q is not a time unit",
-			r, d, r.PerUnit)
+// Returns:
+//   - (result, true, nil) when cancellation succeeded — the rate's
+//     numerator is reconstructed via `rateNumeratorAsResult`.
+//   - (nil, false, nil) when the cancellation predicate did NOT match,
+//     OR matched but the conversion failed. In both cases the caller
+//     should fall through to R6 refusal at the dispatch level rather
+//     than surface the convert-error string. (Plan G3 resolution:
+//     leak no internal "cannot convert X to Y" messages as user-
+//     facing errors; R6's contract takes over.)
+//
+// The predicate: cancellation applies when (a) `categoryOf(r.PerUnit)`
+// equals `categoryOf(oppUnit)` and both are non-empty, AND (b) for
+// `Custom` units, the strings are equal (since Custom has no
+// converter).
+func tryRateCancellation(r *types.Rate, oppValue decimal.Decimal, oppUnit string) (types.Type, bool, error) {
+	rateCat := categoryOf(r.PerUnit)
+	oppCat := categoryOf(oppUnit)
+	if rateCat == "" || oppCat == "" {
+		return nil, false, nil
 	}
-	converted, err := d.Convert(r.PerUnit)
+	if rateCat != oppCat {
+		return nil, false, nil
+	}
+	// Custom units cancel only when literally the same string. Distinct
+	// Custom names (cake vs box) fall through to refusal.
+	if rateCat == "Custom" && r.PerUnit != oppUnit {
+		return nil, false, nil
+	}
+	converted, err := convertWithinCategory(oppValue, oppUnit, r.PerUnit)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"cannot multiply rate (%s) by duration (%s): %w",
-			r, d, err)
+		// Predicate matched but conversion math failed. Treat as
+		// "no cancellation" so dispatch routes to R6's friendlier
+		// refusal message rather than leaking the converter's
+		// internal error string.
+		return nil, false, nil
 	}
-	value := r.Amount.Value.Mul(converted.Value)
-	return rateNumeratorAsResult(r, value), nil
+	value := r.Amount.Value.Mul(converted)
+	return rateNumeratorAsResult(r, value), true, nil
+}
+
+// rateTimesDuration is a thin wrapper around `tryRateCancellation` for
+// the Rate × Duration call site in operators.go. Returns the same
+// 3-tuple shape as `tryRateRateCancellation` so the dispatch can
+// uniformly check `cancelled` and fall through to R6 on false.
+func rateTimesDuration(r *types.Rate, d *types.Duration) (types.Type, bool, error) {
+	return tryRateCancellation(r, d.Value, d.Unit)
+}
+
+// rateTimesQuantity is a thin wrapper for the Rate × Quantity call
+// site. Same shape as `rateTimesDuration`. This replaces the
+// long-standing `operators.go:367-371` silent-coercion rule that
+// ignored the rate's `PerUnit` entirely.
+func rateTimesQuantity(r *types.Rate, q *types.Quantity) (types.Type, bool, error) {
+	return tryRateCancellation(r, q.Value, q.Unit)
 }
 
 // tryRateRateCancellation handles `Rate × Rate` when one rate's
@@ -85,14 +114,13 @@ func rateTimesDuration(r *types.Rate, d *types.Duration) (types.Type, error) {
 //     Amount type itself.
 func tryRateRateCancellation(left, right *types.Rate) (types.Type, bool, error) {
 	// Shape 1: left.PerUnit ↔ right.Amount.Unit
-	if isTimeUnit(left.PerUnit) && isTimeUnit(right.Amount.Unit) {
-		// Convert right's Amount value into left.PerUnit so we can
-		// multiply against left's Amount cleanly.
-		factor, err := convertTimeValue(right.Amount.Value, right.Amount.Unit, left.PerUnit)
+	if cancellable(left.PerUnit, right.Amount.Unit) {
+		factor, err := convertWithinCategory(right.Amount.Value, right.Amount.Unit, left.PerUnit)
 		if err != nil {
-			return nil, false, fmt.Errorf(
-				"cannot cancel %q on (%s) * (%s): %w",
-				left.PerUnit, left, right, err)
+			// Predicate matched but conversion failed — treat as
+			// no-cancellation so dispatch routes to R6 refusal.
+			// (Same plan G3 rule as `tryRateCancellation`.)
+			return nil, false, nil
 		}
 		newAmount := left.Amount.Value.Mul(factor)
 		return &types.Rate{
@@ -105,12 +133,10 @@ func tryRateRateCancellation(left, right *types.Rate) (types.Type, bool, error) 
 	}
 
 	// Shape 2: left.Amount.Unit ↔ right.PerUnit (the commuted case).
-	if isTimeUnit(left.Amount.Unit) && isTimeUnit(right.PerUnit) {
-		factor, err := convertTimeValue(left.Amount.Value, left.Amount.Unit, right.PerUnit)
+	if cancellable(right.PerUnit, left.Amount.Unit) {
+		factor, err := convertWithinCategory(left.Amount.Value, left.Amount.Unit, right.PerUnit)
 		if err != nil {
-			return nil, false, fmt.Errorf(
-				"cannot cancel %q on (%s) * (%s): %w",
-				right.PerUnit, left, right, err)
+			return nil, false, nil
 		}
 		newAmount := factor.Mul(right.Amount.Value)
 		return &types.Rate{
@@ -123,6 +149,21 @@ func tryRateRateCancellation(left, right *types.Rate) (types.Type, bool, error) 
 	}
 
 	return nil, false, nil
+}
+
+// cancellable reports whether two units can cancel against each other:
+// they share a non-empty category, and for `Custom` (which has no
+// converter) the strings are equal.
+func cancellable(a, b string) bool {
+	catA := categoryOf(a)
+	catB := categoryOf(b)
+	if catA == "" || catB == "" || catA != catB {
+		return false
+	}
+	if catA == "Custom" && a != b {
+		return false
+	}
+	return true
 }
 
 // rateNumeratorAsResult reconstructs the rate's numerator as a

--- a/impl/interpreter/rate_arithmetic.go
+++ b/impl/interpreter/rate_arithmetic.go
@@ -1,0 +1,264 @@
+package interpreter
+
+import (
+	"fmt"
+
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/CalcMark/go-calcmark/v2/spec/units"
+	"github.com/shopspring/decimal"
+)
+
+// Rate × Duration / Rate × Rate / Rate × Quantity arithmetic with
+// same-dimension unit cancellation across every category CalcMark
+// supports. Sits next to the binary-op dispatch in operators.go.
+//
+// The dispatch calls into these helpers when it spots a Rate on the
+// left and a Duration / Quantity / Rate on the right; everything else
+// stays in operators.go where it always lived.
+//
+// The cancellation predicate is "shared category" (with exact-string
+// equality as the fallback for Custom units that have no converter).
+// Time units live in spec/types/duration.go and use Duration.Convert;
+// every other category lives in spec/units/conversion.go. The
+// categoryOf + convertWithinCategory helpers below paper over that
+// split so the cancellation engine itself doesn't have to care.
+
+// rateTimesDuration multiplies a Rate by a Duration. The Duration is
+// converted into the rate's PerUnit (e.g. weeks → hours when the
+// rate is `$/hour`); once both sides agree on the time unit, that
+// dimension cancels and the rate's numerator is the result type.
+//
+// Errors when:
+//   - The rate's PerUnit is not a recognised time unit (so the
+//     conversion has nowhere to land — e.g. `100 req/server * 3
+//     weeks` doesn't compose).
+//   - The Duration's unit can't convert to the PerUnit (defence in
+//     depth — Duration values from the parser already use the
+//     canonical time-unit set, but a future feature could surface a
+//     different unit name).
+func rateTimesDuration(r *types.Rate, d *types.Duration) (types.Type, error) {
+	// PerUnit must be a time unit for the conversion to be meaningful.
+	// `100 req / server * 3 weeks` is a category error; surface it.
+	if !types.IsValidDurationUnit(r.PerUnit) {
+		return nil, fmt.Errorf(
+			"cannot multiply rate (%s) by duration (%s): rate's PerUnit %q is not a time unit",
+			r, d, r.PerUnit)
+	}
+	converted, err := d.Convert(r.PerUnit)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"cannot multiply rate (%s) by duration (%s): %w",
+			r, d, err)
+	}
+	value := r.Amount.Value.Mul(converted.Value)
+	return rateNumeratorAsResult(r, value), nil
+}
+
+// tryRateRateCancellation handles `Rate × Rate` when one rate's
+// numerator unit cancels the other rate's denominator unit. Returns
+// (result, true, nil) on a successful cancellation, (nil, false, nil)
+// when no cancellation applies (caller falls through to other rules),
+// or (nil, false, err) when a cancellation was detected but the unit
+// arithmetic failed (e.g. minute↔hour conversion of an unknown unit).
+//
+// The two cancellable shapes:
+//
+//   left.PerUnit ↔ right.Amount.Unit
+//     (a / b) * (b / c) → (a / c)
+//     example: ($/hour) * (hours/week) → $/week
+//
+//   right.PerUnit ↔ left.Amount.Unit
+//     (b / c) * (a / b) → (a / c)  — commuted
+//     example: (hours/week) * ($/hour) → $/week
+//
+// In each case the cancelled time unit is converted on the
+// quantity-side rate (rightSide for the first, leftSide for the
+// second) so a `... * 60 minutes / hour` left-hand factor still
+// cancels a `... / hour` right-hand denominator.
+//
+// Result kind:
+//   - The remaining numerator is the surviving Amount (currency or
+//     quantity).
+//   - The remaining denominator is the surviving PerUnit. If the
+//     surviving PerUnit is empty (which doesn't happen today — Rate
+//     literals always carry a PerUnit), the result reduces to the
+//     Amount type itself.
+func tryRateRateCancellation(left, right *types.Rate) (types.Type, bool, error) {
+	// Shape 1: left.PerUnit ↔ right.Amount.Unit
+	if isTimeUnit(left.PerUnit) && isTimeUnit(right.Amount.Unit) {
+		// Convert right's Amount value into left.PerUnit so we can
+		// multiply against left's Amount cleanly.
+		factor, err := convertTimeValue(right.Amount.Value, right.Amount.Unit, left.PerUnit)
+		if err != nil {
+			return nil, false, fmt.Errorf(
+				"cannot cancel %q on (%s) * (%s): %w",
+				left.PerUnit, left, right, err)
+		}
+		newAmount := left.Amount.Value.Mul(factor)
+		return &types.Rate{
+			Amount: &types.Quantity{
+				Value: newAmount,
+				Unit:  left.Amount.Unit,
+			},
+			PerUnit: right.PerUnit,
+		}, true, nil
+	}
+
+	// Shape 2: left.Amount.Unit ↔ right.PerUnit (the commuted case).
+	if isTimeUnit(left.Amount.Unit) && isTimeUnit(right.PerUnit) {
+		factor, err := convertTimeValue(left.Amount.Value, left.Amount.Unit, right.PerUnit)
+		if err != nil {
+			return nil, false, fmt.Errorf(
+				"cannot cancel %q on (%s) * (%s): %w",
+				right.PerUnit, left, right, err)
+		}
+		newAmount := factor.Mul(right.Amount.Value)
+		return &types.Rate{
+			Amount: &types.Quantity{
+				Value: newAmount,
+				Unit:  right.Amount.Unit,
+			},
+			PerUnit: left.PerUnit,
+		}, true, nil
+	}
+
+	return nil, false, nil
+}
+
+// rateNumeratorAsResult reconstructs the rate's numerator as a
+// concrete result type after the denominator has been cancelled.
+// Currency-symbol numerator → Currency; non-empty unit → Quantity;
+// empty unit → Number.
+func rateNumeratorAsResult(r *types.Rate, value decimal.Decimal) types.Type {
+	unit := r.Amount.Unit
+	if unit == "" {
+		return types.NewNumber(value)
+	}
+	if _, ok := types.SymbolToCode[unit]; ok {
+		return types.NewCurrency(value, unit)
+	}
+	// ISO codes (USD, EUR, ...) live in the symbol→code map values
+	// AND can appear as Amount.Unit when the user wrote "100 USD/day"
+	// rather than "$100/day". Reverse-lookup catches them.
+	if isCurrencyCode(unit) {
+		return types.NewCurrency(value, unit)
+	}
+	return &types.Quantity{Value: value, Unit: unit}
+}
+
+// categoryOf returns the unit category for `unit`, or "" when the
+// unit is unrecognised.
+//
+// Returns:
+//   - "time" — for any time unit recognised by `types.IsValidDurationUnit`
+//     (second, minute, hour, day, week, month, year, etc.).
+//     Time units live separately from `units.conversionRegistry`, so
+//     they get the first-pass branch here.
+//   - The result of `units.CategoryForUnit(unit)` for everything else.
+//     That's the canonical name from the units registry: "Length",
+//     "Mass", "DataSize", "Speed", "Volume", etc., or "Custom" for
+//     unrecognised units (cakes, boxes, anything user-coined).
+//   - "" — when `unit` is the empty string (a unitless rate's
+//     numerator). Empty-vs-empty equality is intentionally NOT a
+//     cancellation match; the cancellation predicate in
+//     `tryRateCancellation` rejects empty categories.
+//
+// The `time` short-circuit is load-bearing: time units appear in
+// `units.CategoryForUnit` as `Custom` (not registered in
+// `conversionRegistry`), and we don't want them to cancel against
+// other Custom units like `box`. Calling `categoryOf` always
+// dispatches `time` correctly first.
+func categoryOf(unit string) string {
+	if unit == "" {
+		return ""
+	}
+	if types.IsValidDurationUnit(unit) {
+		return "time"
+	}
+	return units.CategoryForUnit(unit)
+}
+
+// convertWithinCategory scales `value` from `fromUnit` to `toUnit`
+// when both units share a unit category and the category supports
+// conversion. Returns the converted value, or an error when the two
+// units don't share a category, when the category has no converter,
+// or when the underlying converter rejects the input.
+//
+// Dispatch:
+//   - Identical units → return the value unchanged.
+//   - Both time units → `types.Duration.Convert` does the math.
+//   - Both in a `units.conversionRegistry` category → `units.Convert`
+//     does the math (same category check is built into that call,
+//     but we pre-check here so the error message names both units).
+//   - Both `Custom` (or any category not in conversionRegistry) →
+//     only the identical-string case above succeeds; otherwise
+//     return an error. Custom units have no converter, so cancellation
+//     between them only works on exact-string matches like
+//     `box × box`.
+//
+// The error message names both units explicitly so the R6 refusal
+// path in operators.go can wrap it without losing information.
+func convertWithinCategory(value decimal.Decimal, fromUnit, toUnit string) (decimal.Decimal, error) {
+	if fromUnit == toUnit {
+		return value, nil
+	}
+	fromCat := categoryOf(fromUnit)
+	toCat := categoryOf(toUnit)
+	if fromCat == "" || toCat == "" {
+		return decimal.Zero, fmt.Errorf(
+			"cannot convert %q to %q: unrecognised unit", fromUnit, toUnit)
+	}
+	if fromCat != toCat {
+		return decimal.Zero, fmt.Errorf(
+			"cannot convert %q to %q: different categories (%s vs %s)",
+			fromUnit, toUnit, fromCat, toCat)
+	}
+	if fromCat == "time" {
+		d := &types.Duration{Value: value, Unit: fromUnit}
+		converted, err := d.Convert(toUnit)
+		if err != nil {
+			return decimal.Zero, err
+		}
+		return converted.Value, nil
+	}
+	// Custom units have no converter. The fromUnit == toUnit case is
+	// handled at the top of the function; reaching here means two
+	// distinct Custom unit names. Refuse rather than silently coerce.
+	if fromCat == "Custom" {
+		return decimal.Zero, fmt.Errorf(
+			"cannot convert %q to %q: %q has no converter (custom unit)",
+			fromUnit, toUnit, fromUnit)
+	}
+	return units.Convert(value, fromUnit, toUnit)
+}
+
+// isTimeUnit reports whether s is a recognised duration unit.
+// Retained as a tiny wrapper around `categoryOf` for call-site
+// readability; new code should prefer `categoryOf(s) == "time"` so
+// the predicate is uniform with non-time-domain checks.
+func isTimeUnit(s string) bool {
+	return categoryOf(s) == "time"
+}
+
+// convertTimeValue is a backwards-compatible alias for
+// `convertWithinCategory` retained while U2 is in flight. Once the
+// cancellation engine is fully generalised, callers will be moved
+// onto `convertWithinCategory` directly and this shim removed.
+func convertTimeValue(value decimal.Decimal, fromUnit, toUnit string) (decimal.Decimal, error) {
+	return convertWithinCategory(value, fromUnit, toUnit)
+}
+
+// isCurrencyCode reports whether s appears as an ISO currency code
+// in the SymbolToCode map (e.g. "USD"). Symbols like "$" are matched
+// directly by membership; codes are matched via the values side.
+//
+// Kept local for now; U3 may switch call sites to `types.IsCurrencyCode`
+// (which checks both SymbolToCode and CodeToSymbol) for completeness.
+func isCurrencyCode(s string) bool {
+	for _, code := range types.SymbolToCode {
+		if code == s {
+			return true
+		}
+	}
+	return false
+}

--- a/impl/interpreter/rate_arithmetic.go
+++ b/impl/interpreter/rate_arithmetic.go
@@ -303,8 +303,10 @@ func convertTimeValue(value decimal.Decimal, fromUnit, toUnit string) (decimal.D
 // in the SymbolToCode map (e.g. "USD"). Symbols like "$" are matched
 // directly by membership; codes are matched via the values side.
 //
-// Kept local for now; U3 may switch call sites to `types.IsCurrencyCode`
-// (which checks both SymbolToCode and CodeToSymbol) for completeness.
+// Retained as a thin local helper. The result-construction path
+// in `rateNumeratorAsResult` uses `types.IsCurrencyCode` directly
+// for completeness; this local helper is preserved as a back-compat
+// shim for any historical callers.
 func isCurrencyCode(s string) bool {
 	for _, code := range types.SymbolToCode {
 		if code == s {
@@ -312,4 +314,81 @@ func isCurrencyCode(s string) bool {
 		}
 	}
 	return false
+}
+
+// rateMismatchError builds the R6 refusal message for `Rate × X`
+// where the cancellation engine couldn't find a shared dimension.
+// The message names both operands AND the categorical reason the
+// multiplication doesn't compose, and includes the word "cancel" so
+// substring-matching tests have a stable anchor.
+//
+// Two distinct templates so the message reads naturally for the
+// two main cases:
+//
+//   - Rate × Currency or Rate × Rate-with-same-numerator-currency →
+//     "cannot multiply two currencies" form.
+//   - Everything else → "cannot multiply rate (X) by Y — Z is a
+//     <category> unit; the rate's denominator is <unit>, a <category>
+//     unit. No shared dimension to cancel."
+//
+// The exact wording is *not* part of the contract — tests verify
+// substrings (`cancel`, both operand displays, both unit names).
+// Future tuning of the wording is welcome as long as those substrings
+// survive.
+func rateMismatchError(left *types.Rate, right types.Type) error {
+	// Special case: Currency × Currency (when right collapses to a
+	// Currency-numerator rate or is a bare Currency operand). Plan
+	// G10: same R6 contract, slightly different template since
+	// "no shared dimension" doesn't quite apply when both sides ARE
+	// the same dimension (currency).
+	if _, ok := right.(*types.Currency); ok {
+		return fmt.Errorf(
+			"cannot multiply rate (%s) by currency (%s): multiplying two currencies has no meaningful unit. "+
+				"To accumulate a rate over time, multiply by a duration that cancels the rate's denominator instead.",
+			left, formatTypeForError(right))
+	}
+
+	// Pull units off the right operand for the message body.
+	var rightUnit string
+	switch r := right.(type) {
+	case *types.Duration:
+		rightUnit = r.Unit
+	case *types.Quantity:
+		rightUnit = r.Unit
+	case *types.Rate:
+		rightUnit = r.PerUnit
+	}
+
+	leftCat := categoryOf(left.PerUnit)
+	rightCat := categoryOf(rightUnit)
+
+	// Build a category description that names both sides clearly.
+	// Keep it short: the substring contract requires the unit names
+	// and the word "cancel"; richer prose can come later.
+	leftCatPhrase := categoryPhrase(left.PerUnit, leftCat)
+	rightCatPhrase := categoryPhrase(rightUnit, rightCat)
+
+	return fmt.Errorf(
+		"cannot multiply rate (%s) by %s: %s, but %s. No shared dimension to cancel.",
+		left, formatTypeForError(right), leftCatPhrase, rightCatPhrase)
+}
+
+// categoryPhrase produces a short natural phrase describing a unit
+// and its category, for use in rateMismatchError.
+//
+//	categoryPhrase("hour", "time")    → `the rate's denominator is "hour" (a time unit)`
+//	categoryPhrase("kg", "Mass")      → `"kg" is a Mass unit`
+//	categoryPhrase("box", "Custom")   → `"box" is a custom unit`
+//	categoryPhrase("", "")            → `the operand has no unit`
+func categoryPhrase(unit, category string) string {
+	if unit == "" {
+		return "the operand has no unit"
+	}
+	if category == "" {
+		return fmt.Sprintf("%q is an unrecognised unit", unit)
+	}
+	if category == "Custom" {
+		return fmt.Sprintf("%q is a custom unit", unit)
+	}
+	return fmt.Sprintf("%q is a %s unit", unit, category)
 }

--- a/impl/interpreter/rate_arithmetic.go
+++ b/impl/interpreter/rate_arithmetic.go
@@ -316,6 +316,24 @@ func isCurrencyCode(s string) bool {
 	return false
 }
 
+// coerceSpeedQuantityToRate widens a Speed-shaped Quantity into the
+// Rate it represents (e.g. `60 mph` → `Rate{60 mi, hour}`). Returns
+// (nil, false) when the quantity's unit isn't a recognised Speed
+// unit. Used by operators.go's left-side widening to make AE4
+// (`60 mph × 2 hours → 120 miles`) flow through the cancellation
+// engine.
+//
+// Free-function variant of `Interpreter.coerceSpeedToRate` —
+// intentionally has no Interpreter receiver since the binary-op
+// dispatch in `evalBinaryOperation` is also a free function.
+func coerceSpeedQuantityToRate(qty *types.Quantity) (*types.Rate, bool) {
+	numUnit, timeUnit, ok := units.DecomposeSpeedUnit(qty.Unit)
+	if !ok {
+		return nil, false
+	}
+	return types.NewRate(&types.Quantity{Value: qty.Value, Unit: numUnit}, timeUnit), true
+}
+
 // rateMismatchError builds the R6 refusal message for `Rate × X`
 // where the cancellation engine couldn't find a shared dimension.
 // The message names both operands AND the categorical reason the

--- a/impl/interpreter/rate_arithmetic_test.go
+++ b/impl/interpreter/rate_arithmetic_test.go
@@ -1,0 +1,203 @@
+package interpreter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/shopspring/decimal"
+)
+
+// Foundation helper tests for U1. The cancellation engine in U2 leans
+// on `categoryOf` to decide whether two units can compose, and on
+// `convertWithinCategory` to do the actual math when they can. Both
+// must behave correctly across the boundary between time units (which
+// live in spec/types/duration.go) and everything else (which lives in
+// spec/units/conversion.go), plus the Custom-unit fallback case where
+// only exact-string matches succeed.
+
+func TestCategoryOf_TimeUnits(t *testing.T) {
+	cases := []string{"second", "minute", "hour", "day", "week", "month", "year"}
+	for _, u := range cases {
+		t.Run(u, func(t *testing.T) {
+			if got := categoryOf(u); got != "time" {
+				t.Errorf("categoryOf(%q) = %q, want \"time\"", u, got)
+			}
+		})
+	}
+}
+
+func TestCategoryOf_KnownPhysicalUnits(t *testing.T) {
+	// Pick one unit from each major units-package category and confirm
+	// categoryOf returns the canonical category name. The exact
+	// category strings come from spec/units/categories.go and the
+	// individual unit registrations.
+	cases := map[string]string{
+		"kg":     "Mass",
+		"g":      "Mass",
+		"meter":  "Length",
+		"meters": "Length",
+		"GB":     "DataSize",
+		"liter":  "Volume",
+		"mph":    "Speed",
+	}
+	for unit, wantCat := range cases {
+		t.Run(unit, func(t *testing.T) {
+			if got := categoryOf(unit); got != wantCat {
+				t.Errorf("categoryOf(%q) = %q, want %q", unit, got, wantCat)
+			}
+		})
+	}
+}
+
+func TestCategoryOf_CustomUnits(t *testing.T) {
+	// Unknown unit names fall through to units.CategoryForUnit which
+	// returns "Custom" for anything outside its registry. Cancellation
+	// between Custom units only works when the unit strings are equal
+	// (handled by convertWithinCategory's fast path); this test just
+	// pins the category-name contract.
+	cases := []string{"cake", "cakes", "box", "boxes", "user", "request"}
+	for _, u := range cases {
+		t.Run(u, func(t *testing.T) {
+			if got := categoryOf(u); got != "Custom" {
+				t.Errorf("categoryOf(%q) = %q, want \"Custom\"", u, got)
+			}
+		})
+	}
+}
+
+func TestCategoryOf_EmptyIsEmpty(t *testing.T) {
+	// Empty unit (a unitless rate's numerator) returns empty category.
+	// Used by tryRateCancellation to refuse cancellation when one side
+	// has no unit at all.
+	if got := categoryOf(""); got != "" {
+		t.Errorf("categoryOf(\"\") = %q, want \"\"", got)
+	}
+}
+
+func TestCategoryOf_TimeBeforeCustom(t *testing.T) {
+	// Time units must NOT fall into the Custom bucket even though
+	// they're not registered in spec/units/conversionRegistry. The
+	// time-first short-circuit in categoryOf is load-bearing: without
+	// it, `box × hour` would match by category (both Custom) and
+	// trigger spurious cancellation attempts.
+	if categoryOf("hour") == categoryOf("box") {
+		t.Errorf("hour and box should NOT share a category; categoryOf(hour)=%q categoryOf(box)=%q",
+			categoryOf("hour"), categoryOf("box"))
+	}
+}
+
+func TestConvertWithinCategory_IdenticalUnitsPassThrough(t *testing.T) {
+	// Same-unit conversion always succeeds and returns the value
+	// unchanged, regardless of category. This is the path Custom
+	// units take in the cakes/box × boxes case.
+	cases := []struct {
+		value string
+		unit  string
+	}{
+		{"5", "hour"},
+		{"3", "kg"},
+		{"100", "box"},
+		{"42.5", "miles"},
+		{"0", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.unit, func(t *testing.T) {
+			value := decimal.RequireFromString(tc.value)
+			got, err := convertWithinCategory(value, tc.unit, tc.unit)
+			if err != nil {
+				t.Fatalf("convertWithinCategory(%s, %q, %q) errored: %v", tc.value, tc.unit, tc.unit, err)
+			}
+			if !got.Equal(value) {
+				t.Errorf("got %s, want %s (identity must pass through)", got.String(), tc.value)
+			}
+		})
+	}
+}
+
+func TestConvertWithinCategory_TimeConversion(t *testing.T) {
+	// Time units convert through types.Duration.Convert. The 3-weeks
+	// → 504-hours case is the canonical example from AE1 in the
+	// brainstorm and locks the expected value.
+	got, err := convertWithinCategory(decimal.NewFromInt(3), "week", "hour")
+	if err != nil {
+		t.Fatalf("convertWithinCategory: %v", err)
+	}
+	if got.String() != "504" {
+		t.Errorf("3 week → hour = %s, want 504", got.String())
+	}
+}
+
+func TestConvertWithinCategory_PhysicalConversion(t *testing.T) {
+	// Mass conversion goes through units.Convert. Verifies the
+	// non-time branch dispatches correctly.
+	got, err := convertWithinCategory(decimal.NewFromInt(5), "kg", "g")
+	if err != nil {
+		t.Fatalf("convertWithinCategory: %v", err)
+	}
+	if got.String() != "5000" {
+		t.Errorf("5 kg → g = %s, want 5000", got.String())
+	}
+}
+
+func TestConvertWithinCategory_CrossCategoryRejected(t *testing.T) {
+	// kg (mass) → hour (time): different categories, must error.
+	// The error message must name both units AND the category split
+	// so the R6 refusal in U4 can wrap it without losing information.
+	_, err := convertWithinCategory(decimal.NewFromInt(5), "kg", "hour")
+	if err == nil {
+		t.Fatal("expected error for kg → hour, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "kg") {
+		t.Errorf("error %q must mention 'kg'", msg)
+	}
+	if !strings.Contains(msg, "hour") {
+		t.Errorf("error %q must mention 'hour'", msg)
+	}
+	if !strings.Contains(msg, "categor") { // matches "category" or "categories"
+		t.Errorf("error %q should mention category mismatch", msg)
+	}
+}
+
+func TestConvertWithinCategory_CustomDistinctRejected(t *testing.T) {
+	// Two distinct Custom units (e.g., cake → box) refuse with a
+	// clear "no converter" error. The cancellation engine in U2
+	// turns this into an R6 refusal at the operator level rather
+	// than leaking the message verbatim, but at the helper layer
+	// the error must still be specific.
+	_, err := convertWithinCategory(decimal.NewFromInt(3), "cake", "box")
+	if err == nil {
+		t.Fatal("expected error for cake → box, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "cake") {
+		t.Errorf("error %q must mention 'cake'", msg)
+	}
+	if !strings.Contains(msg, "box") {
+		t.Errorf("error %q must mention 'box'", msg)
+	}
+}
+
+func TestConvertWithinCategory_UnknownUnitRejected(t *testing.T) {
+	// Empty-string unit on either side: refuse with a message
+	// pointing at the bad input.
+	_, err := convertWithinCategory(decimal.NewFromInt(1), "", "hour")
+	if err == nil {
+		t.Fatal("expected error for empty-from, got nil")
+	}
+}
+
+func TestIsTimeUnit_StillWorks(t *testing.T) {
+	// Backward-compat shim — existing callers in tryRateRateCancellation
+	// continue to call isTimeUnit. The behavior is now categoryOf-driven;
+	// confirm the equivalence holds.
+	if !isTimeUnit("hour") {
+		t.Error("isTimeUnit(hour) should be true")
+	}
+	if isTimeUnit("kg") {
+		t.Error("isTimeUnit(kg) should be false")
+	}
+	if isTimeUnit("") {
+		t.Error("isTimeUnit(\"\") should be false")
+	}
+}

--- a/impl/interpreter/rate_duration_arithmetic_test.go
+++ b/impl/interpreter/rate_duration_arithmetic_test.go
@@ -160,6 +160,80 @@ func TestRateDuration_ChainedIntermediateRate(t *testing.T) {
 	}
 }
 
+// R7 — currency identity preservation. When the cancellation engine
+// produces a Currency-shaped result, the Code and Symbol on the
+// Currency must reflect the user's typed form. `$100/hour × 3 weeks`
+// → "$50,400" (Symbol=$, Code=USD). `100 USD/hour × 3 weeks` →
+// "50,400 USD" preserving the ISO-code form.
+func TestRateDuration_CurrencyIdentity_Symbol(t *testing.T) {
+	res := evalSingleResult(t, "$100 / hour * 3 weeks\n")
+	cur, ok := res.(*types.Currency)
+	if !ok {
+		t.Fatalf("want *types.Currency, got %T (%v)", res, res)
+	}
+	if cur.Symbol != "$" {
+		t.Errorf("Symbol = %q, want \"$\"", cur.Symbol)
+	}
+	if cur.Code != "USD" {
+		t.Errorf("Code = %q, want \"USD\"", cur.Code)
+	}
+	if got := cur.Value.String(); got != "50400" {
+		t.Errorf("Value = %s, want 50400", got)
+	}
+}
+
+func TestRateDuration_CurrencyIdentity_ISOCode(t *testing.T) {
+	res := evalSingleResult(t, "100 USD / hour * 3 weeks\n")
+	cur, ok := res.(*types.Currency)
+	if !ok {
+		t.Fatalf("want *types.Currency, got %T (%v)", res, res)
+	}
+	if cur.Code != "USD" {
+		t.Errorf("Code = %q, want \"USD\"", cur.Code)
+	}
+	if got := cur.Value.String(); got != "50400" {
+		t.Errorf("Value = %s, want 50400", got)
+	}
+}
+
+func TestRateDuration_CurrencyIdentity_Euro(t *testing.T) {
+	res := evalSingleResult(t, "€50 / hour * 8 hours\n")
+	cur, ok := res.(*types.Currency)
+	if !ok {
+		t.Fatalf("want *types.Currency, got %T (%v)", res, res)
+	}
+	if cur.Symbol != "€" {
+		t.Errorf("Symbol = %q, want \"€\"", cur.Symbol)
+	}
+	if cur.Code != "EUR" {
+		t.Errorf("Code = %q, want \"EUR\"", cur.Code)
+	}
+	if got := cur.Value.String(); got != "400" {
+		t.Errorf("Value = %s, want 400", got)
+	}
+}
+
+// Regression: Quantity-numerator rate must NOT false-positive into
+// Currency. `40 hours/week × 3 weeks → 120 hour` is a Quantity, not a
+// Currency, even though "hour" isn't a currency code/symbol — confirms
+// IsCurrencyCode doesn't catch non-currency strings.
+func TestRateDuration_QuantityNumeratorStaysQuantity(t *testing.T) {
+	res := evalSingleResult(t, "40 hours / week * 3 weeks\n")
+	if _, isCurrency := res.(*types.Currency); isCurrency {
+		t.Fatalf("Quantity-numerator result must not be Currency, got %v", res)
+	}
+	qty, ok := res.(*types.Quantity)
+	if !ok {
+		t.Fatalf("want *types.Quantity, got %T", res)
+	}
+	if qty.Unit != "hour" {
+		t.Errorf("Unit = %q, want \"hour\"", qty.Unit)
+	}
+	if got := qty.Value.String(); got != "120" {
+		t.Errorf("Value = %s, want 120", got)
+	}
+}
+
 // AE3 (engine-level) — same-dimension Custom-unit cancellation. The
 // language-level form `100 cakes / box * 5 boxes` doesn't parse
 // today because `box` isn't recognised as a rate denominator at

--- a/impl/interpreter/rate_duration_arithmetic_test.go
+++ b/impl/interpreter/rate_duration_arithmetic_test.go
@@ -1,6 +1,7 @@
 package interpreter
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/CalcMark/go-calcmark/v2/spec/parser"
@@ -301,6 +302,100 @@ func TestRateDuration_NumberScalingPreserved(t *testing.T) {
 	}
 	if got := rate.Amount.Value.String(); got != "200" {
 		t.Errorf("Amount.Value = %s, want 200", got)
+	}
+}
+
+// R6 — refusal contract for dimensional mismatches. Locks the
+// substring contract from Decision 6 of the plan: tests verify the
+// error mentions both operands' display strings and the offending
+// unit names. They do NOT assert the verbatim message format.
+
+func TestRateDuration_RefusalForCrossCategory_RateTimesQuantity(t *testing.T) {
+	// AE5 — `$100/hour × 5 kg` doesn't compose. mass ≠ time.
+	interp := NewInterpreter()
+	nodes, err := parser.Parse("$100 / hour * 5 kg\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = interp.Eval(nodes)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"kg", "hour", "cancel"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q must mention %q", msg, want)
+		}
+	}
+}
+
+func TestRateDuration_RefusalForCrossCategory_DataRateTimesMass(t *testing.T) {
+	// `100 MB/s × 5 kg` — DataSize/time × Mass. No shared dimension.
+	interp := NewInterpreter()
+	nodes, err := parser.Parse("r = 100 MB / s\nresult = r * 5 kg\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = interp.Eval(nodes)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{"kg", "cancel"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error %q must mention %q", msg, want)
+		}
+	}
+}
+
+func TestRateDuration_RefusalForCrossCategory_TimeRateTimesData(t *testing.T) {
+	// The case the old line-367 silent-coercion exercised:
+	// `100/second × 10 KB`. Now refuses.
+	interp := NewInterpreter()
+	nodes, err := parser.Parse("r = 100 / second\nresult = r * 10 KB\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = interp.Eval(nodes)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "cancel") {
+		t.Errorf("error %q must mention 'cancel'", msg)
+	}
+}
+
+func TestRateDuration_RefusalForCurrencyTimesCurrency(t *testing.T) {
+	// G10 — multiplying rate by a currency uses the special template
+	// (no "shared dimension" framing since both ARE the same kind).
+	interp := NewInterpreter()
+	nodes, err := parser.Parse("$100 / hour * $50\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = interp.Eval(nodes)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// Substring contract: rate display + currency operand display
+	// + the "currency" framing. The exact display format uses the
+	// rate's String() ("100 $/h") and formatTypeForError on the
+	// right ("currency ($50.00)"), so we check for "100" + "$/h"
+	// for the left, and "$50" for the right. These survive any
+	// future tuning of the message wording.
+	msg := err.Error()
+	if !strings.Contains(msg, "100") || !strings.Contains(msg, "$/h") {
+		t.Errorf("error %q must mention left rate (100 / $/h)", msg)
+	}
+	if !strings.Contains(msg, "$50") {
+		t.Errorf("error %q must mention '$50' (right operand)", msg)
+	}
+	// The currency-×-currency template uses "currencies" or
+	// "currency" rather than "cancel" — verify the wording differs
+	// from the standard template.
+	if !strings.Contains(msg, "currenc") {
+		t.Errorf("error %q must mention 'currency' or 'currencies'", msg)
 	}
 }
 

--- a/impl/interpreter/rate_duration_arithmetic_test.go
+++ b/impl/interpreter/rate_duration_arithmetic_test.go
@@ -1,0 +1,172 @@
+package interpreter
+
+import (
+	"testing"
+
+	"github.com/CalcMark/go-calcmark/v2/spec/parser"
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+)
+
+// Rate × Duration / Rate × Rate arithmetic with time-unit cancellation
+// and conversion. The motivating use case (user 2026-04-30):
+//
+//   cost = $100 / hour
+//   work = 3 weeks
+//   fee  = cost * work          # → $50,400 (3 weeks → 504 hours, × $100)
+//
+// Plus the chained form the user actually preferred:
+//
+//   rate    = $100 / hour
+//   density = 40 hours / week
+//   weeks   = 3 weeks
+//   fee     = rate * density * weeks   # → $12,000
+//
+// And the simplest case that was also failing pre-change:
+//
+//   $100 / hour * 1 hour     # → $100  (units already match — no conversion)
+//
+// All three failed pre-change with "cannot multiply rate (...) and
+// duration (...)". Tests are concrete value assertions to lock the
+// numeric semantics.
+
+func evalSingleResult(t *testing.T, src string) types.Type {
+	t.Helper()
+	interp := NewInterpreter()
+	nodes, err := parser.Parse(src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	results, err := interp.Eval(nodes)
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatalf("no result")
+	}
+	return results[len(results)-1]
+}
+
+func TestRateDuration_CurrencyRateMatchingUnit(t *testing.T) {
+	// $100/hour × 1 hour → $100. No conversion needed; just multiply
+	// values and drop the cancelled unit. Currency comes back out
+	// because the rate's amount was a Currency at construction.
+	res := evalSingleResult(t, "$100 / hour * 1 hour\n")
+	cur, ok := res.(*types.Currency)
+	if !ok {
+		t.Fatalf("want *types.Currency, got %T (%v)", res, res)
+	}
+	if got := cur.Value.String(); got != "100" {
+		t.Errorf("value = %s, want 100", got)
+	}
+}
+
+func TestRateDuration_CurrencyRateMatchingUnitFiveHours(t *testing.T) {
+	res := evalSingleResult(t, "$100 / hour * 5 hours\n")
+	cur, ok := res.(*types.Currency)
+	if !ok {
+		t.Fatalf("want *types.Currency, got %T", res)
+	}
+	if got := cur.Value.String(); got != "500" {
+		t.Errorf("value = %s, want 500", got)
+	}
+}
+
+func TestRateDuration_CurrencyRateConvertedFromWeeks(t *testing.T) {
+	// $100/hour × 3 weeks → 3 × 7 × 24 × $100 = $50,400.
+	// The duration's unit (weeks) is converted to the rate's PerUnit
+	// (hours) before multiplication.
+	res := evalSingleResult(t, "$100 / hour * 3 weeks\n")
+	cur, ok := res.(*types.Currency)
+	if !ok {
+		t.Fatalf("want *types.Currency, got %T", res)
+	}
+	if got := cur.Value.String(); got != "50400" {
+		t.Errorf("value = %s, want 50400", got)
+	}
+}
+
+func TestRateDuration_QuantityRateConstruction(t *testing.T) {
+	// `40 hours / week` must construct a valid Rate with a
+	// Duration-shaped numerator. Pre-change: rejected with "rate
+	// amount must be a number, quantity, or currency, got
+	// *types.Duration".
+	res := evalSingleResult(t, "40 hours / week\n")
+	rate, ok := res.(*types.Rate)
+	if !ok {
+		t.Fatalf("want *types.Rate, got %T (%v)", res, res)
+	}
+	if rate.PerUnit != "week" {
+		t.Errorf("PerUnit = %q, want 'week'", rate.PerUnit)
+	}
+	if rate.Amount.Unit != "hour" {
+		t.Errorf("Amount.Unit = %q, want 'hour' (canonical singular)",
+			rate.Amount.Unit)
+	}
+	if got := rate.Amount.Value.String(); got != "40" {
+		t.Errorf("Amount.Value = %s, want 40", got)
+	}
+}
+
+func TestRateDuration_QuantityRateTimesDuration(t *testing.T) {
+	// 40 hours/week × 3 weeks → 120 hours. Time unit on the rate's
+	// numerator stays as the result's unit; the PerUnit cancels with
+	// the multiplier's unit.
+	res := evalSingleResult(t, "40 hours / week * 3 weeks\n")
+	qty, ok := res.(*types.Quantity)
+	if !ok {
+		t.Fatalf("want *types.Quantity, got %T (%v)", res, res)
+	}
+	if qty.Unit != "hour" {
+		t.Errorf("Unit = %q, want 'hour'", qty.Unit)
+	}
+	if got := qty.Value.String(); got != "120" {
+		t.Errorf("Value = %s, want 120", got)
+	}
+}
+
+func TestRateDuration_ChainedCancellation(t *testing.T) {
+	// $100/hour × 40 hours/week × 3 weeks = $12,000.
+	// Left-associative parse: ((rate × density) × weeks).
+	//   ($100/hour × 40 hours/week) → cancel hour → $4,000/week
+	//   ($4,000/week × 3 weeks)     → cancel week → $12,000 (Currency)
+	res := evalSingleResult(t, "$100 / hour * 40 hours / week * 3 weeks\n")
+	cur, ok := res.(*types.Currency)
+	if !ok {
+		t.Fatalf("want *types.Currency, got %T (%v)", res, res)
+	}
+	if got := cur.Value.String(); got != "12000" {
+		t.Errorf("Value = %s, want 12000", got)
+	}
+}
+
+func TestRateDuration_ChainedIntermediateRate(t *testing.T) {
+	// Intermediate: ($100/hour × 40 hours/week) by itself is a Rate
+	// of $4000/week — a useful expression in its own right (annual
+	// salary at 40 hr/wk * 52 weeks).
+	res := evalSingleResult(t, "$100 / hour * 40 hours / week\n")
+	rate, ok := res.(*types.Rate)
+	if !ok {
+		t.Fatalf("want *types.Rate, got %T (%v)", res, res)
+	}
+	if rate.PerUnit != "week" {
+		t.Errorf("PerUnit = %q, want 'week'", rate.PerUnit)
+	}
+	// $4000/week — Amount.Unit is the currency symbol "$" (the
+	// existing convention from rate_eval.go for currency-numerator
+	// rates). The numeric value is what we lock here.
+	if got := rate.Amount.Value.String(); got != "4000" {
+		t.Errorf("Amount.Value = %s, want 4000", got)
+	}
+}
+
+// Out-of-scope for this round (documented for the follow-up):
+//
+//   - `3 weeks * $100 / hour` (duration on the left). Operator
+//     precedence parses this as `((3 weeks) * $100) / hour` rather
+//     than `(3 weeks) * ($100/hour)`, so it requires explicit
+//     parentheses around the rate. The natural form is rate-on-left
+//     and we lock that one above.
+//   - `$100 / hour * 5 kg` should error with a dimensional-mismatch
+//     diagnostic. Today the existing Rate × Quantity branch silently
+//     coerces the result to `500 kg` — pre-existing behavior we
+//     don't tighten in this PR to keep the soak window stable.

--- a/impl/interpreter/rate_duration_arithmetic_test.go
+++ b/impl/interpreter/rate_duration_arithmetic_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/CalcMark/go-calcmark/v2/spec/parser"
 	"github.com/CalcMark/go-calcmark/v2/spec/types"
+	"github.com/shopspring/decimal"
 )
 
 // Rate × Duration / Rate × Rate arithmetic with time-unit cancellation
@@ -159,7 +160,77 @@ func TestRateDuration_ChainedIntermediateRate(t *testing.T) {
 	}
 }
 
-// Out-of-scope for this round (documented for the follow-up):
+// AE3 (engine-level) — same-dimension Custom-unit cancellation. The
+// language-level form `100 cakes / box * 5 boxes` doesn't parse
+// today because `box` isn't recognised as a rate denominator at
+// the lexer/parser level (it's treated as a variable lookup and
+// fails). The cancellation engine itself is correct — this test
+// constructs the Rate programmatically and verifies the engine
+// handles same-string Custom cancellation. Parser-level support
+// for arbitrary Custom-unit rate denominators is tracked as a
+// follow-up.
+func TestRateDuration_QuantityCustomCancellation_Engine(t *testing.T) {
+	rate := &types.Rate{
+		Amount:  &types.Quantity{Value: decimal.NewFromInt(100), Unit: "cake"},
+		PerUnit: "box",
+	}
+	qty := &types.Quantity{Value: decimal.NewFromInt(5), Unit: "box"}
+	result, cancelled, err := rateTimesQuantity(rate, qty)
+	if err != nil {
+		t.Fatalf("rateTimesQuantity errored: %v", err)
+	}
+	if !cancelled {
+		t.Fatal("expected cancellation, got false")
+	}
+	resQty, ok := result.(*types.Quantity)
+	if !ok {
+		t.Fatalf("want *types.Quantity, got %T", result)
+	}
+	if resQty.Unit != "cake" {
+		t.Errorf("Unit = %q, want 'cake'", resQty.Unit)
+	}
+	if got := resQty.Value.String(); got != "500" {
+		t.Errorf("Value = %s, want 500", got)
+	}
+}
+
+// AE3 (engine-level, refusal) — distinct Custom units do NOT cancel.
+// `cake / box * 5 cake` would naively look like cancellation since
+// both sides have Custom-category units, but `cake != box` so the
+// engine refuses (returns cancelled=false). Dispatch then routes
+// to U4's R6 refusal at the operator level.
+func TestRateDuration_DistinctCustomDoesNotCancel(t *testing.T) {
+	rate := &types.Rate{
+		Amount:  &types.Quantity{Value: decimal.NewFromInt(100), Unit: "cake"},
+		PerUnit: "box",
+	}
+	qty := &types.Quantity{Value: decimal.NewFromInt(5), Unit: "cake"}
+	_, cancelled, err := rateTimesQuantity(rate, qty)
+	if err != nil {
+		t.Fatalf("rateTimesQuantity errored unexpectedly: %v", err)
+	}
+	if cancelled {
+		t.Fatal("expected no cancellation between cake/box and cake (distinct Custom units)")
+	}
+}
+
+// AE6 — Rate × Number stays as scaling. Confirms R5 — bare numbers
+// don't get treated as implicit durations in the rate's denominator.
+func TestRateDuration_NumberScalingPreserved(t *testing.T) {
+	res := evalSingleResult(t, "$100 / hour * 2\n")
+	rate, ok := res.(*types.Rate)
+	if !ok {
+		t.Fatalf("want *types.Rate (scaled), got %T (%v)", res, res)
+	}
+	if rate.PerUnit != "hour" {
+		t.Errorf("PerUnit = %q, want 'hour'", rate.PerUnit)
+	}
+	if got := rate.Amount.Value.String(); got != "200" {
+		t.Errorf("Amount.Value = %s, want 200", got)
+	}
+}
+
+// Out-of-scope for v2.1 (documented for the follow-up):
 //
 //   - `3 weeks * $100 / hour` (duration on the left). Operator
 //     precedence parses this as `((3 weeks) * $100) / hour` rather
@@ -167,6 +238,5 @@ func TestRateDuration_ChainedIntermediateRate(t *testing.T) {
 //     parentheses around the rate. The natural form is rate-on-left
 //     and we lock that one above.
 //   - `$100 / hour * 5 kg` should error with a dimensional-mismatch
-//     diagnostic. Today the existing Rate × Quantity branch silently
-//     coerces the result to `500 kg` — pre-existing behavior we
-//     don't tighten in this PR to keep the soak window stable.
+//     diagnostic — locked by the U4 refusal-contract tests in this
+//     same PR (see TestRateDuration_RefusalForCrossCategory_*).

--- a/impl/interpreter/rate_duration_arithmetic_test.go
+++ b/impl/interpreter/rate_duration_arithmetic_test.go
@@ -305,6 +305,59 @@ func TestRateDuration_NumberScalingPreserved(t *testing.T) {
 	}
 }
 
+// AE4 — `60 mph × 2 hours → 120 miles`. The Speed-shaped Quantity
+// gets widened to its underlying Rate before the cancellation engine
+// sees it, then the time dimension cancels and the result is a
+// distance Quantity. Routes through the U6 widening + U2 cancellation
+// engine.
+func TestRateDuration_SpeedQuantityTimesDuration(t *testing.T) {
+	res := evalSingleResult(t, "60 mph * 2 hours\n")
+	qty, ok := res.(*types.Quantity)
+	if !ok {
+		t.Fatalf("want *types.Quantity, got %T (%v)", res, res)
+	}
+	// `mi` is the canonical unit name (DecomposeSpeedUnit returns "mi").
+	if qty.Unit != "mi" {
+		t.Errorf("Unit = %q, want \"mi\"", qty.Unit)
+	}
+	if got := qty.Value.String(); got != "120" {
+		t.Errorf("Value = %s, want 120", got)
+	}
+}
+
+func TestRateDuration_SpeedQuantityKph(t *testing.T) {
+	// `100 kph × 30 minutes`: U6 coerces kph → km/hour, U2 cancels
+	// hour ↔ minutes via the time-conversion path. Expected:
+	// 100 km/hour × 0.5 hour = 50 km.
+	res := evalSingleResult(t, "100 kph * 30 minutes\n")
+	qty, ok := res.(*types.Quantity)
+	if !ok {
+		t.Fatalf("want *types.Quantity, got %T (%v)", res, res)
+	}
+	if qty.Unit != "km" {
+		t.Errorf("Unit = %q, want \"km\"", qty.Unit)
+	}
+	if got := qty.Value.String(); got != "50" {
+		t.Errorf("Value = %s, want 50", got)
+	}
+}
+
+func TestRateDuration_NonSpeedQuantityNotCoerced(t *testing.T) {
+	// `5 kg × 3 hours` — kg isn't a Speed unit. The U6 widening
+	// must NOT fire; dispatch falls through to standard handling.
+	// Today, Quantity × Duration has no handler and produces an
+	// error — exactly what we want for a dimensional-mismatch case.
+	interp := NewInterpreter()
+	nodes, err := parser.Parse("5 kg * 3 hours\n")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, err = interp.Eval(nodes)
+	if err == nil {
+		t.Fatal("expected error for kg × hours, got nil")
+	}
+}
+
 // R6 — refusal contract for dimensional mismatches. Locks the
 // substring contract from Decision 6 of the plan: tests verify the
 // error mentions both operands' display strings and the offending

--- a/impl/interpreter/rate_eval.go
+++ b/impl/interpreter/rate_eval.go
@@ -34,8 +34,19 @@ func (interp *Interpreter) evalRateLiteral(node *ast.RateLiteral) (types.Type, e
 			Value: v.Value,
 			Unit:  v.Symbol,
 		}
+	case *types.Duration:
+		// Duration as rate amount (e.g., "40 hours / week", "30 minutes
+		// per session"). Stored as Quantity{value, time-unit} so the
+		// Rate × Duration / Rate × Rate arithmetic in operators.go can
+		// detect time-unit cancellation against the PerUnit. The
+		// Duration value is already canonicalised by the parser, so
+		// `40 hours` and `40 hour` both land here as Unit="hour".
+		amountQty = &types.Quantity{
+			Value: v.Value,
+			Unit:  v.Unit,
+		}
 	default:
-		return nil, fmt.Errorf("rate amount must be a number, quantity, or currency, got %T", amountVal)
+		return nil, fmt.Errorf("rate amount must be a number, quantity, currency, or duration, got %T", amountVal)
 	}
 
 	// Create the Rate

--- a/spec/document/literal_eval.go
+++ b/spec/document/literal_eval.go
@@ -199,7 +199,7 @@ func evalRateLiteral(n *ast.RateLiteral) (types.Type, error) {
 		return nil, fmt.Errorf("rate amount evaluation failed: %w", err)
 	}
 
-	// Convert amount to Quantity
+	// Convert amount to Quantity (mirrors impl/interpreter/rate_eval.go)
 	var amountQty *types.Quantity
 	switch v := amountVal.(type) {
 	case *types.Quantity:
@@ -214,8 +214,14 @@ func evalRateLiteral(n *ast.RateLiteral) (types.Type, error) {
 			Value: v.Value,
 			Unit:  v.Symbol,
 		}
+	case *types.Duration:
+		// Duration as rate amount (e.g., "40 hours / week").
+		amountQty = &types.Quantity{
+			Value: v.Value,
+			Unit:  v.Unit,
+		}
 	default:
-		return nil, fmt.Errorf("rate amount must be a number, quantity, or currency, got %T", amountVal)
+		return nil, fmt.Errorf("rate amount must be a number, quantity, currency, or duration, got %T", amountVal)
 	}
 
 	return types.NewRate(amountQty, n.PerUnit), nil

--- a/testdata/eval/success/features/rates.cm
+++ b/testdata/eval/success/features/rates.cm
@@ -71,5 +71,10 @@ scale = 3
 scaled_bw = scale * bandwidth
 scaled_qps_val = 10 * qps
 
-# Rate * Quantity = Quantity
-total_data = bandwidth * 500 MB
+# Rate * matching-category Quantity → cancellation (v2.1).
+# The pre-v2.1 silent-coercion rule that produced "50000 MB" from
+# `bandwidth * 500 MB` (multiplying MB/s by MB without canceling) has
+# been retired; that expression now errors with a dimensional-mismatch
+# diagnostic. The cancellation engine replaces it with a same-
+# category-only rule.
+total_data = bandwidth * 10 seconds

--- a/testdata/eval/success/features/rates.cm
+++ b/testdata/eval/success/features/rates.cm
@@ -78,3 +78,27 @@ scaled_qps_val = 10 * qps
 # diagnostic. The cancellation engine replaces it with a same-
 # category-only rule.
 total_data = bandwidth * 10 seconds
+
+# Rate × Duration with auto-conversion (v2.1) — AE1 from the
+# brainstorm: $100/hour × 3 weeks → $50,400. The duration converts
+# into the rate's PerUnit (3 weeks → 504 hours) before multiplying.
+hourly_cost = $100 / hour
+project_length = 3 weeks
+project_fee = hourly_cost * project_length
+
+# Chained Rate × Rate × Duration (v2.1) — AE2 from the brainstorm:
+# $100/hour × 40 hours/week × 3 weeks → $12,000. Left-associative
+# reduction: first Rate × Rate cancels hour to give $4000/week,
+# then Rate × Duration cancels week to give $12000.
+rate_per_hour = $100 / hour
+hours_per_week = 40 hours / week
+weekly_rate = rate_per_hour * hours_per_week
+total_salary = rate_per_hour * hours_per_week * 3 weeks
+
+# Speed Quantity × Duration (v2.1) — AE4 from the brainstorm:
+# 60 mph × 2 hours → 120 mi. The Speed-shaped Quantity widens to
+# its underlying Rate (60 mi/hour) before the cancellation engine
+# sees it.
+speed = 60 mph
+trip_duration = 2 hours
+trip_distance = speed * trip_duration


### PR DESCRIPTION
## Summary

Implements the rate-arithmetic plan from `docs/plans/2026-04-30-001-feat-rate-arithmetic-least-surprise-plan.md`. Targets `v2.1.0` post `v2.0.0` stable per the plan's scope; PR stays draft until v2.0.0 tags.

The user-facing principle (from the brainstorm at `docs/brainstorms/2026-04-30-rate-arithmetic-least-surprise-requirements.md`):

> **CalcMark works when a normal human reading the expression aloud would expect it to work — and refuses with a clear message when they wouldn't.**

## Progress

| Unit | Status | What |
|---|---|---|
| U1 — Generic category + conversion helpers | ✓ Shipped (`da38b99`) | `categoryOf` + `convertWithinCategory` foundations |
| U2 — Generalize cancellation engine | Pending | Predicate from `isTimeUnit` to category equality; retire line-367 silent-coercion |
| U3 — Currency identity preservation | Pending | `rateNumeratorAsResult` extended with `IsCurrencyCode` reverse-lookup |
| U4 — R6 refusal contract | Pending | Dimensional-mismatch errors with named-units substring contract |
| U6 — Speed-unit coercion (AE4) | Pending | `60 mph × 2 hours → 120 miles` via `coerceSpeedToRate` widening |
| U5 — Docs / registry / regression goldens | Pending | CHANGELOG promote, features registry, examples, rates.cm |

U1 establishes the foundation: time units short-circuit before falling through to `units.CategoryForUnit`, and `convertWithinCategory` dispatches by category to either `Duration.Convert` or `units.Convert`. 12 unit tests cover the contract surface.

## Verification (current state)

- `go build ./...` clean
- `go test ./...` green across every package
- 7 PR #148 time-only value tests still pass (brought forward unchanged)
- 12 new helper tests for U1 pass

## Why draft

The plan explicitly targets v2.1.0 post v2.0.0 stable. This PR stays draft until upstream tags v2.0.0; once that ships, this work is the natural follow-on for the v2.1 cycle.

## Continuing

When you resume, the next unit is U2 — the centerpiece work that swaps the cancellation predicate from `isTimeUnit` to `categoryOf` equality and retires the long-standing too-permissive `Rate × Quantity` rule at `operators.go:367-371`. U1's helpers + tests are the foundation U2 leans on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-velocity:pr:150 -->
### Metrics

Opened by `@dvhthomas` (agent-assisted) on 2026-04-30 21:15 UTC. Merged 2026-04-30 22:27 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 1h 11m  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
