### PR TITLE
fix(lsp): admit bare-IDENT-prefix-of-known-function as calc-shape for completion

### DIFF
--- a/lsp/acceptance_test.go
+++ b/lsp/acceptance_test.go
@@ -818,3 +818,50 @@ func TestBugB_AfterClosedInterpolationReturnsToProse(t *testing.T) {
 		t.Errorf("prose after closed interpolation surfaced completions: %v", labels)
 	}
 }
+
+// TestBareIdentPrefix_FreshCalcLine_SurfacesFunctionCompletions —
+// the user-flagged 2026-05-07 regression. v2.2.4 tightened the
+// completion classifier so a single-IDENT line like `com` on a
+// fresh line classified as prose and returned no completions. The
+// strict block-detector classifier intentionally rejects bare
+// IDENTs (so a paragraph with the word `compound` on a line stays
+// a text block), but the LSP completion path uses the lenient
+// `LooksLikeCalculationForCompletion` variant which admits a bare
+// IDENT when it matches a registered function-name prefix.
+//
+// Pins: source `x = 100\ncom`, cursor at end of `com` on line 1,
+// expect `compound` in the completion labels. If this test ever
+// fails, autocomplete on the first character of a function name
+// has regressed in the LSP.
+func TestBareIdentPrefix_FreshCalcLine_SurfacesFunctionCompletions(t *testing.T) {
+	source := "x = 100\ncom"
+	s, uri := prepareServerDoc(t, source)
+
+	// Line 1 (0-indexed): cursor at end of `com` — character 3.
+	items := completionAt(t, s, uri, 1, 3)
+
+	labels := itemLabels(items)
+	if !slices.Contains(labels, "compound") {
+		t.Fatalf("expected `compound` in completion labels for bare-IDENT prefix `com`; got %v", labels)
+	}
+}
+
+// TestBareIdentPrefix_NonFunctionWord_NoCompletions — the lenient
+// classifier admits ONLY bare IDENTs that match a registered
+// function-name prefix. Arbitrary prose words like `alpha` or
+// `xyz` do NOT trigger the admit, preserving the prose-protection
+// fix that v2.2.2 / v2.2.4 originally shipped.
+func TestBareIdentPrefix_NonFunctionWord_NoCompletions(t *testing.T) {
+	source := "x = 100\nalpha"
+	s, uri := prepareServerDoc(t, source)
+
+	// Line 1: cursor at end of `alpha` — character 5.
+	items := completionAt(t, s, uri, 1, 5)
+	if len(items) != 0 {
+		var labels []string
+		for _, it := range items {
+			labels = append(labels, it.Label)
+		}
+		t.Errorf("bare-IDENT non-function word surfaced completions; got labels=%v", labels)
+	}
+}

