### PR TITLE
fix(frontmatter): preserve verbatim scalar text in ExtraField.RawValue

### DIFF
--- a/docs/cmw-fit-and-finish-fixes.md
+++ b/docs/cmw-fit-and-finish-fixes.md
@@ -1,0 +1,85 @@
+# go-calcmark fixes from the calcmark-web fit-and-finish pass
+
+Branch: `fix/cmw-fit-and-finish`. These are go-calcmark-side items surfaced
+while QA-ing the calcmark-web editor. Each notes root cause, approach, value,
+and status. Cross-references are to the calcmark-web repo.
+
+---
+
+## 1. Positionless argument-type errors → editors can't squiggle the bad arg
+**Status: tracked, NOT implemented (bigger change). Filed as issue #164.**
+Value: medium–high (no inline squiggle on the offending argument).
+
+Symptom: `sx_grown = grow(100, 20%, 5)` reports a correct error, but with no
+source position, so an editor can show it in the gutter yet cannot underline
+the bad `20%`.
+
+Root cause: the growth / capacity / rate builtins reject arguments with a
+bare positionless error:
+
+```go
+// impl/interpreter/growth_functions.go (also capacity_functions.go, rate_eval.go)
+return decZero, fmt.Errorf(
+    "%s: %s must be a number, quantity, or currency — got percentage",
+    funcName, paramName)
+```
+
+`spec/document.Diagnostic` already has `Line/Column/EndLine/EndColumn`, but the
+interpreter error carries no AST position, so the resulting diagnostic is
+line-only.
+
+Two fix options (either suffices; the second is cleaner long-term):
+1. **Interpreter** — attach the rejected argument's AST `Range` to the emitted
+   diagnostic (the call node knows each argument's position). Requires
+   threading the arg node/position into the error path of these builtins.
+2. **Semantic checker** — encode these builtins' parameter-type contracts
+   (e.g. `grow`'s increment ∈ {number, quantity, currency}) in
+   `spec/semantic` so invalid args are caught at *check* time with a `Range`,
+   the same path that already produces ranged diagnostics for undefined
+   variables. Bonus: surfaces the error before evaluation.
+
+Consumers already map a diagnostic `Range` → inline squiggle, so either fix
+lights up the underline with zero consumer changes.
+
+---
+
+## 2. Frontmatter scalars coerce on parse → `version: 1.0` displays as `1`
+**Status: DONE on this branch.**
+Value: low (cosmetic), change: contained + backward-compatible.
+
+Symptom: a frontmatter `version: 1.0` rendered as `1` because `Extra.Value`
+holds the typed YAML value (`float64(1)`).
+
+Fix (committed here): added `ExtraField.RawValue string` —
+`spec/document/frontmatter.go` now captures the verbatim YAML scalar text from
+the node tree (`parseYAMLMapping`) alongside the coerced `Value`. Scalars get
+the literal (`"1.0"`, `"3.140"`); maps/lists keep `RawValue` empty. Additive
+field — existing `Key`/`Value` consumers (e.g. `format/html_formatter.go`) are
+untouched. Covered by `TestParseFrontmatter_ExtraRawValuePreservesScalarText`.
+
+Consumer follow-up (calcmark-web): the frontmatter card should prefer
+`RawValue` over `Value` for scalar OTHER fields when displaying. Needs a
+go-calcmark release + version bump in cmw.
+
+---
+
+## 3. `read from` is offered as a completion but absent from the Help index
+**Status: tracked, routing unclear (likely calcmark-web, not go-calcmark).**
+Value: low.
+
+`read from` is a real registered NL function (functions.go / registry.go /
+nl_functions.go), so offering it as a completion is correct. It's missing from
+calcmark-web's generated Help index. Determine whether go-calcmark's
+reference/help data includes `read from` (if not → go-calcmark reference-data
+gap) or whether cmw's `gen-help-index` drops it (→ calcmark-web fix). No code
+change made until routing is confirmed.
+
+---
+
+## Not included here (stay in calcmark-web)
+- Diagnostic-message **styling** (rendering a quoted identifier like
+  `"seniors"` as `code`): a presentation concern handled in cmw's
+  `diagnostic-message-parts.ts`, not a go-calcmark message-text change.
+- Signature-help flakiness for paren calls: the LSP answers correctly
+  (`lsp/signature.go` + tests cover `avg`/`accumulate`); the flakiness is in
+  the cmw client's probe timing.

--- a/spec/document/frontmatter.go
+++ b/spec/document/frontmatter.go
@@ -150,6 +150,12 @@ type Frontmatter struct {
 type ExtraField struct {
 	Key   string
 	Value any // string, int, float64, []any, map[string]any
+	// RawValue is the verbatim YAML scalar text for scalar values, before
+	// type coercion — e.g. `version: 1.0` yields Value float64(1) but
+	// RawValue "1.0". Empty for non-scalar values (maps, lists). Lets
+	// consumers display exactly what the author typed instead of the
+	// coerced form (a `1.0` version string rendering as `1`).
+	RawValue string
 }
 
 // validUnitCategories maps lowercase category names to their canonical form.
@@ -769,12 +775,23 @@ func ParseFrontmatter(source string) (*Frontmatter, string, error) {
 	extraOrder := extractYAMLTopLevelKeyOrder(yamlContent)
 	var rawMap map[string]any
 	_ = yaml.Unmarshal([]byte(yamlContent), &rawMap)
+	// Verbatim scalar text per top-level key, from the node tree (the typed
+	// unmarshal above coerces `1.0` → float64(1) and loses the literal). Only
+	// scalar values get an entry; maps/lists keep RawValue empty.
+	rawScalars := map[string]string{}
+	if mapping := parseYAMLMapping(yamlContent); mapping != nil {
+		for i := 0; i+1 < len(mapping.Content); i += 2 {
+			if valNode := mapping.Content[i+1]; valNode.Kind == yaml.ScalarNode {
+				rawScalars[mapping.Content[i].Value] = valNode.Value
+			}
+		}
+	}
 	for _, key := range extraOrder {
 		if IsRegisteredKey(key) {
 			continue
 		}
 		if val, ok := rawMap[key]; ok {
-			fm.Extra = append(fm.Extra, ExtraField{Key: key, Value: val})
+			fm.Extra = append(fm.Extra, ExtraField{Key: key, Value: val, RawValue: rawScalars[key]})
 		}
 	}
 

--- a/spec/document/frontmatter_test.go
+++ b/spec/document/frontmatter_test.go
@@ -1799,3 +1799,43 @@ func TestParseFrontmatter_RegistryDrivesKnownKeyRouting(t *testing.T) {
 		t.Errorf("expected 'title' in Extra, got %+v", fm2.Extra)
 	}
 }
+
+// RawValue preserves the verbatim YAML scalar text for Extra fields, so a
+// `version: 1.0` is available to consumers instead of only the coerced
+// float64(1) that renders as `1` (cmw fit-and-finish F2).
+func TestParseFrontmatter_ExtraRawValuePreservesScalarText(t *testing.T) {
+	source := `---
+version: 1.0
+ratio: 3.140
+title: Owning the P&L
+tags:
+  - finance
+  - planning
+---`
+	fm, _, err := ParseFrontmatter(source)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	byKey := map[string]ExtraField{}
+	for _, ef := range fm.Extra {
+		byKey[ef.Key] = ef
+	}
+	// Scalars keep their literal text even though Value coerces.
+	if got := byKey["version"].RawValue; got != "1.0" {
+		t.Errorf("version RawValue = %q, want \"1.0\"", got)
+	}
+	if got := byKey["ratio"].RawValue; got != "3.140" {
+		t.Errorf("ratio RawValue = %q, want \"3.140\"", got)
+	}
+	if got := byKey["title"].RawValue; got != "Owning the P&L" {
+		t.Errorf("title RawValue = %q, want \"Owning the P&L\"", got)
+	}
+	// The typed Value still coerces (this is what rendered as `1` before).
+	if f, ok := byKey["version"].Value.(float64); !ok || f != 1.0 {
+		t.Errorf("version Value = %v (%T), want float64(1)", byKey["version"].Value, byKey["version"].Value)
+	}
+	// Non-scalar values (a list) carry no RawValue.
+	if got := byKey["tags"].RawValue; got != "" {
+		t.Errorf("tags RawValue = %q, want empty (non-scalar)", got)
+	}
+}


### PR DESCRIPTION
Adds `ExtraField.RawValue string`, populated from the YAML node's verbatim scalar text during frontmatter parsing. `ExtraField.Value any` loses the original textual form of a scalar (quoting, exact digits), which downstream editors (CalcMark Web's frontmatter editor) need to round-trip a directive byte-identically. `RawValue` preserves it alongside the typed `Value`.

Purely additive — no change to existing `Value` semantics. Covered by `TestParseFrontmatter_ExtraRawValuePreservesScalarText`. Prepared for CalcMark Web's frontmatter raw-value round-trip work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- gh-velocity:pr:165 -->
### Metrics

Opened by `@dvhthomas` (agent-assisted) on 2026-06-28 18:39 UTC. Merged 2026-06-28 18:40 UTC.

| Metric | Value |
|--------|-------|
| Cycle Time | 38s  (created -> merged) |
| Time to First Review | [n/a](https://dvhthomas.github.io/gh-velocity/guides/troubleshooting/#cycle-time-shows-na-for-all-issues) |
| Review Rounds | 0 |

<sub>Generated by <a href="https://dvhthomas.github.io/gh-velocity/">gh-velocity</a></sub>
<details>
<summary>How to interpret</summary>

**Command**: `gh velocity pr --post`

| Setting | Value |
|---------|-------|
| repository | `CalcMark/go-calcmark` |

</details>

<!-- /gh-velocity -->
