### PR TITLE
fix(detector): admit `5% of` and other unambiguous calc-shape partials

### DIFF
--- a/spec/document/detector.go
+++ b/spec/document/detector.go
@@ -394,36 +394,90 @@ func (d *Detector) isCalculationWithKnownNames(line string, knownNames map[strin
 		return false, nil
 	}
 
-	// Try to parse the line as a CalcMark expression/statement
-	// If parsing fails, it's text (markdown)
+	// Try to parse the line as a CalcMark expression/statement.
 	source := trimmed
 	if !strings.HasSuffix(source, "\n") {
 		source += "\n"
 	}
-	_, err := parser.Parse(source)
-	if err != nil {
-		// Parse error = not valid CalcMark syntax = treat as markdown
-		return false, nil
-	}
+	_, parseErr := parser.Parse(source)
 
-	// Successfully parsed - it's a valid calculation
-	// But we still need to check if it LOOKS like a calculation vs prose
-	// (e.g., "Hello" parses as an identifier but is likely prose)
-	// Use lexer-based heuristics for this final check
+	// Tokenize for the shape check below + the parser-failure fallback.
 	lex := lexer.NewLexer(trimmed)
-	tokens, err := lex.Tokenize()
-	if err != nil {
+	tokens, lexErr := lex.Tokenize()
+	if lexErr != nil {
+		// Lexer rejected the line — historically classified as text
+		// at the BLOCK level. Pre-existing tests (`octothorpe in
+		// calc expressions` etc.) depend on this behaviour: a calc
+		// line with a stray `#` lexes-error and stays as text. Don't
+		// add the LooksLikeCalculation fast paths here; they belong
+		// at the line-shape API for in-flight typing, not at block
+		// detection where the parser is the strict gate.
 		return false, nil
 	}
 
-	// Filter out NEWLINE tokens for analysis
 	meaningfulTokens := filterNonNewlineTokens(tokens)
 	if len(meaningfulTokens) == 0 {
 		return false, nil
 	}
 
-	// A valid calculation must have recognizable structure
+	if parseErr != nil {
+		// User-asked 2026-05-07: `5% of` mid-typing classified as
+		// text because the strict parser rejected the partial input.
+		// But `5% of <RHS>` is unambiguously calc-shape, so the user
+		// expects the editor to stay in calc context the whole way
+		// through.
+		//
+		// Trade-off: we can't fall through to `looksLikeCalculation`
+		// unconditionally — NL-trigger English prose like
+		// `Read more about this topic` lexes with `Read` as a
+		// recognised IDENT lead and would over-admit (regression
+		// against `TestNLFunctionVariableDetection`). The parser's
+		// rejection of those lines IS the right signal for prose
+		// disambiguation.
+		//
+		// Narrow the fall-through to leading shapes that English
+		// prose never starts with: number-shaped tokens (`5`, `5%`,
+		// `5K`), an opening paren, a leading `=` (anonymous calc),
+		// a unary minus, or a currency literal. IDENT-leading
+		// partial parses stay TEXT, preserving the prose
+		// classification path.
+		first := meaningfulTokens[0]
+		if isCalcUnambiguousLeader(first.Type) {
+			return true, nil
+		}
+		return false, nil
+	}
+
+	// Parser succeeded — this is a well-formed calc statement. But
+	// `Hello` parses as a bare identifier; the token-shape check
+	// (`looksLikeCalculation`) is what filters those out as prose.
 	return d.looksLikeCalculation(meaningfulTokens, knownNames), nil
+}
+
+// isCalcUnambiguousLeader returns true when the given leading token
+// type is shape-only enough to admit a partial line as calc even when
+// the parser rejects it. Lines starting with these tokens are not
+// confusable with English prose.
+//
+// Used by `isCalculationWithKnownNames` to admit in-flight typing
+// like `5% of` (NUMBER_PERCENT lead) or `(1 + 2` (LPAREN lead) as
+// calc while keeping NL-trigger prose (`Read more...`) classified as
+// text per the parser's rejection.
+func isCalcUnambiguousLeader(t lexer.TokenType) bool {
+	if isNumberToken(t) {
+		return true
+	}
+	switch t {
+	case lexer.ASSIGN, // anonymous calc: `= expr`
+		lexer.LPAREN,       // parenthesised expression
+		lexer.AT_SIGN,      // directive reference
+		lexer.CURRENCY,     // ISO currency code: USD, EUR
+		lexer.CURRENCY_SYM, // currency symbol: $, €
+		lexer.QUANTITY,     // `5kg`, `100 USD` (lexer pre-folds)
+		lexer.MINUS:        // unary negation: `-5`
+		return true
+	}
+	return false
 }
 
 // filterNonNewlineTokens returns tokens excluding NEWLINE and EOF.

--- a/spec/document/detector_test.go
+++ b/spec/document/detector_test.go
@@ -650,6 +650,98 @@ func TestStandaloneSumOfDetection(t *testing.T) {
 	}
 }
 
