### PR TITLE
feat(lsp): deliver calc keyword-operator forms over completion

### DIFF
--- a/lsp/argctx.go
+++ b/lsp/argctx.go
@@ -30,6 +30,14 @@ type argumentContext struct {
 	// the user sees `grow X by Y over Z months` while typing the NL
 	// form, instead of `grow(amount, increment, periods)`.
 	isNL bool
+	// requiredType, when non-empty, is the expected argument type at the
+	// cursor independent of any function spec. It is set for keyword-
+	// operator operands (e.g. the percentage operand of `X% of Y`) where
+	// there is no enclosing function call to look up a ParamSpec from. The
+	// completion handler prefers this over the funcName/paramIdx path so
+	// variable suggestions are type-filtered the same way they are inside
+	// a function call.
+	requiredType types.ArgType
 }
 
 // extractArgumentContext scans lineText from the start up to col and reports
@@ -92,9 +100,19 @@ func extractArgumentContext(lineText string, col int) argumentContext {
 	}
 
 	if len(stack) == 0 {
+		// Natural-language *function* forms win first (`grow 100 by 20`,
+		// `average of 1, 2, 3`), so a known function keyword like `of` in
+		// `average of …` resolves to its function rather than the bare
+		// percentage operator below.
 		nl := extractNLArgumentContext(lineText, col)
 		if nl.funcName != "" {
 			nl.isNL = true
+			return nl
+		}
+		// No enclosing function: try the keyword-operator forms, which type
+		// their operands (e.g. the percentage operand of `X% of Y`).
+		if kw, ok := extractKeywordArgumentContext(lineText, col); ok {
+			return kw
 		}
 		return nl
 	}
@@ -293,6 +311,88 @@ func resolveNLFunctionName(name string) string {
 	}
 
 	return ""
