### PR TITLE
fix(lsp): suppress completions on prose lines; variables only inside {{ ... }}

### DIFF
--- a/lsp/acceptance_test.go
+++ b/lsp/acceptance_test.go
@@ -711,3 +711,110 @@ func TestFrontmatter_Unit9_ExtraOnlyNoLSPResponse(t *testing.T) {
 		t.Errorf("expected Variable 'price' even with Extra-only frontmatter; got %+v", syms)
 	}
 }
+
+// TestBugB_ProseLineDoesNotSurfaceCompletions — cmw user-asked 2026-05-06:
+// typing prose like `some te` in a text block surfaced unit completions
+// (`teaspoon`, `terahertz`, `tesla`, …). The detector knows `some te` is
+// not a valid calculation; the LSP must consult that classifier and
+// suppress general completions for prose lines.
+func TestBugB_ProseLineDoesNotSurfaceCompletions(t *testing.T) {
+	source := "some te"
+	s, uri := prepareServerDoc(t, source)
+
+	// Cursor at end of `some te` — what the user types before the
+	// dropdown surfaces. col = 7.
+	items := completionAt(t, s, uri, 0, 7)
+
+	// Positive contract: nothing comes back. The classifier returns
+	// completionContextMarkdown which the handler maps to nil.
+	if len(items) != 0 {
+		var labels []string
+		for _, it := range items {
+			labels = append(labels, it.Label)
+		}
+		t.Errorf("prose line surfaced completions: %v", labels)
+	}
+}
+
+// TestBugB_KnownVariableLeadingPositionAdmitsCompletions — when a prior
+// line in the document defined `revenue`, typing `revenue *` is a calc
+// expression (variable * pending number/expr). Completions should still
+// fire so the user gets variable / function suggestions for the RHS.
+func TestBugB_KnownVariableLeadingPositionAdmitsCompletions(t *testing.T) {
+	source := "revenue = 1000\nrevenue * "
+	s, uri := prepareServerDoc(t, source)
+
+	// Line 1 is `revenue * ` — cursor at end (col = 10) is in the
+	// expression position. The classifier sees `revenue` as a known
+	// IDENT so the line is calc, not prose.
+	items := completionAt(t, s, uri, 1, 10)
+	if len(items) == 0 {
+		t.Fatal("expected completions for in-flight calc expression `revenue * `")
+	}
+}
+
+// TestBugB_InsideInterpolationReturnsVariableCompletionsOnly — inside
+// `{{ ... }}` in prose, the user is typing a variable reference. The
+// LSP returns variable items only (no functions, no units, no dates),
+// which keeps the dropdown focused on the only completion shape that
+// the interpolation syntax accepts.
+func TestBugB_InsideInterpolationReturnsVariableCompletionsOnly(t *testing.T) {
+	// Flat mode: top-level calc assignment defines `price`; subsequent
+	// lines (after a blank-line block boundary) are a text block where
+	// the user can write prose containing `{{ price }}` interpolation.
+	// The LSP server parses flat-mode sources via specDoc.NewDocument
+	// (see lsp/server.go evaluate); embedded fenced sources don't
+	// evaluate through this path, so this test stays in flat mode.
+	source := "price = 100\n\nThe total is {{ pri"
+	s, uri := prepareServerDoc(t, source)
+
+	// Line 2 is `The total is {{ pri` — cursor at end (col = 19).
+	items := completionAt(t, s, uri, 2, 19)
+	if len(items) == 0 {
+		t.Fatal("expected variable completion items inside `{{ ... }}` interpolation")
+	}
+
+	// Every returned item must be a variable. Functions / units / dates
+	// would clutter the dropdown for a slot that only accepts a var ref.
+	for _, it := range items {
+		d, ok := it.Data.(completionItemData)
+		if !ok {
+			t.Errorf("interpolation surfaced item %q with no data — likely a function/unit leak", it.Label)
+			continue
+		}
+		if d.Kind != "variable" {
+			t.Errorf("interpolation surfaced non-variable item: label=%q kind=%q", it.Label, d.Kind)
+		}
+	}
+
+	// And `price` specifically should be among the items.
+	var sawPrice bool
+	for _, it := range items {
+		if it.Label == "price" {
+			sawPrice = true
+			break
+		}
+	}
+	if !sawPrice {
+		t.Errorf("expected variable `price` in interpolation completions, got %v", itemLabels(items))
+	}
+}
+
+// TestBugB_AfterClosedInterpolationReturnsToProse — once the user has
+// typed the closing `}}`, subsequent typing is prose again and must
+// not surface completions.
+func TestBugB_AfterClosedInterpolationReturnsToProse(t *testing.T) {
+	source := "price = 100\n\nThe price is {{ price }} per unit te"
+	s, uri := prepareServerDoc(t, source)
+
+	// Line 2: cursor at end of `... per unit te` (col = 49 — past
+	// the closing `}}`, mid prose word). No completions should fire.
+	items := completionAt(t, s, uri, 2, 49)
+	if len(items) != 0 {
+		var labels []string
+		for _, it := range items {
+			labels = append(labels, it.Label)
+		}
+		t.Errorf("prose after closed interpolation surfaced completions: %v", labels)
+	}
+}

