### PR TITLE
feat(period): explicit-year quarter syntax (CY2026 Q3, Q3 2026, FY2027 FQ1, …)

### DIFF
--- a/impl/interpreter/date_test.go
+++ b/impl/interpreter/date_test.go
@@ -1872,6 +1872,107 @@ func TestCalendarQuarterNotation(t *testing.T) {
 	}
 }
 
+// TestCalendarQuarterNotation_ExplicitYear — User-asked 2026-05-07:
+// `Q1`-`Q4` alone resolves to the current calendar year, but the user
+// needed syntax to specify a quarter of an explicit year. The parser
+// canonicalises every form (`2026 Q3`, `CY2026 Q3`, `Q3 2026`,
+// `Q3 CY2026`) to `Q:<n>@<year>`; this test pins the interpreter
+// dispatch on the explicit year regardless of the clock.
+func TestCalendarQuarterNotation_ExplicitYear(t *testing.T) {
+	// Clock at 2030 to prove the explicit year wins — without the
+	// fix, the test would resolve `Q3` to 2030 Q3.
+	clock := time.Date(2030, 1, 15, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		input     string
+		wantYear  int
+		wantMonth int
+		wantDay   int
+	}{
+		// Quarter-first orderings: parser produces `Q:3@2026` regardless
+		// of which token came first in the source.
+		{"Q3 followed by NUMBER year", "d = Q3 2026\n", 2026, 7, 1},
+		{"Q3 followed by CY year", "d = Q3 CY2026\n", 2026, 7, 1},
+		{"NUMBER year followed by Q3", "d = 2026 Q3\n", 2026, 7, 1},
+		{"CY year followed by Q3", "d = CY2026 Q3\n", 2026, 7, 1},
+		// Two-digit years follow the existing CY/FY 2-digit rule
+		// (CY26 → 2026); explicit year suffix gets the same expansion.
+		{"CY26 Q3 expands to 2026", "d = CY26 Q3\n", 2026, 7, 1},
+		{"Q3 CY26 expands to 2026", "d = Q3 CY26\n", 2026, 7, 1},
+		// Different quarters confirm we're routing on the parsed
+		// value, not coincidentally landing on Q3.
+		{"CY2027 Q1", "d = CY2027 Q1\n", 2027, 1, 1},
+		{"CY2025 Q4", "d = CY2025 Q4\n", 2025, 10, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interp := newTestInterpreterWithClock(clock)
+			nodes, err := parser.Parse(tt.input)
+			if err != nil {
+				t.Fatalf("Parse(%q) error = %v", tt.input, err)
+			}
+			results, err := interp.Eval(nodes)
+			if err != nil {
+				t.Fatalf("Eval(%q) error = %v", tt.input, err)
+			}
+			date := resultStartDate(t, results[0])
+			if date.Time.Year() != tt.wantYear || int(date.Time.Month()) != tt.wantMonth || date.Time.Day() != tt.wantDay {
+				t.Errorf("Got %d-%02d-%02d, want %d-%02d-%02d",
+					date.Time.Year(), int(date.Time.Month()), date.Time.Day(),
+					tt.wantYear, tt.wantMonth, tt.wantDay)
+			}
+		})
+	}
+}
+
+// TestFiscalQuarterNotation_ExplicitYear — companion to the calendar
+// case. `FY2027 FQ1` and `FQ1 FY2027` both produce `FQ:1@2027`; the
+// interpreter routes against the explicit fiscal year label.
+func TestFiscalQuarterNotation_ExplicitYear(t *testing.T) {
+	// Clock at 2030 (fiscal config: July → FY2031 in early 2030 with
+	// june-end label-mode). The explicit year overrides regardless.
+	clock := time.Date(2030, 8, 15, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name      string
+		input     string
+		wantYear  int
+		wantMonth int
+		wantDay   int
+	}{
+		// fiscal_year_starts: July 1, so FY2027 starts 2027-07-01.
+		// FQ1 of FY2027 = July 2027.
+		{"FY2027 FQ1", "d = FY2027 FQ1\n", 2027, 7, 1},
+		{"FQ1 FY2027", "d = FQ1 FY2027\n", 2027, 7, 1},
+		// 2-digit year expansion mirrors CY behaviour.
+		{"FY27 FQ1 expands to 2027", "d = FY27 FQ1\n", 2027, 7, 1},
+		{"FQ1 FY27 expands to 2027", "d = FQ1 FY27\n", 2027, 7, 1},
+		// Different fiscal quarters within the same FY.
+		{"FY2027 FQ3", "d = FY2027 FQ3\n", 2028, 1, 1}, // FQ3 = Jan of fiscal year+1
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			interp := newTestInterpreterWithClock(clock)
+			interp.SetFiscalYearStarts(7, 1)
+			nodes, err := parser.Parse(tt.input)
+			if err != nil {
+				t.Fatalf("Parse(%q) error = %v", tt.input, err)
+			}
+			results, err := interp.Eval(nodes)
+			if err != nil {
+				t.Fatalf("Eval(%q) error = %v", tt.input, err)
+			}
+			date := resultStartDate(t, results[0])
+			if date.Time.Year() != tt.wantYear || int(date.Time.Month()) != tt.wantMonth || date.Time.Day() != tt.wantDay {
+				t.Errorf("Got %d-%02d-%02d, want %d-%02d-%02d",
+					date.Time.Year(), int(date.Time.Month()), date.Time.Day(),
+					tt.wantYear, tt.wantMonth, tt.wantDay)
+			}
+		})
+	}
+}
+
 // TestFiscalQuarterNotation tests FQ1-FQ4 shorthand.
 func TestFiscalQuarterNotation(t *testing.T) {
 	clock := time.Date(2026, 8, 15, 0, 0, 0, 0, time.UTC)

--- a/impl/interpreter/datetime.go
+++ b/impl/interpreter/datetime.go
@@ -304,16 +304,40 @@ func (interp *Interpreter) evalNotation(keyword string, now time.Time) (types.Ty
 	}
 	prefix, value := strings.ToUpper(parts[0]), parts[1]
 
+	// User-asked 2026-05-07: explicit-year suffix `@YYYY`. The parser
+	// canonicalises year+quarter combinations (`CY2026 Q3`, `Q3 2026`,
+	// `FY2027 FQ1`, etc.) to `Q:<n>@<year>` / `FQ:<n>@<year>`. Strip
+	// the suffix here so the existing quarter dispatch can route
+	// against the explicit year instead of `now.Year() + yearOffset`.
+	// 2-digit years follow the same expansion rule the bare CY/FY
+	// notation uses (CY26 → 2026), so `Q:3@26` resolves to 2026.
+	explicitYear := 0
+	if at := strings.Index(value, "@"); at >= 0 {
+		yStr := value[at+1:]
+		value = value[:at]
+		if y, err := strconv.Atoi(yStr); err == nil {
+			if y < 100 {
+				y += 2000
+			}
+			explicitYear = y
+		}
+	}
+
 	switch prefix {
 	case "Q":
 		// v2.0: Q1-Q4 evaluates to Period (calendar quarter of the
 		// current calendar year). yearOffset shifts the year for
-		// `next Q1` / `last Q4`.
+		// `next Q1` / `last Q4`. An explicit `@YYYY` suffix overrides
+		// both — it's the user-typed year for `2026 Q3` / `CY2026 Q3`.
 		q, err := strconv.Atoi(value)
 		if err != nil || q < 1 || q > 4 {
 			return nil, fmt.Errorf("invalid calendar quarter: Q%s", value)
 		}
-		return types.NewCalendarQuarter(now.Year()+yearOffset, q)
+		year := now.Year() + yearOffset
+		if explicitYear != 0 {
+			year = explicitYear
+		}
+		return types.NewCalendarQuarter(year, q)
 
 	case "FQ":
 		if interp.fiscalYearStarts == nil {
@@ -327,8 +351,15 @@ func (interp *Interpreter) evalNotation(keyword string, now time.Time) (types.Ty
 		fyStartMonth := time.Month(fc.month)
 		fyStartDay := fc.day
 		// FQ1 starts at the fiscal year start; yearOffset selects
-		// next/last/this FY relative to `now`.
-		fy := fiscalYearWithDay(now, fyStartMonth, fyStartDay) + yearOffset
+		// next/last/this FY relative to `now`. Explicit `@YYYY`
+		// (`FY2027 FQ1`) overrides — that's the FY label the user
+		// typed.
+		var fy int
+		if explicitYear != 0 {
+			fy = explicitYear
+		} else {
+			fy = fiscalYearWithDay(now, fyStartMonth, fyStartDay) + yearOffset
+		}
 		fyStart := time.Date(fy, fyStartMonth, fyStartDay, 0, 0, 0, 0, time.UTC)
 		return types.NewFiscalQuarterWithMode(fyStart, q, fc.labelMode)
 

--- a/spec/parser/period_literal_test.go
+++ b/spec/parser/period_literal_test.go
@@ -363,3 +363,94 @@ func TestParser_DaysIn_AtEOF(t *testing.T) {
 		t.Fatal("expected parse error for `days in` at EOF")
 	}
 }
+
+// User-asked 2026-05-07: Q1-Q4 alone resolve to the current calendar
+// year, but there was no syntax to specify a quarter of an explicit
+// year. `CY2026 Q3` and `Q3 CY2026` parse-errored; `2026 Q3` lexed as
+// a Quantity (not a Period) because the lexer recognizes `<digits> Q<digit>`
+// as a quantity-shape token. Same gap for fiscal: `FY2027 FQ1` and
+// `FQ1 FY2027` parse-errored.
+//
+// The fix combines an adjacent year + quarter literal into a single
+// RelativeDateLiteral with a year-bearing keyword. Encoding:
+//
+//   `Q:<n>@<year>`   — calendar quarter <n> of calendar year <year>.
+//   `FQ:<n>@<year>`  — fiscal quarter <n> of fiscal year <year>.
+//
+// All four input forms canonicalise to the same keyword:
+//
+//   2026 Q3      → Q:3@2026
+//   CY2026 Q3    → Q:3@2026
+//   Q3 2026      → Q:3@2026
+//   Q3 CY2026    → Q:3@2026
+//
+// Two-digit years follow the existing CY/FY rule (CY26 → 2026), so
+// `CY26 Q3` keyword is `Q:3@26`; the interpreter expands at eval
+// time. The explicit-year suffix coexists with the directionless
+// `Q:3` (current year): the latter is unchanged.
+func TestParser_PeriodYearQuarterCombinations(t *testing.T) {
+	cases := []struct {
+		input       string
+		wantKeyword string
+	}{
+		// Calendar quarter + year, all four orderings + year shapes.
+		{"2026 Q3", "Q:3@2026"},
+		{"CY2026 Q3", "Q:3@2026"},
+		{"Q3 2026", "Q:3@2026"},
+		{"Q3 CY2026", "Q:3@2026"},
+		{"CY26 Q3", "Q:3@26"},
+		{"Q3 CY26", "Q:3@26"},
+		// Fiscal quarter + fiscal year.
+		{"FY2027 FQ1", "FQ:1@2027"},
+		{"FQ1 FY2027", "FQ:1@2027"},
+		{"FY27 FQ1", "FQ:1@27"},
+		{"FQ1 FY27", "FQ:1@27"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			n := parseFirstStmt(t, "x = "+tc.input)
+			expr := expressionFromAssignment(t, n)
+			rdl, ok := expr.(*ast.RelativeDateLiteral)
+			if !ok {
+				t.Fatalf("input %q: expected *ast.RelativeDateLiteral, got %T", tc.input, expr)
+			}
+			if rdl.Keyword != tc.wantKeyword {
+				t.Errorf("input %q: Keyword = %q, want %q", tc.input, rdl.Keyword, tc.wantKeyword)
+			}
+			// SourceText preserves both tokens with their original
+			// spacing — used in diagnostics + AST round-tripping.
+			if !strings.Contains(rdl.SourceText, "Q") &&
+				!strings.Contains(rdl.SourceText, "q") {
+				t.Errorf("input %q: SourceText missing quarter token: %q", tc.input, rdl.SourceText)
+			}
+		})
+	}
+}
+
+// The unchanged path: bare `Q1`-`Q4` and `CY2026` still produce the
+// pre-feature keyword shape. Documents that worked before continue
+// to work without any keyword shift.
+func TestParser_PeriodYearQuarterCombinations_BareFormUnchanged(t *testing.T) {
+	cases := []struct {
+		input       string
+		wantKeyword string
+	}{
+		{"Q1", "Q:1"},
+		{"Q4", "Q:4"},
+		{"CY2026", "CY:2026"},
+		{"FY27", "FY:27"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			n := parseFirstStmt(t, "x = "+tc.input)
+			expr := expressionFromAssignment(t, n)
+			rdl, ok := expr.(*ast.RelativeDateLiteral)
+			if !ok {
+				t.Fatalf("input %q: expected *ast.RelativeDateLiteral, got %T", tc.input, expr)
+			}
+			if rdl.Keyword != tc.wantKeyword {
+				t.Errorf("input %q: Keyword = %q, want %q", tc.input, rdl.Keyword, tc.wantKeyword)
+			}
+		})
+	}
+}

--- a/spec/parser/primary.go
+++ b/spec/parser/primary.go
@@ -306,6 +306,21 @@ func (p *RecursiveDescentParser) parsePrimary() (ast.Node, error) {
 			}, nil
 		}
 