+}
+
+// extractKeywordArgumentContext recognizes keyword-operator expressions that
+// are NOT function calls and types the operand under the cursor, so variable
+// completions there are filtered the same way function arguments are.
+//
+// Recognized forms (detection is structural — keyed on the operator phrase,
+// not on a literal `%` — so it still fires while the user is mid-typing a
+// variable into a placeholder, e.g. `myrate of 1000`):
+//
+//   - `A as % of B` / `A as a % of B` — inverse percentage. Both operands are
+//     same-type amounts (currency, quantity, number), so we surface amounts
+//     and exclude percentage variables. Checked first because it also
+//     contains ` of `.
+//   - `A of B` — percentage of a value. Operand A is a percentage; operand B
+//     (the base) is left unfiltered.
+//   - `A in unit` / `A as unit` — unit conversion. Operand A is a quantity.
+//     The unit side is served separately by completionContextAfterUnitKeyword.
+//
+// Returns ok=false when the line is not one of these forms, or when the cursor
+// sits in a position with no meaningful type constraint (so the caller falls
+// through to unfiltered completion).
+func extractKeywordArgumentContext(lineText string, col int) (argumentContext, bool) {
+	runes := []rune(lineText)
+	if col > len(runes) {
+		col = len(runes)
+	}
+	lower := []rune(strings.ToLower(lineText))
+
+	// Inverse percentage — both operands are amounts. Check before plain
+	// ` of ` since this phrase also contains it.
+	for _, phrase := range []string{" as a % of ", " as % of "} {
+		if runeIndex(lower, phrase) >= 0 {
+			return argumentContext{paramIdx: -1, requiredType: types.ArgTypeAmount}, true
+		}
+	}
+
+	// Percentage of a value: the operand before ` of ` is a percentage.
+	if s := runeIndex(lower, " of "); s >= 0 {
+		if col <= s {
+			return argumentContext{paramIdx: -1, requiredType: types.ArgTypePercentage}, true
+		}
+		// Operand B (the base) accepts any value — nothing to filter.
+		return argumentContext{}, false
+	}
+
+	// Unit conversion: the operand before ` in `/` as ` is a quantity.
+	for _, phrase := range []string{" in ", " as "} {
+		if s := runeIndex(lower, phrase); s >= 0 {
+			if col <= s {
+				return argumentContext{paramIdx: -1, requiredType: types.ArgTypeQuantity}, true
+			}
+			// After the keyword the completion handler is already in the
+			// after-unit-keyword context; nothing to type here.
+			return argumentContext{}, false
+		}
+	}
+
+	return argumentContext{}, false
+}
+
+// runeIndex returns the rune index of the first occurrence of needle in
+// haystack, or -1. Rune-aware so multi-byte text before the match doesn't
+// skew the offset (callers compare against a rune-indexed cursor column).
+func runeIndex(haystack []rune, needle string) int {
+	nr := []rune(needle)
+	if len(nr) == 0 || len(nr) > len(haystack) {
+		return -1
+	}
+	for i := 0; i+len(nr) <= len(haystack); i++ {
+		match := true
+		for j := range nr {
+			if haystack[i+j] != nr[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
 }
 
 // extractLeadingIdentifier returns the first identifier at the start of s.

--- a/lsp/argctx_test.go
+++ b/lsp/argctx_test.go
@@ -1,6 +1,10 @@
 package lsp
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/CalcMark/go-calcmark/v2/spec/types"
+)
 
 func TestExtractArgumentContext(t *testing.T) {
 	cases := []struct {
@@ -360,6 +364,81 @@ func TestFindNumericLiterals(t *testing.T) {
 			if len(lits) != tc.want {
 				t.Errorf("findNumericLiterals(%q, %d) found %d literals, want %d",
 					tc.input, tc.startIdx, len(lits), tc.want)
+			}
+		})
+	}
+}
+
+// TestExtractArgumentContext_KeywordOperands verifies that keyword-operator
+// expressions type their operands so variable completions get filtered the
+// same way function arguments are — even with no enclosing function call.
+func TestExtractArgumentContext_KeywordOperands(t *testing.T) {
+	cases := []struct {
+		name     string
+		line     string
+		col      int
+		wantType types.ArgType
+	}{
+		{
+			name:     "percent-of left operand is a percentage",
+			line:     "23% of 1000",
+			col:      1, // inside "23%"
+			wantType: types.ArgTypePercentage,
+		},
+		{
+			name:     "percent-of left operand while typing a variable",
+			line:     "myrate of 1000",
+			col:      3, // inside "myrate"
+			wantType: types.ArgTypePercentage,
+		},
+		{
+			name:     "percent-of with assignment prefix",
+			line:     "pct = 23% of 1000",
+			col:      8, // inside "23%"
+			wantType: types.ArgTypePercentage,
+		},
+		{
+			name:     "percent-of base operand is unfiltered",
+			line:     "23% of 1000",
+			col:      9, // inside "1000"
+			wantType: "",
+		},
+		{
+			name:     "as-%-of operands are amounts",
+			line:     "$100 as % of $500",
+			col:      2, // inside "$100"
+			wantType: types.ArgTypeAmount,
+		},
+		{
+			name:     "as-a-%-of operands are amounts",
+			line:     "100 as a % of 500",
+			col:      1,
+			wantType: types.ArgTypeAmount,
+		},
+		{
+			name:     "conversion left operand is a quantity",
+			line:     "5 kg in oz",
+			col:      0, // on the '5'
+			wantType: types.ArgTypeQuantity,
+		},
+		{
+			name:     "average of is the avg function, not a percentage operand",
+			line:     "average of 1, 2, 3",
+			col:      15, // on the '2'
+			wantType: "",
+		},
+		{
+			name:     "plain arithmetic has no keyword type",
+			line:     "x = 100 + 200",
+			col:      5,
+			wantType: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := extractArgumentContext(tc.line, tc.col)
+			if ctx.requiredType != tc.wantType {
+				t.Errorf("requiredType = %q, want %q", ctx.requiredType, tc.wantType)
 			}
 		})
 	}

--- a/lsp/completion.go
+++ b/lsp/completion.go
@@ -92,8 +92,14 @@ func (s *Server) textDocumentCompletion(_ *glsp.Context, params *protocol.Comple
 		}
 
 		// Determine active parameter type for variable filtering, if any.
+		// A keyword-operator operand (e.g. the percentage operand of
+		// `X% of Y`) carries its type directly and takes precedence; only
+		// when it is absent do we look up an enclosing function's ParamSpec.
 		var requiredType types.ArgType
-		if argCtx.funcName != "" && !argCtx.insideString {
+		switch {
+		case argCtx.requiredType != "":
+			requiredType = argCtx.requiredType
+		case argCtx.funcName != "" && !argCtx.insideString:
 			if spec := types.GetFunctionSpec(argCtx.funcName); spec != nil {
 				if p := spec.GetParamAtIndex(argCtx.paramIdx); p != nil {
 					requiredType = p.Type
@@ -101,9 +107,10 @@ func (s *Server) textDocumentCompletion(_ *glsp.Context, params *protocol.Comple
 			}
 		}
 
-		// General context -> functions, units, variables, directives, dates
+		// General context -> functions, keywords, units, variables, directives, dates
 		var items []protocol.CompletionItem
 		items = append(items, functionCompletionItems(prefix)...)
+		items = append(items, keywordCompletionItems(prefix)...)
 		items = append(items, unitCompletionItems(prefix)...)
 		items = append(items, dateCompletionItems(prefix)...)
 		if snap.Evaluator != nil {
@@ -193,6 +200,45 @@ func functionCompletionItems(prefix string) []protocol.CompletionItem {
 				Data: data,
 			})
 		}
+	}
+
+	return items
+}
+
+// keywordCompletionItems returns snippet completion items for the calc
+// keyword-operator forms (`X% of Y`, `X as a % of Y`, `X in unit`). Delegates
+// to features.KeywordSuggestions for the canonical templates, then attaches
+// the LSP-specific snippet format and structured data so clients (slash
+// palette, inline completion) get the same delivery vehicle functions use.
+//
+// The snippet `InsertText` from the registry already carries `${N:default}`
+// placeholders with units/`%` correctly absorbed (see the registry keyword
+// block), so — unlike the NL-function path — it is shipped verbatim without
+// re-running buildNLExampleSnippet.
+func keywordCompletionItems(prefix string) []protocol.CompletionItem {
+	suggestions := features.KeywordSuggestions(prefix)
+	var items []protocol.CompletionItem
+
+	for _, s := range suggestions {
+		kind := protocol.CompletionItemKindKeyword
+		detail := s.Syntax
+		insertText := s.InsertText
+		snippetFormat := protocol.InsertTextFormatSnippet
+		items = append(items, protocol.CompletionItem{
+			Label:            s.Name,
+			Kind:             &kind,
+			Detail:           &detail,
+			InsertText:       &insertText,
+			InsertTextFormat: &snippetFormat,
+			Documentation: &protocol.MarkupContent{
+				Kind:  protocol.MarkupKindMarkdown,
+				Value: s.Description,
+			},
+			Data: completionItemData{
+				Kind:    "keyword",
+				Keyword: s.Name,
+			},
+		})
 	}
 
 	return items

--- a/lsp/completion_data.go
+++ b/lsp/completion_data.go
@@ -61,6 +61,10 @@ type completionItemData struct {
 	// ParamName is set on enum_value and example_value items to identify
 	// which parameter the value is for (useful for UI labeling).
 	ParamName string `json:"paramName,omitempty"`
+	// Keyword is set on "keyword" items to the canonical keyword-operator
+	// name (e.g. "of", "as % of", "in") so clients can join it to their own
+	// palette label/aliases without parsing the snippet.
+	Keyword string `json:"keyword,omitempty"`
 }
 
 // enumCompletionsForContext returns enum value completions for the active

--- a/lsp/completion_test.go
+++ b/lsp/completion_test.go
@@ -200,6 +200,30 @@ func TestVariableCompletions_TypeFiltering(t *testing.T) {
 	}
 }
 
+// TestVariableCompletions_PercentOfOperandFiltersToPercentage drives the real
+// completion handler end-to-end: the percentage operand of `X% of Y` must
+// surface only percentage-typed variables, not quantities — even though there
+// is no enclosing function call to read a ParamSpec from. This is the keyword-
+// operand counterpart to the function-argument filtering above.
+func TestVariableCompletions_PercentOfOperandFiltersToPercentage(t *testing.T) {
+	// Both variables share the `my` prefix, so prefix-matching alone cannot
+	// explain the exclusion — the type filter is what drops the quantity.
+	source := "myrate = 5%\nmyqty = 10 kg\nresult = my of 1000"
+	s, uri := prepareServerDoc(t, source)
+
+	// Line 2, cursor right after the `my` the user is typing into the
+	// percentage operand (col 11 = just past the 'y' of "my").
+	items := completionAt(t, s, uri, 2, 11)
+	labels := itemLabels(items)
+
+	if !slices.Contains(labels, "myrate") {
+		t.Errorf("expected percentage var 'myrate' at the '%% of' operand, got %v", labels)
+	}
+	if slices.Contains(labels, "myqty") {
+		t.Errorf("did not expect quantity var 'myqty' at the '%% of' operand, got %v", labels)
+	}
+}
+
 // TestVariableCompletions_PositionFiltering pins the bug repro:
 // `grow $100 by flour over 10` (line 0) followed by `flour = 10`
 // (line 1) used to offer `flour` as a completion on line 0 because
@@ -489,6 +513,40 @@ func TestFunctionCompletions_NLExampleCarriesSnippetFormat(t *testing.T) {
 	// inside the placeholder, not as `}%`.
 	if containsString(nlItem.insertText, "}%") {
 		t.Errorf("NL example InsertText leaves `%%` outside the placeholder: %q", nlItem.insertText)
+	}
+}
+
+// TestKeywordCompletions_SnippetAndData asserts the keyword-operator forms are
+// delivered as snippet items carrying data.kind == "keyword" and the keyword
+// identity, with the canonical templates (percent inside the first tab stop).
+func TestKeywordCompletions_SnippetAndData(t *testing.T) {
+	items := keywordCompletionItems("")
+	byKeyword := map[string]protocol.CompletionItem{}
+	for _, it := range items {
+		d, ok := it.Data.(completionItemData)
+		if !ok {
+			t.Fatalf("item %q missing completionItemData", it.Label)
+		}
+		if d.Kind != "keyword" {
+			t.Errorf("item %q data.kind = %q, want %q", it.Label, d.Kind, "keyword")
+		}
+		if it.InsertTextFormat == nil || *it.InsertTextFormat != protocol.InsertTextFormatSnippet {
+			t.Errorf("keyword item %q is not InsertTextFormat=Snippet", it.Label)
+		}
+		byKeyword[d.Keyword] = it
+	}
+
+	of, ok := byKeyword["of"]
+	if !ok {
+		t.Fatal("expected an 'of' keyword item")
+	}
+	if of.InsertText == nil || *of.InsertText != "${1:23%} of ${2:1000}" {
+		t.Errorf("of InsertText = %v, want the %% inside stop 1", of.InsertText)
+	}
+	for _, want := range []string{"of", "as % of", "in"} {
+		if _, ok := byKeyword[want]; !ok {
+			t.Errorf("expected keyword item %q", want)
+		}
 	}
 }
 

--- a/spec/features/completion.go
+++ b/spec/features/completion.go
@@ -112,6 +112,40 @@ func FunctionSuggestions(prefix string, implementedNames map[string]bool) []Sugg
 	return suggestions
 }
 
