### PR TITLE
fix(detector): admit in-flight @directive / assignment lines as calc-shape

### DIFF
--- a/spec/document/detector.go
+++ b/spec/document/detector.go
@@ -296,9 +296,33 @@ func (d *Detector) LooksLikeCalculation(lineText string, knownNames map[string]b
 	if isMarkdownPattern(trimmed) {
 		return false
 	}
+	// Unambiguous calc-shape starters that the lexer rejects in their
+	// in-flight-typing form. Catch these BEFORE tokenising so callers
+	// (notably the LSP) get the right verdict for partial input the
+	// strict lexer chokes on.
+	//
+	// `@<word>.` (e.g. `@globals.`) is the documented incomplete shape
+	// for a directive field reference — the lexer raises
+	// `expected field name after '@globals.' (e.g., @globals.tax_rate)`
+	// and returns no tokens. There is no markdown construct that
+	// starts with `@` followed by a letter, so admit unconditionally.
+	// The follow-on completion path will surface the directive's
+	// fields, which is exactly the user's intent.
+	if isDirectiveLeadingShape(trimmed) {
+		return true
+	}
 	lex := lexer.NewLexer(trimmed)
 	tokens, err := lex.Tokenize()
 	if err != nil {
+		// In-flight `name = @globals.` on the RHS of an assignment
+		// also lex-errors on the trailing dot. The presence of an
+		// assignment `=` (not `==`/`!=`/`<=`/`>=`) is itself an
+		// unambiguous calc signal, so admit when we can find one.
+		// This covers the common "user typed `x = @globals.` and
+		// expected globals-field completions" path.
+		if hasAssignmentEquals(trimmed) {
+			return true
+		}
 		return false
 	}
 	meaningful := filterNonNewlineTokens(tokens)
@@ -306,6 +330,51 @@ func (d *Detector) LooksLikeCalculation(lineText string, knownNames map[string]b
 		return false
 	}
 	return d.looksLikeCalculation(meaningful, knownNames)
+}
+
+// hasAssignmentEquals returns true when `s` contains a `=` that isn't part of
+// a comparison operator (`==`, `!=`, `<=`, `>=`). Used as a fast calc-admit
+// for in-flight typing where the lexer chokes — the presence of a plain `=`
+// is enough signal that we're inside a calc assignment regardless of what
+// comes after.
+func hasAssignmentEquals(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] != '=' {
+			continue
+		}
+		// Skip `==`.
+		if i+1 < len(s) && s[i+1] == '=' {
+			i++ // step past the second `=`
+			continue
+		}
+		// Skip operators that precede `=`: `!`, `<`, `>`.
+		if i > 0 {
+			prev := s[i-1]
+			if prev == '!' || prev == '<' || prev == '>' {
+				continue
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// isDirectiveLeadingShape returns true when `trimmed` begins with `@<letter>`
+// — the shape of a directive reference (`@scale`, `@globals.tax_rate`,
+// `@convert_to`). Catches the in-flight `@globals.` case where the lexer's
+// strict directive validation rejects the dot without a following field.
+//
+// Pure: no side effects, no allocation. Used as a calc-admit fast path
+// from `LooksLikeCalculation`.
+func isDirectiveLeadingShape(trimmed string) bool {
+	if len(trimmed) < 2 {
+		return false
+	}
+	if trimmed[0] != '@' {
+		return false
+	}
+	c := trimmed[1]
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'
 }
 
 func (d *Detector) isCalculationWithKnownNames(line string, knownNames map[string]bool) (bool, error) {

--- a/spec/document/detector_test.go
+++ b/spec/document/detector_test.go
@@ -681,6 +681,57 @@ func TestDirectiveReferenceDetection(t *testing.T) {
 	}
 }
 
+// TestLooksLikeCalculation_InFlightDirectiveReference — the LSP completion
+// provider calls `LooksLikeCalculation` to decide whether a line in
+// in-flight typing is calc-shape. Directive references like
+// `@globals.tax_rate` complete cleanly through the lexer, but the
+// in-flight form `@globals.` (user has typed the dot, hasn't typed the
+// field name yet) raises a strict lexer error and returns no tokens.
+// Without a fast-path, the LSP would classify it as prose and suppress
+// the very completions the user is trying to invoke. This test pins the
+// "directive shape admits as calc even when the lexer rejects the
+// in-flight form" contract.
+func TestLooksLikeCalculation_InFlightDirectiveReference(t *testing.T) {
+	d := NewDetector()
+
+	calcShape := []string{
+		"@scale",
+		"@globals",
+		"@globals.",            // in-flight: dot typed, field pending
+		"@globals.t",           // in-flight: prefix typed
+		"@globals.tax_rate",    // complete
+		"@convert_to",
+		"x = @globals.",        // in-flight inside an assignment
+		"x = @globals.tax_rate",
+	}
+	for _, line := range calcShape {
+		t.Run("calc:"+line, func(t *testing.T) {
+			if !d.LooksLikeCalculation(line, nil) {
+				t.Errorf("LooksLikeCalculation(%q) = false, want true", line)
+			}
+		})
+	}
+
+	// Lines that LOOK like they might start with `@` but shouldn't admit:
+	// stray `@` followed by a digit / punctuation / whitespace is prose
+	// or a typo, not a directive reference. The narrow shape we admit
+	// is `@<letter>` only — see `isDirectiveLeadingShape`.
+	notCalcShape := []string{
+		"@",
+		"@ space",  // trailing space, no name
+		"@1",       // digit after @, not a directive
+		"@-",       // punctuation after @
+		"some prose with @ symbol",
+	}
+	for _, line := range notCalcShape {
+		t.Run("not-calc:"+line, func(t *testing.T) {
+			if d.LooksLikeCalculation(line, nil) {
+				t.Errorf("LooksLikeCalculation(%q) = true, want false", line)
+			}
+		})
+	}
+}
+
 // --- Phase 4e: Regression safety net ---
 // Parse all existing .cm files through DetectBlocks and record block type counts.
 // This prevents detector changes from silently reclassifying existing documents.


### PR DESCRIPTION
## Summary

Follow-up to #153 (v2.2.2). The new \`LooksLikeCalculation\` returned false on lexer errors, which tripped two real-world in-flight typing cases:

- \`@globals.\` — the lexer's strict directive validation rejects a trailing dot without a following field name and returns no tokens.
- \`x = @globals.\` — same error, just on the RHS of an assignment.

cmw's \`TestLSPDispatcher_AtGlobalsDot_ReturnsGlobalsFields\` regressed on the v2.2.2 bump because the LSP now classifies these as prose and suppresses the very completions the user is invoking.

Fix: two narrow fast-paths around the lexer-error branch.

1. \`isDirectiveLeadingShape(line)\` — if the line starts with \`@<letter>\`, admit unconditionally. No markdown construct starts with \`@\` followed by a letter.
2. \`hasAssignmentEquals(line)\` — when the lexer errors, if the line contains a plain \`=\` (not \`==\`/\`!=\`/\`<=\`/\`>=\`), admit. The presence of an assignment operator is itself unambiguous calc shape regardless of what's on either side.

## Test plan

- [x] 13-case \`TestLooksLikeCalculation_InFlightDirectiveReference\` covers \`@scale\`, \`@globals\`, \`@globals.\`, \`@globals.t\`, \`@globals.tax_rate\`, \`@convert_to\`, \`x = @globals.\`, \`x = @globals.tax_rate\` (positive) and \`@\`, \`@ space\`, \`@1\`, \`@-\`, \`some prose with @ symbol\` (negative).
- [x] Full go-calcmark suite green.
- [x] Verified locally: cmw \`TestLSPDispatcher_AtGlobalsDot_ReturnsGlobalsFields\` passes once cmw bumps to the post-merge version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-velocity:pr:154 -->
### Metrics

Opened by `@dvhthomas` on 2026-05-07 04:54 UTC. Merged 2026-05-07 04:54 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 9s  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
