### PR TITLE
test: lock in variable +/- percentage widening (cmw#83)

### DIFF
--- a/impl/interpreter/percentage_test.go
+++ b/impl/interpreter/percentage_test.go
@@ -66,3 +66,73 @@ func TestPercentageCalculations(t *testing.T) {
 		})
 	}
 }
+
+// TestPercentageWideningOnVariableRef covers issue #83: a variable that
+// holds a Number, Currency, or unit-bearing Quantity must widen under
+// `+ N%` / `- N%` identically to the underlying literal. Regression lock
+// for the user-asked patterns `base = $100; base + 5%` and `test = 1K;
+// test + 5%` so future refactors of the widening path cannot silently
+// regress identifier resolution before widening.
+func TestPercentageWideningOnVariableRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "currency variable + and - percent",
+			input:    "base = $100\nbase + 5%\nbase - 5%\n",
+			expected: []string{"$100.00", "$105.00", "$95.00"},
+		},
+		{
+			name:     "K-suffix variable + and - percent",
+			input:    "test = 1K\ntest + 5%\ntest - 5%\n",
+			expected: []string{"1000", "1050", "950"},
+		},
+		{
+			name:     "unit-quantity variable + and - percent",
+			input:    "x = 500g\nx + 5%\nx - 5%\n",
+			expected: []string{"500 g", "525 g", "475 g"},
+		},
+		{
+			name:     "EUR currency variable + and - percent",
+			input:    "y = 100 EUR\ny + 5%\ny - 5%\n",
+			expected: []string{"EUR100.00", "EUR105.00", "EUR95.00"},
+		},
+		{
+			name:     "bare number variable + and - percent",
+			input:    "n = 100\nn + 5%\nn - 5%\n",
+			expected: []string{"100", "105", "95"},
+		},
+		{
+			name:     "variable widened result assigned to another variable",
+			input:    "base = $100\nmarked_up = base + 5%\nmarked_up\n",
+			expected: []string{"$100.00", "$105.00", "$105.00"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes, err := parser.Parse(tt.input)
+			if err != nil {
+				t.Fatalf("Parse error: %v", err)
+			}
+
+			interp := interpreter.NewInterpreter()
+			results, err := interp.Eval(nodes)
+			if err != nil {
+				t.Fatalf("Eval error: %v", err)
+			}
+
+			if len(results) != len(tt.expected) {
+				t.Fatalf("expected %d results, got %d", len(tt.expected), len(results))
+			}
+
+			for i, want := range tt.expected {
+				if got := results[i].String(); got != want {
+					t.Errorf("results[%d] = %q, want %q", i, got, want)
+				}
+			}
+		})
+	}
+}

--- a/testdata/eval/success/features/percentage_widening_variable.cm
+++ b/testdata/eval/success/features/percentage_widening_variable.cm
@@ -1,0 +1,43 @@
+# Percentage Widening on Variables
+# Regression lock for issue #83: a variable that holds a Number,
+# Currency, or unit-bearing Quantity must widen under `+ N%` / `- N%`
+# identically to the underlying literal.
+
+## Currency variable
+base = $100
+# Expected: $100.00
+base + 5%
+# Expected: $105.00
+base - 5%
+# Expected: $95.00
+
+## K-suffix variable
+test = 1K
+# Expected: 1000
+test + 5%
+# Expected: 1050
+test - 5%
+# Expected: 950
+
+## Unit-quantity variable
+mass = 500g
+# Expected: 500 g
+mass + 5%
+# Expected: 525 g
+mass - 5%
+# Expected: 475 g
+
+## EUR currency variable
+eur = 100 EUR
+# Expected: EUR100.00
+eur + 5%
+# Expected: EUR105.00
+eur - 5%
+# Expected: EUR95.00
+
+## Widened result stored in another variable
+price = $100
+marked_up = price + 5%
+# Expected: $105.00
+discounted = price - 5%
+# Expected: $95.00


### PR DESCRIPTION
## Summary
- Adds regression tests that lock in the contract from CalcMark/cmw#83: a variable reference must widen under `+ N%` / `- N%` identically to the underlying literal.
- Verified end-to-end (`cm --format text`) that the behavior already works on `main` for every shape called out in the issue. This PR pins that behavior so future refactors of the widening path can't silently regress identifier resolution before widening.
- **No behavior change — tests-only.** Intended for a v2.2.8 patch immediately after merge.

## What's covered
| Shape | Example |
|---|---|
| Currency variable | `base = $100; base + 5%` → `$105.00` |
| K-suffix variable | `test = 1K; test + 5%` → `1050` |
| Unit-quantity variable | `mass = 500g; mass - 5%` → `475 g` |
| EUR currency variable | `eur = 100 EUR; eur + 5%` → `EUR105.00` |
| Bare number variable | `n = 100; n + 5%` → `105` |
| Widened result re-assigned | `marked_up = base + 5%` → `$105.00` |

## Test plan
- [x] `go test ./impl/interpreter/ -run TestPercentageWideningOnVariableRef`
- [x] `go test ./cmd/calcmark/ -run TestGoldenExpectedValues/percentage_widening_variable.cm`
- [x] `task test` full suite
- [ ] `task release:dogfood` before tagging v2.2.8

Refs CalcMark/cmw#83 (per the issue author, that issue belongs in this repo exclusively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-velocity:pr:161 -->
### Metrics

Opened by `@dvhthomas` (agent-assisted) on 2026-05-11 18:09 UTC. Merged 2026-05-11 18:11 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 1m  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