--- a/lsp/completion.go
+++ b/lsp/completion.go
@@ -269,7 +269,14 @@ func classifyCompletionContext(lineText string, col int, knownNames map[string]b
 		// fast paths for the cases the lexer rejects (`@<letter>`,
 		// lines containing a plain assignment `=`, …) and otherwise
 		// classifies as prose.
-		if detectorForCompletion.LooksLikeCalculation(lineText, knownNames) {
+		//
+		// Use the completion-lenient variant so a single bare IDENT
+		// that matches a registered function prefix (`com` for
+		// `compound`) admits as calc-shape. The strict variant
+		// classifies bare IDENTs as prose because that shape is
+		// also a common prose word — but in the LSP context the
+		// user is mid-typing a function call and expects autocomplete.
+		if detectorForCompletion.LooksLikeCalculationForCompletion(lineText, knownNames) {
 			return completionContextGeneral
 		}
 		return completionContextMarkdown
@@ -314,14 +321,18 @@ func classifyCompletionContext(lineText string, col int, knownNames map[string]b
 	// earlier). Without it, every IDENT-leading line that isn't a
 	// registered NL-trigger / function would classify as prose.
 	//
-	// We use `LooksLikeCalculation` (token-shape check) rather than
-	// `IsCalculationWithKnownNames` because the user is in-flight typing
+	// We use `LooksLikeCalculationForCompletion` (token-shape check
+	// with the function-prefix admit) rather than the strict
+	// `LooksLikeCalculation` because the user is in-flight typing
 	// and the partial line — `accumulate(`, `compound 1000`,
-	// `revenue * ` — fails the strict parser even though it's
-	// unambiguously calc-shape. The token check is what `DetectBlocks`
-	// uses internally as its final classification step, so we get the
-	// same verdict without requiring full parser success.
-	if !detectorForCompletion.LooksLikeCalculation(lineText, knownNames) {
+	// `revenue * `, or just bare `com` — fails the strict parser
+	// even though it's unambiguously calc-shape from the user's
+	// perspective. The strict variant rejects bare-IDENT lines as
+	// prose; the completion-lenient variant admits them when they
+	// match a registered function prefix, preserving block-detection
+	// safety while giving the user autocomplete on the first
+	// keystroke past the prefix length threshold.
+	if !detectorForCompletion.LooksLikeCalculationForCompletion(lineText, knownNames) {
 		return completionContextMarkdown
 	}
 

--- a/lsp/server_test.go
+++ b/lsp/server_test.go
@@ -265,11 +265,22 @@ func TestClassifyCompletionContext(t *testing.T) {
 		{name: "after as space", line: "price as ", col: 9, want: completionContextAfterUnitKeyword},
 		{name: "after as typing napkin", line: "price as nap", col: 12, want: completionContextAfterUnitKeyword},
 		{name: "general assignment", line: "a = 1 + 1", col: 9, want: completionContextGeneral},
-		// "acc" alone — leading IDENT is `acc`, not in knownNames, not a registered
-		// NL trigger or IDENT-callable function. Per Bug B (2026-05-06), bare prose
-		// like this is now classified as markdown so the LSP doesn't drown the
-		// dropdown with units / functions. (Earlier: was completionContextGeneral.)
-		{name: "bare identifier prose", line: "acc", col: 3, want: completionContextMarkdown},
+		// "acc" alone — leading IDENT is `acc`, the prefix of registered
+		// IDENT-callable function `accumulate`. The completion-lenient
+		// classifier (`LooksLikeCalculationForCompletion`) admits this
+		// shape so the user gets autocomplete on the first character of
+		// a function name. The strict block-detector classifier still
+		// rejects bare IDENTs as prose — only the LSP completion path
+		// uses the lenient variant. (Earlier 2026-05-06: classified as
+		// markdown after Bug B; restored as general 2026-05-08 after
+		// the cmw user-flagged regression.)
+		{name: "bare identifier function prefix", line: "acc", col: 3, want: completionContextGeneral},
+		// "xyz" — single-IDENT line that does NOT match any registered
+		// function prefix. The lenient variant correctly rejects it
+		// because the admit gate is "matches a recognised IDENT lead",
+		// not "is any single IDENT". Arbitrary prose words stay
+		// markdown.
+		{name: "bare identifier non-function word", line: "xyz", col: 3, want: completionContextMarkdown},
 		{name: "markdown heading", line: "# Heading", col: 9, want: completionContextMarkdown},
 		{name: "markdown list", line: "- item", col: 6, want: completionContextMarkdown},
 		{name: "empty line", line: "", col: 0, want: completionContextMarkdown},

--- a/spec/document/detector.go
+++ b/spec/document/detector.go
@@ -332,6 +332,81 @@ func (d *Detector) LooksLikeCalculation(lineText string, knownNames map[string]b
 	return d.looksLikeCalculation(meaningful, knownNames)
 }
 
+// LooksLikeCalculationForCompletion is the LSP-completion variant of
+// `LooksLikeCalculation`. It returns true for everything the strict
+// classifier already admits AND admits one extra shape: a single bare
+// IDENTIFIER whose value is a case-insensitive prefix of any
+// registered IDENT-callable function name (or NL trigger keyword).
+//
+// Why a separate method? `LooksLikeCalculation` is used by
+// `DetectBlocks` to decide whether a line in a document becomes a
+// calc block. A paragraph in prose containing the single word
+// `compound` on its own line should stay a text block — the strict
+// classifier's "single bare IDENT → prose" rule is correct there.
+//
+// But the LSP completion provider has the user typing in-flight: the
+// cursor sits at the end of `com` on a fresh line and the user
+// expects `compound` to autosuggest. The same conservative rule that
+// protects block detection silences autocomplete on the very first
+// character of a function name — the regression cmw flagged on
+// 2026-05-07. The lenient variant admits the bare-prefix case only
+// when the prefix matches the registered function-name set, so
+// arbitrary prose words like `alpha` or `hello` still classify as
+// markdown.
+//
+// Block-detection callers MUST keep using `LooksLikeCalculation`.
+// LSP completion classifiers SHOULD use this variant.
+func (d *Detector) LooksLikeCalculationForCompletion(lineText string, knownNames map[string]bool) bool {
+	if d.LooksLikeCalculation(lineText, knownNames) {
+		return true
+	}
+	trimmed := strings.TrimSpace(lineText)
+	if trimmed == "" {
+		return false
+	}
+	if hasIndentedCodePrefix(lineText) {
+		return false
+	}
+	if isMarkdownPattern(trimmed) {
+		return false
+	}
+	lex := lexer.NewLexer(trimmed)
+	tokens, err := lex.Tokenize()
+	if err != nil {
+		return false
+	}
+	meaningful := filterNonNewlineTokens(tokens)
+	if len(meaningful) != 1 {
+		return false
+	}
+	if meaningful[0].Type != lexer.IDENTIFIER {
+		return false
+	}
+	return d.matchesRecognisedIdentLeadPrefix(meaningful[0].Value)
+}
+
+// matchesRecognisedIdentLeadPrefix returns true when `prefix` is a
+// case-insensitive prefix of any registered IDENT-callable function
+// name or NL trigger keyword (the union held in
+// `recognisedIdentLeads`). Used by `LooksLikeCalculationForCompletion`
+// to admit the bare-IDENT-prefix completion case.
+//
+// Pure scan — no allocation in the hot path beyond what `strings.HasPrefix`
+// requires. The recognisedIdentLeads map is already lower-cased at
+// construction (`NewDetector`).
+func (d *Detector) matchesRecognisedIdentLeadPrefix(prefix string) bool {
+	if prefix == "" {
+		return false
+	}
+	lower := strings.ToLower(prefix)
+	for name := range d.recognisedIdentLeads {
+		if strings.HasPrefix(name, lower) {
+			return true
+		}
+	}
+	return false
+}
+
 // hasAssignmentEquals returns true when `s` contains a `=` that isn't part of
 // a comparison operator (`==`, `!=`, `<=`, `>=`). Used as a fast calc-admit
 // for in-flight typing where the lexer chokes — the presence of a plain `=`

--- a/spec/document/detector_test.go
+++ b/spec/document/detector_test.go
@@ -695,12 +695,12 @@ func TestDetector_PercentOfPartialIsCalc(t *testing.T) {
 	// MUST classify as calc because English prose never starts this
 	// way.
 	otherUnambiguous := []string{
-		"5K",       // NUMBER_K leading
-		"5 +",      // NUMBER + binary op (in-flight)
-		"(5",       // open paren
-		"= 5",      // anonymous calc
-		"$1k",      // currency leading
-		"-5 +",     // unary minus + in-flight
+		"5K",   // NUMBER_K leading
+		"5 +",  // NUMBER + binary op (in-flight)
+		"(5",   // open paren
+		"= 5",  // anonymous calc
+		"$1k",  // currency leading
+		"-5 +", // unary minus + in-flight
 	}
 	for _, src := range otherUnambiguous {
 		t.Run("calc:"+src, func(t *testing.T) {
@@ -789,11 +789,11 @@ func TestLooksLikeCalculation_InFlightDirectiveReference(t *testing.T) {
 	calcShape := []string{
 		"@scale",
 		"@globals",
-		"@globals.",            // in-flight: dot typed, field pending
-		"@globals.t",           // in-flight: prefix typed
-		"@globals.tax_rate",    // complete
+		"@globals.",         // in-flight: dot typed, field pending
+		"@globals.t",        // in-flight: prefix typed
+		"@globals.tax_rate", // complete
 		"@convert_to",
-		"x = @globals.",        // in-flight inside an assignment
+		"x = @globals.", // in-flight inside an assignment
 		"x = @globals.tax_rate",
 	}
 	for _, line := range calcShape {
@@ -810,15 +810,106 @@ func TestLooksLikeCalculation_InFlightDirectiveReference(t *testing.T) {
 	// is `@<letter>` only — see `isDirectiveLeadingShape`.
 	notCalcShape := []string{
 		"@",
-		"@ space",  // trailing space, no name
-		"@1",       // digit after @, not a directive
-		"@-",       // punctuation after @
+		"@ space", // trailing space, no name
+		"@1",      // digit after @, not a directive
+		"@-",      // punctuation after @
 		"some prose with @ symbol",
 	}
 	for _, line := range notCalcShape {
 		t.Run("not-calc:"+line, func(t *testing.T) {
 			if d.LooksLikeCalculation(line, nil) {
 				t.Errorf("LooksLikeCalculation(%q) = true, want false", line)
+			}
+		})
+	}
+}
+
+// TestLooksLikeCalculationForCompletion_BareFunctionPrefix — the LSP
+// completion provider needs to admit a single bare IDENTIFIER whose
+// value is the prefix of a registered IDENT-callable function name.
+// The strict classifier (`LooksLikeCalculation`) treats a single-IDENT
+// line as prose because that shape is also a common prose word — but
+// in the LSP context the user is typing the first character of a
+// function call and EXPECTS autocomplete on the very first keystroke
+// past the prefix length threshold.
+//
+// `LooksLikeCalculationForCompletion` returns true for everything
+// `LooksLikeCalculation` already does, PLUS the bare-function-prefix
+// case. Block-detection still uses the strict variant — this lenient
+// variant is for completion classification only.
+func TestLooksLikeCalculationForCompletion_BareFunctionPrefix(t *testing.T) {
+	d := NewDetector()
+
+	// Lines whose only token is an IDENT prefix of a registered
+	// function name. Every registered IDENT-callable function in the
+	// registry contributes — `compound`, `accumulate`, `compress`,
+	// etc. — so users get autocomplete from the first character.
+	functionPrefixes := []string{
+		"com",        // compound, compress, …
+		"comp",       // compound, compress
+		"compound",   // exact match
+		"acc",        // accumulate
+		"accumulate", // exact match
+	}
+	for _, line := range functionPrefixes {
+		t.Run("calc:"+line, func(t *testing.T) {
+			if !d.LooksLikeCalculationForCompletion(line, nil) {
+				t.Errorf("LooksLikeCalculationForCompletion(%q) = false, want true", line)
+			}
+		})
+	}
+
+	// Strict variant must still reject these — block detection cannot
+	// promote a single bare-IDENT line to a calc block. Only the
+	// completion classifier benefits from the lenient admit.
+	for _, line := range functionPrefixes {
+		t.Run("strict-still-rejects:"+line, func(t *testing.T) {
+			if d.LooksLikeCalculation(line, nil) {
+				t.Errorf("LooksLikeCalculation(%q) = true, want false (strict variant must stay conservative)", line)
+			}
+		})
+	}
+
+	// Lines that are NOT function-name prefixes — must still classify
+	// as not-calc even under the lenient variant. The lenient variant
+	// admits ONLY for shapes that match the registered function set;
+	// arbitrary words remain prose.
+	nonFunctionPrefixes := []string{
+		"alpha",   // not a function
+		"hello",   // not a function
+		"xyz",     // not a function
+		"some",    // not a function (multi-token "some te" was Bug B's case)
+		"qrandom", // not a function
+	}
+	for _, line := range nonFunctionPrefixes {
+		t.Run("not-calc:"+line, func(t *testing.T) {
+			if d.LooksLikeCalculationForCompletion(line, nil) {
+				t.Errorf("LooksLikeCalculationForCompletion(%q) = true, want false", line)
+			}
+		})
+	}
+
+	// Strict-variant admits flow through unchanged.
+	calcShape := []string{
+		"x = 5",
+		"5 + 3",
+		"@globals.tax",
+		"sum(1, 2, 3)",
+	}
+	for _, line := range calcShape {
+		t.Run("strict-calc-flows-through:"+line, func(t *testing.T) {
+			if !d.LooksLikeCalculationForCompletion(line, nil) {
+				t.Errorf("LooksLikeCalculationForCompletion(%q) = false, want true (strict variant admits)", line)
+			}
+		})
+	}
+
+	// Empty / whitespace-only lines remain non-calc.
+	empty := []string{"", "   ", "\t"}
+	for _, line := range empty {
+		t.Run("not-calc-empty:"+line, func(t *testing.T) {
+			if d.LooksLikeCalculationForCompletion(line, nil) {
+				t.Errorf("LooksLikeCalculationForCompletion(%q) = true, want false (empty)", line)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

The cmw user-flagged 2026-05-07 regression: typing `com` on a fresh calc line returned no completions, even though `compound` is a registered function. v2.2.4 (PR #155) tightened `classifyCompletionContext` to defer to `LooksLikeCalculation` so prose like `some te` would no longer surface unit completions. The fix was correct for prose, but also silenced the user-expected entry-point for autocomplete on the first character of a function name.

## Root cause

`LooksLikeCalculation` rejects a single bare IDENT line as prose by design — the same shape (`compound` alone on a line) is common in prose, and the strict block-detector classifier must keep those lines as text blocks. The LSP completion path was using the strict classifier, which is the wrong tool for in-flight typing.

## Fix

Split into two classifier methods:

- `LooksLikeCalculation` (strict, **unchanged**) — used by `DetectBlocks`. Single bare IDENT → prose.
- `LooksLikeCalculationForCompletion` (**new**, lenient) — used by the LSP `classifyCompletionContext`. Returns true for everything the strict variant admits AND for a single bare IDENT whose value is a case-insensitive prefix of any registered IDENT-callable function name or NL trigger keyword.

Block detection is unaffected. Only the LSP completion classifier benefits from the lenient admit. The non-function-prefix case stays gated: bare IDENT lines like `alpha`, `xyz`, or `hello` still classify as markdown because they don't match any name in `recognisedIdentLeads`. Bug B's prose-suppression intent is preserved (the v2.2.2 fix for `some te` → `teaspoon` still holds because that's a multi-token line).

## Tests

- `spec/document/detector_test.go` — `TestLooksLikeCalculationForCompletion_BareFunctionPrefix` pins the lenient/strict split: function prefixes admit under the lenient variant, strict still rejects, non-function words remain markdown under both, strict-calc shapes flow through, empty lines stay non-calc.
- `lsp/acceptance_test.go` — `TestBareIdentPrefix_FreshCalcLine_SurfacesFunctionCompletions` pins the user-flagged regression: source `x = 100\ncom`, cursor at end of `com` on line 1, expect `compound` in completion labels. Plus `TestBareIdentPrefix_NonFunctionWord_NoCompletions` for the prose-protection gate.
- `lsp/server_test.go` — `TestClassifyCompletionContext` updated: `acc` now classifies as General (it's the prefix of `accumulate`); added `xyz` case (non-function word) still classifies as Markdown.

## Verification

- Full `task test` green.
- `task release:dogfood` passes against cmw's task check (174 test files, 2660 tests).

## Test plan

- [x] `task test` green
- [x] `task release:dogfood` green against cmw
- [ ] Tag v2.2.7 after merge
- [ ] Bump cmw go.mod to v2.2.7 and remove cmw-side bareIdentifierFunctionFallback workaround

<!-- gh-velocity:pr:159 -->
### Metrics

Opened by `@dvhthomas` on 2026-05-08 17:54 UTC. Merged 2026-05-08 19:38 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 1h 43m  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
