### PR TITLE
fix(lsp): consult detector when lexer rejects in-flight input

### DIFF
--- a/lsp/completion.go
+++ b/lsp/completion.go
@@ -262,10 +262,16 @@ func classifyCompletionContext(lineText string, col int, knownNames map[string]b
 	}
 
 	if len(meaningful) == 0 {
-		// No tokens -> blank or pure prose. `isMarkdownLine` only
-		// catches explicit prefixes (#, >, -, *); falling through to
-		// general would surface unit / function completions on every
-		// blank line. Treat as markdown so the dropdown stays quiet.
+		// No tokens — could mean genuinely empty input, or that the
+		// lexer rejected the line entirely (notably `@globals.` and
+		// other in-flight directive forms it validates strictly).
+		// Defer to the detector's calc-vs-text check; it has its own
+		// fast paths for the cases the lexer rejects (`@<letter>`,
+		// lines containing a plain assignment `=`, …) and otherwise
+		// classifies as prose.
+		if detectorForCompletion.LooksLikeCalculation(lineText, knownNames) {
+			return completionContextGeneral
+		}
 		return completionContextMarkdown
 	}
 

--- a/lsp/server_test.go
+++ b/lsp/server_test.go
@@ -309,6 +309,17 @@ func TestClassifyCompletionContext(t *testing.T) {
 		{name: "inside interpolation, empty after open", line: "Order total: {{ ", col: 16, want: completionContextInterpolation},
 		// Closed interpolation: cursor is after `}}` — back to prose.
 		{name: "after closed interpolation, prose continues", line: "Hello {{ price }} now", col: 21, want: completionContextMarkdown},
+
+		// In-flight `@globals.` — the lexer rejects the trailing dot
+		// without a following field name and returns no tokens. The
+		// classifier must defer to the detector (which has a fast path
+		// for `@<letter>`) instead of treating "no tokens" as markdown.
+		// Otherwise the LSP suppresses the very globals-fields
+		// completions the user is invoking. (Regression: cmw's
+		// TestLSPDispatcher_AtGlobalsDot_ReturnsGlobalsFields broke on
+		// the v2.2.2 bump.)
+		{name: "in-flight @globals. directive", line: "@globals.", col: 9, want: completionContextGeneral},
+		{name: "in-flight assignment with @globals.", line: "x = @globals.", col: 13, want: completionContextGeneral},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Follow-up to #154 (v2.2.3). The detector's \`LooksLikeCalculation\` now has fast paths for in-flight \`@globals.\` and \`x = @globals.\` typing, but \`classifyCompletionContext\` short-circuited on \`len(meaningful) == 0\` BEFORE reaching that call. Result: cmw's \`TestLSPDispatcher_AtGlobalsDot_ReturnsGlobalsFields\` still failed after the v2.2.3 bump because the LSP returned \`markdown\` for the no-tokens case unconditionally.

## Fix

In the \`len(meaningful) == 0\` branch, defer to \`LooksLikeCalculation\` instead of hard-coding markdown. The detector has the right answer for both:

- \`@globals.\` (lexer-rejected directive shape) → calc, surface directive completions.
- Genuinely empty / blank lines → prose, suppress (Bug B).

## Test plan

- [x] Two new cases in \`TestClassifyCompletionContext\` pin the contract — \`@globals.\` and \`x = @globals.\` both classify as general, not markdown.
- [x] Full go-calcmark suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-velocity:pr:155 -->
### Metrics

Opened by `@dvhthomas` on 2026-05-07 05:03 UTC. Merged 2026-05-07 05:03 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 11s  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