+// KeywordSuggestions returns insertable suggestions for the calc keyword-
+// operator forms (`X% of Y`, `X as a % of Y`, `X in unit`). It mirrors
+// FunctionSuggestions but is far simpler: keywords have no synonyms and no
+// NL/paren split. Only keyword features that carry a snippet `InsertText`
+// surface — the rest (`per`, `over`, `at`, napkin/precise, bare `as`) are
+// language keywords without a slash-command form yet.
+//
+// The Name field carries the keyword identity (e.g. "of", "as % of", "in") so
+// clients can attach their own palette label/aliases; InsertText carries the
+// canonical `${N:default}` snippet so the `%`/unit placeholders live in one
+// authoritative place.
+func KeywordSuggestions(prefix string) []Suggestion {
+	registry := DefaultRegistry()
+	var suggestions []Suggestion
+
+	for _, f := range registry.ByCategory(CategoryKeyword) {
+		if f.InsertText == "" {
+			continue
+		}
+		if !MatchesPrefix(f.Name, prefix) {
+			continue
+		}
+		suggestions = append(suggestions, Suggestion{
+			Name:        f.Name,
+			Category:    string(CategoryKeyword),
+			Description: f.Description,
+			Syntax:      f.Syntax,
+			InsertText:  f.InsertText,
+		})
+	}
+
+	return suggestions
+}
+
 // UnitSuggestions returns unit suggestions matching prefix.
 // Deduplicates by canonical name.
 func UnitSuggestions(prefix string) []Suggestion {

--- a/spec/features/completion_test.go
+++ b/spec/features/completion_test.go
@@ -5,6 +5,73 @@ import (
 	"testing"
 )
 
+func TestKeywordSuggestions(t *testing.T) {
+	byName := func(sugs []Suggestion) map[string]Suggestion {
+		m := make(map[string]Suggestion, len(sugs))
+		for _, s := range sugs {
+			m[s.Name] = s
+		}
+		return m
+	}
+
+	t.Run("empty prefix returns only the insertable keyword forms", func(t *testing.T) {
+		got := byName(KeywordSuggestions(""))
+		for _, want := range []string{"of", "in", "as % of"} {
+			if _, ok := got[want]; !ok {
+				t.Errorf("expected keyword %q in suggestions, got %v", want, keys(got))
+			}
+		}
+		// Keywords without a snippet InsertText must NOT surface as slash forms.
+		for _, absent := range []string{"per", "over", "at", "as", "as napkin", "as precise"} {
+			if _, ok := got[absent]; ok {
+				t.Errorf("keyword %q has no InsertText and must not surface", absent)
+			}
+		}
+	})
+
+	t.Run("percent-of snippet keeps the %% inside the first tab stop", func(t *testing.T) {
+		got := byName(KeywordSuggestions(""))
+		if it := got["of"].InsertText; it != "${1:23%} of ${2:1000}" {
+			t.Errorf("of InsertText = %q, want the %% inside stop 1", it)
+		}
+		if it := got["as % of"].InsertText; it != "${1:23} as a % of ${2:43}" {
+			t.Errorf("as %% of InsertText = %q", it)
+		}
+		if it := got["in"].InsertText; it != "${1:32 g} in ${2:oz}" {
+			t.Errorf("in InsertText = %q", it)
+		}
+	})
+
+	t.Run("prefix filters by keyword name", func(t *testing.T) {
+		got := byName(KeywordSuggestions("of"))
+		if _, ok := got["of"]; !ok {
+			t.Errorf("prefix 'of' should match 'of', got %v", keys(got))
+		}
+		if _, ok := got["in"]; ok {
+			t.Errorf("prefix 'of' should not match 'in'")
+		}
+	})
+
+	t.Run("every suggestion carries the keyword category and a description", func(t *testing.T) {
+		for _, s := range KeywordSuggestions("") {
+			if s.Category != string(CategoryKeyword) {
+				t.Errorf("%q Category = %q, want %q", s.Name, s.Category, CategoryKeyword)
+			}
+			if s.Description == "" {
+				t.Errorf("%q has empty Description", s.Name)
+			}
+		}
+	})
+}
+
+func keys(m map[string]Suggestion) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
 func TestFunctionSuggestions(t *testing.T) {
 	// Build implementedNames from known function names
 	implementedNames := map[string]bool{

--- a/spec/features/registry.go
+++ b/spec/features/registry.go
@@ -1067,6 +1067,10 @@ func getKeywords() []Feature {
 			Description: "Convert to a different unit",
 			Aliases:     nil,
 			Example:     "100 cm in inches → 39.37 inches",
+			// Snippet template for slash-command insertion. The quantity
+			// (number + unit) is one tab stop so a quantity variable can
+			// replace the whole token; the target unit is the second stop.
+			InsertText: "${1:32 g} in ${2:oz}",
 		},
 		{
 			Name:        "as",
@@ -1083,6 +1087,11 @@ func getKeywords() []Feature {
 			Description: "Calculate percentage of a value",
 			Aliases:     nil,
 			Example:     "15% of 200 → 30",
+			// Snippet template for slash-command insertion. The `%` lives
+			// INSIDE the first tab stop so the operand is a whole percentage
+			// token (the user overtypes `23%` as a unit, not a bare integer
+			// with a stranded `%`).
+			InsertText: "${1:23%} of ${2:1000}",
 		},
 		{
 			Name:        "per",
@@ -1131,6 +1140,10 @@ func getKeywords() []Feature {
 			Description: "Compute the ratio of two same-type values as a percentage. Both operands must be the same type (e.g., both currency, both quantities). The inverse of '% of': 20% of $500 = $100, $100 as % of $500 = 20%.",
 			Aliases:     nil,
 			Example:     "$100 as % of $500 → 20%",
+			// Snippet template for slash-command insertion. Both operands are
+			// plain numerators (same-type amounts); the `%` belongs to the
+			// literal operator phrase, not to either tab stop.
+			InsertText: "${1:23} as a % of ${2:43}",
 		},
 		{
 			Name:        "at",


### PR DESCRIPTION
The keyword-operator forms (`X% of Y`, `X as a % of Y`, `X in unit`) had no LSP delivery vehicle. Clients (the cmw slash palette, inline completion) had to hardcode the snippet templates, which drifts from the registry's canonical `${N:default}` forms.

## What

- **spec/features**: `KeywordSuggestions(prefix)` mirrors `FunctionSuggestions` over the keyword category, surfacing only keywords that carry a snippet `InsertText`. `Name` is the keyword identity (`of`, `as % of`, `in`); `InsertText` is the canonical snippet so the `%`/unit placeholders live in one authoritative place.
- **lsp/completion**: `keywordCompletionItems` ships them with `InsertTextFormat=Snippet` and `data.kind="keyword"` / `data.keyword`, the same delivery vehicle functions already use. `argctx` routes the operand context so they only surface where they actually parse.
- Tests across `spec/features` + `lsp` pin the prefix filter, the snippet shape, and the operand-context gating.

## Why

Downstream (cmw) builds its slash-command catalogue from these completions; without an LSP source it kept a hardcoded copy. This is the delivery vehicle that lets the client drop the hardcode.

## Verification

- `go test ./...` green
- `task lint` (fmt + vet), staticcheck, modernize all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-velocity:pr:163 -->
### Metrics

Opened by `@dvhthomas` (agent-assisted) on 2026-06-14 15:06 UTC. Merged 2026-06-14 15:07 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 40s  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