+// TestDetector_PercentOfPartialIsCalc — User-asked 2026-05-07: typing
+// `5% of` (with the RHS not yet entered) currently classified as text
+// because the strict parser rejected the partial input. The user
+// expected to stay in calc context the whole way through — `5% of` is
+// unambiguously calc-shape and the editor should not flip out of
+// calc mode just because the line isn't finished yet.
+//
+// The fix admits parser-rejected lines as calc when the leading token
+// is one English prose never starts with (numbers, `=`, `(`, `@`,
+// currency, unary minus). NL-trigger English prose like
+// `Read more...` (IDENT-leading) stays text per the parser's
+// rejection — that's the regression line tested in
+// `TestNLFunctionVariableDetection`.
+func TestDetector_PercentOfPartialIsCalc(t *testing.T) {
+	detector := NewDetector()
+
+	// Calc-shape: every form of percent-of, complete or in-flight.
+	calcCases := []string{
+		"5%",
+		"5% of",
+		"5% of 10",
+		"5% of revenue",
+		"x = 5% of 10",
+		"x = 10% of revenue",
+	}
+	for _, src := range calcCases {
+		t.Run("calc:"+src, func(t *testing.T) {
+			blocks, err := detector.DetectBlocks(src)
+			if err != nil {
+				t.Fatalf("DetectBlocks(%q) error: %v", src, err)
+			}
+			if len(blocks) != 1 {
+				t.Fatalf("Expected 1 block for %q, got %d", src, len(blocks))
+			}
+			if blocks[0].Type() != BlockCalculation {
+				t.Errorf("Expected calculation for %q, got %v", src, blocks[0].Type())
+			}
+		})
+	}
+
+	// Other unambiguous calc-shape leaders — pin the broader contract,
+	// not just `5% of`. Each line parser-rejects (incomplete) but
+	// MUST classify as calc because English prose never starts this
+	// way.
+	otherUnambiguous := []string{
+		"5K",       // NUMBER_K leading
+		"5 +",      // NUMBER + binary op (in-flight)
+		"(5",       // open paren
+		"= 5",      // anonymous calc
+		"$1k",      // currency leading
+		"-5 +",     // unary minus + in-flight
+	}
+	for _, src := range otherUnambiguous {
+		t.Run("calc:"+src, func(t *testing.T) {
+			blocks, err := detector.DetectBlocks(src)
+			if err != nil {
+				t.Fatalf("DetectBlocks(%q) error: %v", src, err)
+			}
+			if len(blocks) != 1 {
+				t.Fatalf("Expected 1 block for %q, got %d", src, len(blocks))
+			}
+			if blocks[0].Type() != BlockCalculation {
+				t.Errorf("Expected calculation for %q, got %v", src, blocks[0].Type())
+			}
+		})
+	}
+
+	// Regression-safety: NL-trigger English prose stays text. The
+	// IDENT-leading + parser-rejected combination is the prose
+	// signal; the fix narrows the parser-failure fallback to non-
+	// IDENT leaders so these stay classified correctly.
+	textCases := []string{
+		"Read more about this topic",
+		"Compress your files before uploading",
+		"Transfer money to your account",
+	}
+	for _, src := range textCases {
+		t.Run("text:"+src, func(t *testing.T) {
+			blocks, err := detector.DetectBlocks(src)
+			if err != nil {
+				t.Fatalf("DetectBlocks(%q) error: %v", src, err)
+			}
+			if len(blocks) != 1 {
+				t.Fatalf("Expected 1 block for %q, got %d", src, len(blocks))
+			}
+			if blocks[0].Type() != BlockText {
+				t.Errorf("Expected text for %q, got %v", src, blocks[0].Type())
+			}
+		})
+	}
+}
+
 // TestDirectiveReferenceDetection verifies that lines containing @directive
 // references are classified as calculations.
 func TestDirectiveReferenceDetection(t *testing.T) {


### PR DESCRIPTION
cmw user-asked 2026-05-07: typing `5% of` defaulted to text. Parser rejection of the partial input was hard-text-classified.

Fix: when parser rejects, fall through to a token-shape check that admits as calc when the leading token is one English prose never starts with (numbers, `=`, `(`, `@`, currency, unary minus). IDENT-leading partials stay text — that's the regression lane for NL prose (`Read more about this topic`).

15-case test (full percent-of matrix + other unambiguous leaders + three NL-prose regression lines). Full suite + dogfood green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-velocity:pr:158 -->
### Metrics

Opened by `@dvhthomas` on 2026-05-07 21:01 UTC. Merged 2026-05-07 21:01 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 9s  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