+		// User-asked 2026-05-07: `2026 Q3` lexes as QUANTITY (`2026:Q3`)
+		// because the lexer matches `<digits>(SP)Q<digit>` as a quantity-
+		// shape token. Pre-fix that produced a Quantity with unit "Q3" —
+		// confusing because `length of q` errored ("got Quantity, not
+		// Period") even though the rendered form looked like a period.
+		// Promote to a calendar-quarter Period when the unit slot holds
+		// a Q1-Q4 / FQ1-FQ4 token. The encoding mirrors the parser's
+		// year-bearing keyword: `Q:<n>@<year>`.
+		if qPrefix, qNum, ok := matchQuarterUnit(unit); ok {
+			return &ast.RelativeDateLiteral{
+				Keyword:    qPrefix + ":" + qNum + "@" + parts[0],
+				SourceText: string(tok.OriginalText),
+			}, nil
+		}
+
 		// Regular quantity (unit of measurement)
 		return &ast.QuantityLiteral{
 			Value: parts[0],
@@ -346,6 +361,17 @@ func (p *RecursiveDescentParser) parsePrimary() (ast.Node, error) {
 	if p.match(lexer.CALENDAR_QUARTER_LITERAL, lexer.FISCAL_QUARTER_LITERAL,
 		lexer.FISCAL_YEAR_LITERAL, lexer.CALENDAR_YEAR_LITERAL) {
 		tok := p.previous()
+		// User-asked 2026-05-07: combine an adjacent year + quarter
+		// literal into a single Period. `CY2026 Q3`, `Q3 CY2026`,
+		// `FY2027 FQ1`, `FQ1 FY2027` all canonicalise to the same
+		// year-bearing keyword (`Q:3@2026`, `FQ:1@2027`). Bare forms
+		// (`Q1`, `CY2026`) are unchanged. See `tryCombinePeriodYearQuarter`.
+		if combinedKw, combinedSource, ok := p.tryCombinePeriodYearQuarter(tok); ok {
+			return &ast.RelativeDateLiteral{
+				Keyword:    combinedKw,
+				SourceText: combinedSource,
+			}, nil
+		}
 		// Encode as RelativeDateLiteral with prefix+value keyword
 		// e.g., "Q:1", "FQ:3", "FY:2026", "CY:26"
 		prefix := notationLiteralPrefix(tok.Type)
@@ -1015,6 +1041,93 @@ func notationLiteralPrefix(t lexer.TokenType) string {
 		return "CY"
 	}
 	return ""
+}
+
+// tryCombinePeriodYearQuarter examines the token immediately after a
+// notation literal (Q/FQ/CY/FY) and, if it's the complementary literal
+// (a year after a quarter, or a quarter after a year, with matching
+// calendar/fiscal flavor), consumes it and returns a year-bearing
+// keyword.
+//
+// All four input orderings canonicalise to the quarter-first form:
+//
+//   `Q3 2026`      → Q:3@2026
+//   `Q3 CY2026`    → Q:3@2026
+//   `2026 Q3`      → handled in the QUANTITY branch (separate path).
+//   `CY2026 Q3`    → Q:3@2026  (we flip when we see year-then-quarter)
+//   `FQ1 FY2027`   → FQ:1@2027
+//   `FY2027 FQ1`   → FQ:1@2027
+//
+// Returns ("", "", false) when the next token isn't a complementary
+// literal — caller falls back to the existing single-token path. Pure:
+// only inspects + advances tokens.
+func (p *RecursiveDescentParser) tryCombinePeriodYearQuarter(first lexer.Token) (string, string, bool) {
+	next := p.peek()
+	switch first.Type {
+	case lexer.CALENDAR_QUARTER_LITERAL:
+		// `Q3` followed by a year-shape token. Bare NUMBER is admitted
+		// as a calendar year (matches the existing `2026 Q3` quantity-
+		// shape behaviour); CY-literals are admitted explicitly. FY
+		// literals are NOT admitted with a calendar quarter — that
+		// would mix calendars and would need separate semantics.
+		if next.Type == lexer.NUMBER || next.Type == lexer.CALENDAR_YEAR_LITERAL {
+			p.advance()
+			return "Q:" + string(first.Value) + "@" + string(next.Value),
+				string(first.OriginalText) + " " + string(next.OriginalText), true
+		}
+	case lexer.FISCAL_QUARTER_LITERAL:
+		// `FQ1` followed by a fiscal-year literal. Bare NUMBER is NOT
+		// admitted here — `FQ1 2027` is ambiguous (calendar or fiscal
+		// year?), require explicit `FY` to disambiguate.
+		if next.Type == lexer.FISCAL_YEAR_LITERAL {
+			p.advance()
+			return "FQ:" + string(first.Value) + "@" + string(next.Value),
+				string(first.OriginalText) + " " + string(next.OriginalText), true
+		}
+	case lexer.CALENDAR_YEAR_LITERAL:
+		// `CY2026` followed by `Q3` — flip to the quarter-first
+		// canonical encoding so downstream sees one shape regardless
+		// of input order.
+		if next.Type == lexer.CALENDAR_QUARTER_LITERAL {
+			p.advance()
+			return "Q:" + string(next.Value) + "@" + string(first.Value),
+				string(first.OriginalText) + " " + string(next.OriginalText), true
+		}
+	case lexer.FISCAL_YEAR_LITERAL:
+		// `FY2027` followed by `FQ1` — same flip for fiscal.
+		if next.Type == lexer.FISCAL_QUARTER_LITERAL {
+			p.advance()
+			return "FQ:" + string(next.Value) + "@" + string(first.Value),
+				string(first.OriginalText) + " " + string(next.OriginalText), true
+		}
+	}
+	return "", "", false
+}
+
+// matchQuarterUnit detects when a QUANTITY token's unit slot holds a
+// quarter literal (Q1-Q4, FQ1-FQ4), so `2026 Q3` (which the lexer
+// pre-folds into a single QUANTITY token) can be promoted from a
+// Quantity to a calendar-quarter Period at the parser level. Returns
+// (prefix, number, true) on match, ("", "", false) otherwise.
+//
+// Case-insensitive — the lexer canonicalises units to lower-case but
+// the original-text path may surface mixed case; matching on either
+// is the safer contract.
+func matchQuarterUnit(unit string) (string, string, bool) {
+	if len(unit) >= 2 && (unit[0] == 'Q' || unit[0] == 'q') {
+		// Q[1-4]
+		if len(unit) == 2 && unit[1] >= '1' && unit[1] <= '4' {
+			return "Q", string(unit[1]), true
+		}
+	}
+	if len(unit) >= 3 && (unit[0] == 'F' || unit[0] == 'f') &&
+		(unit[1] == 'Q' || unit[1] == 'q') {
+		// FQ[1-4]
+		if len(unit) == 3 && unit[2] >= '1' && unit[2] <= '4' {
+			return "FQ", string(unit[2]), true
+		}
+	}
+	return "", "", false
 }
 
 // diagnostic messages.


### PR DESCRIPTION
## Summary

cmw user-asked 2026-05-07: \`Q1\`-\`Q4\` alone resolves to the current calendar year, but pre-fix there was no way to specify a quarter of a SPECIFIC year. \`q = CY2026 Q3\` parse-errored; \`q = 2026 Q3\` quietly produced a Quantity (not a Period — \`length of q\` errored).

This patch admits the natural orderings as a single Period literal:

| Input | Resolves to |
|---|---|
| \`2026 Q3\` | Q3 of CY2026 |
| \`CY2026 Q3\` | Q3 of CY2026 |
| \`CY26 Q3\` | Q3 of CY2026 (2-digit expansion mirrors bare CY rule) |
| \`Q3 2026\` | Q3 of CY2026 |
| \`Q3 CY2026\` | Q3 of CY2026 |
| \`FY2027 FQ1\` | FQ1 of FY2027 |
| \`FQ1 FY2027\` | FQ1 of FY2027 |
| \`FY27 FQ1\` / \`FQ1 FY27\` | FQ1 of FY2027 |

All four orderings canonicalise at the parser to the quarter-first encoding \`Q:<n>@<year>\` / \`FQ:<n>@<year>\`. The interpreter strips the \`@<year>\` suffix and routes against the explicit year, falling back to \`now.Year() + yearOffset\` when the suffix is absent — so bare \`Q1\`-\`Q4\` and \`CY2026\` keep their pre-fix shape.

## Three-layer change

1. **\`spec/parser/primary.go\`** — \`tryCombinePeriodYearQuarter\` peeks past a notation literal for its complement and consumes both when found. Bare-NUMBER years are admitted only with calendar quarters (no ambiguity); fiscal quarters require an explicit \`FY\` prefix to avoid \`FQ1 2027\`'s "calendar 2027 or fiscal 2027?" question. The QUANTITY branch (which the lexer pre-folds for \`2026 Q3\`) is also promoted from Quantity to Period via \`matchQuarterUnit\`.

2. **\`impl/interpreter/datetime.go\`** — \`evalNotation\` parses the \`@YYYY\` suffix off the keyword's value half. Two-digit years follow the same expansion rule the bare CY/FY notation uses.

3. **No AST changes** — the encoding rides on \`RelativeDateLiteral.Keyword\` (string-encoded suffix), keeping the AST shape stable for downstream consumers.

## Test plan

- [x] \`TestParser_PeriodYearQuarterCombinations\` — 10 cases pinning every input ordering produces the canonical keyword.
- [x] \`TestParser_PeriodYearQuarterCombinations_BareFormUnchanged\` — 4 cases proving the pre-fix shape still works.
- [x] \`TestCalendarQuarterNotation_ExplicitYear\` — 8 cases proving the explicit year wins over the clock.
- [x] \`TestFiscalQuarterNotation_ExplicitYear\` — 5 cases for fiscal.
- [x] Full go-calcmark suite green (30 packages, fresh run).
- [x] \`task release:dogfood\` against cmw — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-velocity:pr:157 -->
### Metrics

Opened by `@dvhthomas` on 2026-05-07 19:32 UTC. Merged 2026-05-07 19:32 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 9s  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