--- a/lsp/completion.go
+++ b/lsp/completion.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/CalcMark/go-calcmark/v2/spec/document"
 	"github.com/CalcMark/go-calcmark/v2/spec/features"
 	"github.com/CalcMark/go-calcmark/v2/spec/lexer"
 	"github.com/CalcMark/go-calcmark/v2/spec/types"
@@ -47,9 +48,16 @@ func (s *Server) textDocumentCompletion(_ *glsp.Context, params *protocol.Comple
 	// Determine prefix (text before cursor on this line, back to last non-identifier char)
 	prefix := features.ExtractPrefix(lineText, col)
 
+	// Build the doc-scoped known-names set so the classifier can admit
+	// lines whose leading IDENT is a known variable (`revenue * 0.1`
+	// after `revenue = 1000` earlier). Built-in constants and frontmatter
+	// globals don't need to be in this set — they don't change the
+	// markdown-vs-calc classification, only what completions resolve to.
+	knownNames := snapshotKnownNames(snap)
+
 	// Tokenize the line up to the cursor to determine context.
 	// This replaces string heuristics with the real lexer.
-	ctx := classifyCompletionContext(lineText, col)
+	ctx := classifyCompletionContext(lineText, col, knownNames)
 
 	// Detect enclosing function call and active parameter position — used for
 	// enum completions and type-filtered variable completions below.
@@ -58,6 +66,15 @@ func (s *Server) textDocumentCompletion(_ *glsp.Context, params *protocol.Comple
 	switch ctx {
 	case completionContextMarkdown:
 		return nil, nil
+
+	case completionContextInterpolation:
+		// Bug B (2026-05-06): cursor inside `{{ ... }}` in prose. Only
+		// variable references resolve here — surface those, nothing else.
+		// No required type filter (interpolation accepts any value).
+		if snap.Evaluator == nil {
+			return []protocol.CompletionItem{}, nil
+		}
+		return variableCompletionItems(snap, prefix, line, ""), nil
 
 	case completionContextAfterUnitKeyword:
 		// After "in" or "as" -> units + conversion keywords (napkin, precise)
@@ -188,18 +205,46 @@ const (
 	completionContextGeneral          completionContext = iota
 	completionContextAfterUnitKeyword                   // cursor is after "in" or "as"
 	completionContextMarkdown                           // line is markdown, suppress completions
+	// Cursor sits inside an open `{{ ... }}` interpolation in prose.
+	// The narrow contract: only variable references make sense here.
+	// No functions, no units, no dates. The result-pill / chip rendering
+	// machinery for embedded interpolation reads the same shape, so
+	// users can type `{{ pri` in prose and get `price`-style variable
+	// completions without surfacing the rest of the calc-language
+	// vocabulary alongside.
+	completionContextInterpolation
 )
+
+// detectorForCompletion is built once per process. The Detector is stateless
+// after construction (it just memoises lexer-trigger / IDENT-callable name
+// sets from the registry), so reusing one is safe across goroutines.
+var detectorForCompletion = document.NewDetector()
 
 // classifyCompletionContext tokenizes the line up to the cursor position and
 // determines the completion context from the token stream. This uses the real
 // lexer instead of string heuristics.
-func classifyCompletionContext(lineText string, col int) completionContext {
+//
+// `knownNames` is the doc-scoped set of identifiers assigned earlier in the
+// document. It lets us classify a leading-IDENT line like `revenue * 0.1`
+// as a calculation when `revenue` is a known variable, even though the
+// IDENT alone wouldn't admit it. Pass nil to apply the rule with no doc
+// context (treats every unknown leading IDENT as prose).
+func classifyCompletionContext(lineText string, col int, knownNames map[string]bool) completionContext {
 	// Truncate line to cursor position for tokenization
 	runes := []rune(lineText)
 	if col > len(runes) {
 		col = len(runes)
 	}
 	textBeforeCursor := string(runes[:col])
+
+	// Bug B (2026-05-06): cursor inside `{{ ... }}` opens a narrow
+	// completion context. The prose around the interpolation is markdown;
+	// only the slot between `{{` and `}}` accepts a variable reference.
+	// Detect first because the rest of the classifier walks lexer tokens
+	// that don't recognise `{{` / `}}` as anything special.
+	if insideInterpolation(textBeforeCursor) {
+		return completionContextInterpolation
+	}
 
 	// Try to tokenize. If the lexer produces no tokens, treat as markdown.
 	l := lexer.NewLexer(textBeforeCursor)
@@ -217,11 +262,11 @@ func classifyCompletionContext(lineText string, col int) completionContext {
 	}
 
 	if len(meaningful) == 0 {
-		// No tokens -> could be blank or pure prose
-		if isMarkdownLine(lineText) {
-			return completionContextMarkdown
-		}
-		return completionContextGeneral
+		// No tokens -> blank or pure prose. `isMarkdownLine` only
+		// catches explicit prefixes (#, >, -, *); falling through to
+		// general would surface unit / function completions on every
+		// blank line. Treat as markdown so the dropdown stays quiet.
+		return completionContextMarkdown
 	}
 
 	// Check if the line starts with a markdown prefix (headings, lists, blockquotes).
@@ -241,8 +286,6 @@ func classifyCompletionContext(lineText string, col int) completionContext {
 	if last.Type == lexer.IDENTIFIER && lastEndRune >= col {
 		if len(meaningful) >= 2 {
 			last = meaningful[len(meaningful)-2]
-		} else {
-			return completionContextGeneral
 		}
 	}
 
@@ -252,7 +295,79 @@ func classifyCompletionContext(lineText string, col int) completionContext {
 		return completionContextAfterUnitKeyword
 	}
 
+	// Bug B (2026-05-06): the line passed every "is this calc-shape?"
+	// heuristic above (no markdown prefix, has tokens, not after AS/IN),
+	// but it might still be plain prose like `some te` or `this is a
+	// sentence`. Run the detector's calc-vs-text token-shape classifier —
+	// same logic that decides whether a line lands in a calc block or a
+	// text block during normal block detection. If the detector says
+	// it's not calc, suppress completions.
+	//
+	// `knownNames` lets us admit lines whose leading IDENT is a known
+	// document variable (`revenue * 0.1` when `revenue` was assigned
+	// earlier). Without it, every IDENT-leading line that isn't a
+	// registered NL-trigger / function would classify as prose.
+	//
+	// We use `LooksLikeCalculation` (token-shape check) rather than
+	// `IsCalculationWithKnownNames` because the user is in-flight typing
+	// and the partial line — `accumulate(`, `compound 1000`,
+	// `revenue * ` — fails the strict parser even though it's
+	// unambiguously calc-shape. The token check is what `DetectBlocks`
+	// uses internally as its final classification step, so we get the
+	// same verdict without requiring full parser success.
+	if !detectorForCompletion.LooksLikeCalculation(lineText, knownNames) {
+		return completionContextMarkdown
+	}
+
 	return completionContextGeneral
+}
+
+// insideInterpolation returns true when `textBeforeCursor` ends inside an
+// open `{{ ... }}` group — i.e. there's a `{{` somewhere in the string and
+// no matching `}}` after it. Pure string scan, no tokenisation.
+//
+// Used to detect the variable-only completion context for prose like
+// `Hello {{ pri|`. Calc-block usage doesn't reach this helper (the
+// detector / parser handle calc lines first) so we don't worry about
+// `{{` appearing inside calc-source.
+func insideInterpolation(textBeforeCursor string) bool {
+	lastOpen := strings.LastIndex(textBeforeCursor, "{{")
+	if lastOpen == -1 {
+		return false
+	}
+	// If there's a `}}` between the last `{{` and the cursor, the
+	// interpolation already closed before we got here — back to prose.
+	if strings.Contains(textBeforeCursor[lastOpen+2:], "}}") {
+		return false
+	}
+	return true
+}
+
+// snapshotKnownNames returns the set of variable names defined anywhere in
+// the document, suitable for the calc-vs-text classifier in
+// `classifyCompletionContext`. Pure: builds a fresh map per call so the
+// caller can mutate it without affecting the snapshot.
+//
+// Built-in constants and frontmatter globals are intentionally included —
+// they're valid leading-IDENT references, so a line like `pi * radius`
+// should classify as calc even when the user hasn't assigned `pi` themselves.
+func snapshotKnownNames(snap *DocumentSnapshot) map[string]bool {
+	if snap == nil || snap.Evaluator == nil {
+		return nil
+	}
+	env := snap.Evaluator.GetEnvironment()
+	if env == nil {
+		return nil
+	}
+	all := env.GetAllVariables()
+	if len(all) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(all))
+	for name := range all {
+		out[name] = true
+	}
+	return out
 }
 
 // runeCountStr returns the number of runes in s[:byteOffset].

--- a/lsp/server_test.go
+++ b/lsp/server_test.go
@@ -254,27 +254,68 @@ func TestIsMarkdownLine(t *testing.T) {
 
 func TestClassifyCompletionContext(t *testing.T) {
 	tests := []struct {
-		name string
-		line string
-		col  int
-		want completionContext
+		name       string
+		line       string
+		col        int
+		knownNames map[string]bool
+		want       completionContext
 	}{
-		{"after in space", "100 meters in ", 14, completionContextAfterUnitKeyword},
-		{"after in typing", "100 meters in fe", 16, completionContextAfterUnitKeyword},
-		{"after as space", "price as ", 9, completionContextAfterUnitKeyword},
-		{"after as typing napkin", "price as nap", 12, completionContextAfterUnitKeyword},
-		{"general assignment", "a = 1 + 1", 9, completionContextGeneral},
-		{"general identifier", "acc", 3, completionContextGeneral},
-		{"markdown heading", "# Heading", 9, completionContextMarkdown},
-		{"markdown list", "- item", 6, completionContextMarkdown},
-		{"empty line", "", 0, completionContextMarkdown},
+		{name: "after in space", line: "100 meters in ", col: 14, want: completionContextAfterUnitKeyword},
+		{name: "after in typing", line: "100 meters in fe", col: 16, want: completionContextAfterUnitKeyword},
+		{name: "after as space", line: "price as ", col: 9, want: completionContextAfterUnitKeyword},
+		{name: "after as typing napkin", line: "price as nap", col: 12, want: completionContextAfterUnitKeyword},
+		{name: "general assignment", line: "a = 1 + 1", col: 9, want: completionContextGeneral},
+		// "acc" alone — leading IDENT is `acc`, not in knownNames, not a registered
+		// NL trigger or IDENT-callable function. Per Bug B (2026-05-06), bare prose
+		// like this is now classified as markdown so the LSP doesn't drown the
+		// dropdown with units / functions. (Earlier: was completionContextGeneral.)
+		{name: "bare identifier prose", line: "acc", col: 3, want: completionContextMarkdown},
+		{name: "markdown heading", line: "# Heading", col: 9, want: completionContextMarkdown},
+		{name: "markdown list", line: "- item", col: 6, want: completionContextMarkdown},
+		{name: "empty line", line: "", col: 0, want: completionContextMarkdown},
+
+		// Bug B (2026-05-06): the user's repro — typing prose in a text
+		// block triggered unit completions (`some te` → `teaspoon`,
+		// `terahertz`). The leading IDENT `some` is not in knownNames
+		// and not a registered NL trigger / function, so the line is
+		// prose and must classify as markdown.
+		{name: "prose with two IDENTs (some te)", line: "some te", col: 7, want: completionContextMarkdown},
+		{name: "prose mid-sentence", line: "this is a sentence wi", col: 21, want: completionContextMarkdown},
+
+		// Lines that ARE calculations under the registry — admit. The
+		// registry exposes `compound` as an NL trigger and `accumulate`
+		// as an IDENT-callable function; both should classify as
+		// general so the dropdown can surface argument completions.
+		{name: "NL trigger leading word", line: "compound 1000 USD", col: 17, want: completionContextGeneral},
+		{name: "registered ident function call", line: "accumulate(", col: 11, want: completionContextGeneral},
+
+		// knownNames bridge: a doc-defined variable in the leading
+		// position is admitted (e.g. `revenue * 0.1` after `revenue =
+		// 1000` earlier in the doc). Without doc context this would
+		// be prose; with it, calc.
+		{
+			name:       "known variable leading reference",
+			line:       "revenue * 0.1",
+			col:        13,
+			knownNames: map[string]bool{"revenue": true},
+			want:       completionContextGeneral,
+		},
+
+		// Interpolation: cursor inside `{{ ... }}` opens a narrow
+		// completion context that only surfaces variable references —
+		// the `{{ }}` syntax is reserved for variable interpolation
+		// in prose. Other tokens around the prose don't matter.
+		{name: "inside interpolation, prefix typed", line: "Hello {{ pri", col: 12, want: completionContextInterpolation},
+		{name: "inside interpolation, empty after open", line: "Order total: {{ ", col: 16, want: completionContextInterpolation},
+		// Closed interpolation: cursor is after `}}` — back to prose.
+		{name: "after closed interpolation, prose continues", line: "Hello {{ price }} now", col: 21, want: completionContextMarkdown},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := classifyCompletionContext(tt.line, tt.col)
+			got := classifyCompletionContext(tt.line, tt.col, tt.knownNames)
 			if got != tt.want {
-				t.Errorf("classifyCompletionContext(%q, %d) = %v, want %v", tt.line, tt.col, got, tt.want)
+				t.Errorf("classifyCompletionContext(%q, %d, %v) = %v, want %v", tt.line, tt.col, tt.knownNames, got, tt.want)
 			}
 		})
 	}

--- a/spec/document/detector.go
+++ b/spec/document/detector.go
@@ -256,6 +256,58 @@ func (d *Detector) IsCalculation(line string) (bool, error) {
 	return d.isCalculationWithKnownNames(line, nil)
 }
 
+// IsCalculationWithKnownNames classifies a single line like IsCalculation,
+// but admits lines whose leading identifier is in the doc-scoped
+// `knownNames` set (e.g. previously-assigned variables) as calculations.
+//
+// Use this from contexts that already know the document's defined
+// names — notably the LSP, where suppressing unit / function completions
+// on prose lines hinges on the same calc-vs-text decision the detector
+// makes when splitting blocks.
+//
+// A `nil` `knownNames` is equivalent to calling `IsCalculation`.
+func (d *Detector) IsCalculationWithKnownNames(line string, knownNames map[string]bool) (bool, error) {
+	return d.isCalculationWithKnownNames(line, knownNames)
+}
+
+// LooksLikeCalculation returns true when the token stream at the start of
+// a line has the syntactic shape of a CalcMark calculation. Like
+// IsCalculation it consults `knownNames` to admit references to
+// document-defined identifiers, but unlike IsCalculation it does NOT
+// require the line to parse end-to-end.
+//
+// Use this from in-flight-typing contexts (notably the LSP completion
+// provider) where the user's partial input — `accumulate(`, `compound 1000`,
+// `revenue * ` — fails the strict parser but is unambiguously calc-shape.
+// The token-shape check is what `DetectBlocks` uses internally as its
+// final step; this method exposes it directly for callers that already
+// have the line and want the detector's verdict without a full parse.
+//
+// `lineText` may be a single line (no terminating newline required).
+// Returns false for empty input. `knownNames` may be nil.
+func (d *Detector) LooksLikeCalculation(lineText string, knownNames map[string]bool) bool {
+	trimmed := strings.TrimSpace(lineText)
+	if trimmed == "" {
+		return false
+	}
+	if hasIndentedCodePrefix(lineText) {
+		return false
+	}
+	if isMarkdownPattern(trimmed) {
+		return false
+	}
+	lex := lexer.NewLexer(trimmed)
+	tokens, err := lex.Tokenize()
+	if err != nil {
+		return false
+	}
+	meaningful := filterNonNewlineTokens(tokens)
+	if len(meaningful) == 0 {
+		return false
+	}
+	return d.looksLikeCalculation(meaningful, knownNames)
+}
+
 func (d *Detector) isCalculationWithKnownNames(line string, knownNames map[string]bool) (bool, error) {
 	trimmed := strings.TrimSpace(line)
 


### PR DESCRIPTION
## Summary

cmw user-asked 2026-05-06: typing \`some te\` in a text block surfaced unit completions (\`teaspoon\`, \`terahertz\`, \`tesla\`, …). The LSP only flagged explicit markdown prefixes (\`#\`, \`>\`, \`-\`, \`*\`) as prose; everything else fell through to general completions.

The detector already knows \`some te\` isn't a calculation — it's the same logic that decides whether a line lands in a calc block or a text block during normal block detection. This PR teaches the LSP to consult that classifier.

Two new exported helpers on \`Detector\`:

- \`IsCalculationWithKnownNames(line, knownNames)\` — full parse + token-shape check.
- \`LooksLikeCalculation(line, knownNames)\` — token-shape check only. Critical for in-flight typing where partial input (\`accumulate(\`, \`compound 1000\`, \`revenue * \`) fails the strict parser even though the shape is unambiguously calc.

The LSP's \`classifyCompletionContext\` consults the token-shape variant, returning:

- \`completionContextMarkdown\` for prose → no completions.
- \`completionContextInterpolation\` (new) when cursor sits inside open \`{{ ... }}\` → variable-only completions.
- \`completionContextGeneral\` for actual calc lines → unchanged behavior.

The doc-scoped \`knownNames\` set comes from the snapshot's evaluator environment so lines like \`revenue * 0.1\` (after \`revenue = 1000\` earlier) are correctly admitted as calc.

## Test plan

- [x] \`TestClassifyCompletionContext\` extended with prose / NL-trigger / IDENT-callable function / known-variable-leading / interpolation cases — 14 tests pass.
- [x] 4 new \`TestBugB_*\` acceptance tests cover the full \`textDocumentCompletion\` flow:
  - prose line returns no completions
  - known-variable leading reference admits completions
  - inside \`{{ ... }}\` returns variable items only
  - prose after closed \`}}\` returns no completions
- [x] Full go-calcmark test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-velocity:pr:153 -->
### Metrics

Opened by `@dvhthomas` on 2026-05-07 04:27 UTC. Merged 2026-05-07 04:40 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 12m  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
